### PR TITLE
feat: Added option to restrict usage to a signle root group

### DIFF
--- a/README.md
+++ b/README.md
@@ -234,6 +234,7 @@ Important `Builder` props:
 - `strings?: IStrings`
 - `readOnly?: boolean`
 - `draggable?: boolean`
+- `singleRootGroup?: boolean`
 - `groupTypes?: 'with-modifiers' | 'without-modifiers' | 'both'`
 
 #### `readOnly`
@@ -250,6 +251,20 @@ When `draggable` is `true`, rules and groups render drag handles and can be:
 - reordered at the root level
 
 When `draggable` is `false`, no drag handles or drop zones are rendered.
+
+#### `singleRootGroup`
+
+When `singleRootGroup` is `true`, the builder is locked to exactly one root group.
+
+- root-level rules cannot be added
+- additional root-level groups cannot be added
+- the root group cannot be deleted
+- the root group cannot be dragged
+- root-level drop zones are not rendered
+
+Nested rules and groups inside the root group still work normally.
+
+If the incoming `data` contains root-level rules or multiple root items, React Query Builder wraps them into a single root group automatically.
 
 #### `groupTypes`
 

--- a/example/src/main.tsx
+++ b/example/src/main.tsx
@@ -3,7 +3,7 @@ import { createRoot } from 'react-dom/client';
 import styled from 'styled-components';
 import {
   Builder,
-  BuilderFieldProps,
+  IBuilderFieldProps,
   colors,
   type DenormalizedQuery,
 } from '../../src';
@@ -55,7 +55,7 @@ const initialQueryTree: DenormalizedQuery = [
   },
 ];
 
-const fields: BuilderFieldProps[] = [
+const fields: IBuilderFieldProps[] = [
   {
     field: 'STATE',
     label: 'State',
@@ -146,6 +146,7 @@ const App: React.FC = () => {
     React.useState<DenormalizedQuery>(initialQueryTree);
   const [readOnly, setReadOnly] = React.useState(false);
   const [draggable, setDraggable] = React.useState(false);
+  const [singleRootGroup, setSingleRootGroup] = React.useState(false);
   const [theme, setTheme] = React.useState<IThemeProviderProps>({
     colors,
   });
@@ -164,6 +165,12 @@ const App: React.FC = () => {
           onClick={() => setDraggable((value) => !value)}
         >
           Toggle draggable
+        </ActionButton>
+        <ActionButton
+          type="button"
+          onClick={() => setSingleRootGroup((value) => !value)}
+        >
+          Toggle single root group
         </ActionButton>
         <ActionButton
           type="button"
@@ -202,6 +209,7 @@ const App: React.FC = () => {
           onChange={setOutput}
           draggable={draggable}
           groupTypes="both"
+          singleRootGroup={singleRootGroup}
         />
       </ThemeProvider>
 

--- a/scripts/copy-dts.mjs
+++ b/scripts/copy-dts.mjs
@@ -1,3 +1,5 @@
+/* global console */
+
 import { copyFile, access } from 'node:fs/promises';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';

--- a/src/builder-context.tsx
+++ b/src/builder-context.tsx
@@ -13,6 +13,7 @@ export interface IBuilderContextProps {
   data: NormalizedQuery;
   readOnly: boolean;
   draggable?: boolean;
+  singleRootGroup?: boolean;
   groupTypes?: BuilderGroupMode;
   components: IBuilderComponentsProps;
   strings: IStrings;
@@ -32,6 +33,7 @@ export interface IBuilderContextProviderProps {
   data: NormalizedQuery;
   readOnly: boolean;
   draggable?: boolean;
+  singleRootGroup?: boolean;
   groupTypes?: BuilderGroupMode;
   components: IBuilderComponentsProps;
   strings: IStrings;
@@ -50,6 +52,7 @@ export const BuilderContextProvider: FC<IBuilderContextProviderProps> = ({
   data,
   readOnly,
   draggable,
+  singleRootGroup,
   groupTypes,
   setData,
   onChange,
@@ -92,6 +95,7 @@ export const BuilderContextProvider: FC<IBuilderContextProviderProps> = ({
         data,
         readOnly,
         draggable,
+        singleRootGroup,
         groupTypes,
         setData,
         onChange,

--- a/src/builder.test.tsx
+++ b/src/builder.test.tsx
@@ -202,4 +202,24 @@ describe('#components/Builder', () => {
     expect(wrapper.find('[data-test="Option[and]"]').length).toEqual(0);
     expect(wrapper.find('[data-test="Option[or]"]').length).toEqual(0);
   });
+
+  it('Locks the builder to a single undeletable root group', () => {
+    const wrapper = mount(
+      <Builder
+        fields={fields}
+        data={[{ field: 'MOCK_FIELD', value: '', operator: 'EQUAL' }]}
+        singleRootGroup
+        draggable
+        onChange={jest.fn()}
+      />
+    );
+
+    expect(wrapper.find('[data-test="AddRootRule"]').length).toEqual(0);
+    expect(wrapper.find('[data-test="AddRootGroup"]').length).toEqual(0);
+    expect(wrapper.find('[data-test="IteratorRule"]').hostNodes().length).toEqual(1);
+    expect(
+      wrapper.find('button').filterWhere((node) => node.text() === 'Delete').length
+    ).toEqual(1);
+    expect(wrapper.find('[data-test="DragHandle"]').hostNodes().length).toEqual(1);
+  });
 });

--- a/src/builder.tsx
+++ b/src/builder.tsx
@@ -154,6 +154,7 @@ export interface IBuilderProps {
   strings?: IStrings;
   readOnly?: boolean;
   draggable?: boolean;
+  singleRootGroup?: boolean;
   groupTypes?: BuilderGroupMode;
   onChange?: (data: DenormalizedQuery) => any;
 }
@@ -184,6 +185,7 @@ export const Builder: FC<IBuilderProps> = ({
   strings = defaultStrings,
   readOnly = false,
   draggable = false,
+  singleRootGroup = false,
   groupTypes = 'with-modifiers',
   onChange,
 }) => {
@@ -192,7 +194,7 @@ export const Builder: FC<IBuilderProps> = ({
 
   const theme = useTheme();
   const [data, setData] = useState<NormalizedQuery>(() =>
-    ingestQuery(originalData, rootGroupType)
+    ingestQuery(originalData, rootGroupType, singleRootGroup)
   );
   const [activeDragId, setActiveDragId] = useState<string | null>(null);
   const [activeDropZoneId, setActiveDropZoneId] = useState<string | null>(null);
@@ -267,8 +269,8 @@ export const Builder: FC<IBuilderProps> = ({
     }
 
     pendingChangeData.current = null;
-    setData(ingestQuery(originalData, rootGroupType));
-  }, [originalData, rootGroupType]);
+    setData(ingestQuery(originalData, rootGroupType, singleRootGroup));
+  }, [originalData, rootGroupType, singleRootGroup]);
 
   const resetDragState = useCallback(() => {
     setActiveDragId(null);
@@ -470,6 +472,7 @@ export const Builder: FC<IBuilderProps> = ({
       strings={strings}
       readOnly={readOnly}
       draggable={draggable}
+      singleRootGroup={singleRootGroup}
       groupTypes={groupTypes}
       data={data}
       setData={setData}
@@ -477,7 +480,7 @@ export const Builder: FC<IBuilderProps> = ({
       updateData={updateData}
     >
       <StyledBuilder $theme={theme}>
-        {!readOnly && strings.group && (
+        {!readOnly && strings.group && !singleRootGroup && (
           <RootControls>
             <AddComponent onClick={handleAddRootRule} data-test="AddRootRule">
               {strings.group.addRule}

--- a/src/group/group.tsx
+++ b/src/group/group.tsx
@@ -33,6 +33,7 @@ export const Group: FC<IGroupProps> = ({
   dragHandle,
   contentOverlay,
   id,
+  isRoot,
 }) => {
   const {
     components,
@@ -43,6 +44,7 @@ export const Group: FC<IGroupProps> = ({
     strings,
     readOnly,
     groupTypes,
+    singleRootGroup,
   } = useContext(BuilderContext);
   const Add = components.Add || Button;
   const GroupContainer = components.Group || DefaultGroupContainer;
@@ -51,6 +53,7 @@ export const Group: FC<IGroupProps> = ({
   const PopoverItem = components.PopoverItem || DefaultPopoverItem;
   const Remove = components.Remove || SecondaryButton;
   const resolvedGroupTypes = groupTypes || 'with-modifiers';
+  const canDeleteGroup = !(singleRootGroup && isRoot);
 
   const addItem = (payload: NormalizedNode) => {
     applyDataUpdate(
@@ -201,9 +204,11 @@ export const Group: FC<IGroupProps> = ({
               {strings.group.addRule}
             </Add>
             {addGroupControl}
-            <Remove onClick={handleDeleteGroup} data-test="Remove">
-              {strings.group.delete}
-            </Remove>
+            {canDeleteGroup ? (
+              <Remove onClick={handleDeleteGroup} data-test="Remove">
+                {strings.group.delete}
+              </Remove>
+            ) : null}
           </>
         )
       }

--- a/src/iterator.tsx
+++ b/src/iterator.tsx
@@ -31,13 +31,16 @@ export const Iterator: FC<IIteratorProps> = ({
   isOverlay = false,
   disableDropZoneTransition = false,
 }) => {
-  const { draggable, readOnly, components } = useContext(BuilderContext);
+  const { draggable, readOnly, components, singleRootGroup } =
+    useContext(BuilderContext);
   const resolvedComponents = components || {};
   const {
     DropZone = DefaultDropZone,
     EmptyGroupDropZone = DefaultEmptyGroupDropZone,
   } = resolvedComponents;
   const isSortable = draggable && !readOnly && !isOverlay;
+  const isRootLocked = Boolean(singleRootGroup && isRoot);
+  const canSortAtLevel = isSortable && !isRootLocked;
   const activeDragIndex = activeDragId
     ? filteredData.findIndex((item) => item.id === activeDragId)
     : -1;
@@ -49,7 +52,7 @@ export const Iterator: FC<IIteratorProps> = ({
     const isCollapsedSourceBoundary =
       activeDragIndex !== -1 && index === activeDragIndex + 1;
     const leadingDropZone =
-      isSortable && shouldRenderLeadingDropZone ? (
+      canSortAtLevel && shouldRenderLeadingDropZone ? (
         <DropZone
           key={dropZoneId}
           id={dropZoneId}
@@ -71,7 +74,7 @@ export const Iterator: FC<IIteratorProps> = ({
       const { id, value, isNegated } = item;
       const emptyGroupDropZoneId = `drop-zone:${id}:0`;
       const emptyGroupDropZone =
-        isSortable && items.length === 0 ? (
+        canSortAtLevel && items.length === 0 ? (
           <EmptyGroupDropZone
             id={emptyGroupDropZoneId}
             index={0}
@@ -106,7 +109,7 @@ export const Iterator: FC<IIteratorProps> = ({
         </Group>
       );
 
-      if (!isSortable) {
+      if (!canSortAtLevel) {
         return [group()];
       }
 
@@ -132,7 +135,7 @@ export const Iterator: FC<IIteratorProps> = ({
       />
     );
 
-    if (!isSortable) {
+    if (!canSortAtLevel) {
       return [rule()];
     }
 
@@ -144,7 +147,7 @@ export const Iterator: FC<IIteratorProps> = ({
     ];
   });
 
-  if (!isSortable) {
+  if (!canSortAtLevel) {
     return <>{content}</>;
   }
 

--- a/src/utils/ensure-single-root-group.util.ts
+++ b/src/utils/ensure-single-root-group.util.ts
@@ -1,0 +1,28 @@
+import { createEmptyRootGroup } from './create-empty-root-group.util';
+import {
+  DenormalizedGroupNode,
+  DenormalizedQuery,
+  QueryGroupType,
+} from './query-tree';
+
+export const ensureSingleRootGroup = (
+  inputQuery: DenormalizedQuery,
+  rootGroupType: QueryGroupType = 'with-modifiers'
+): DenormalizedQuery => {
+  if (inputQuery.length === 0) {
+    return createEmptyRootGroup(rootGroupType);
+  }
+
+  if (inputQuery.length === 1 && 'type' in inputQuery[0]) {
+    return inputQuery;
+  }
+
+  const [rootGroup] = createEmptyRootGroup(rootGroupType);
+
+  return [
+    {
+      ...(rootGroup as DenormalizedGroupNode),
+      children: inputQuery,
+    },
+  ];
+};

--- a/src/utils/ingest-query.util.test.ts
+++ b/src/utils/ingest-query.util.test.ts
@@ -1,0 +1,46 @@
+import { emitQuery } from './emit-query.util';
+import { ingestQuery } from './ingest-query.util';
+
+describe('ingestQuery', () => {
+  it('Wraps root-level rules in a single root group when singleRootGroup is enabled', () => {
+    const normalizedQuery = ingestQuery(
+      [{ field: 'MOCK_FIELD', value: '', operator: 'EQUAL' }],
+      'with-modifiers',
+      true
+    );
+
+    const emittedQuery = emitQuery(normalizedQuery);
+
+    expect(emittedQuery).toHaveLength(1);
+    expect(emittedQuery[0]).toMatchObject({
+      type: 'GROUP',
+      value: 'AND',
+      isNegated: false,
+      children: [{ field: 'MOCK_FIELD', value: '', operator: 'EQUAL' }],
+    });
+  });
+
+  it('Wraps multiple root items in a single root group when singleRootGroup is enabled', () => {
+    const normalizedQuery = ingestQuery(
+      [
+        { field: 'FIRST_FIELD', value: '', operator: 'EQUAL' },
+        { field: 'SECOND_FIELD', value: '', operator: 'EQUAL' },
+      ],
+      'without-modifiers',
+      true
+    );
+
+    const emittedQuery = emitQuery(normalizedQuery);
+
+    expect(emittedQuery).toHaveLength(1);
+    expect(emittedQuery[0]).toMatchObject({
+      type: 'GROUP',
+      children: [
+        { field: 'FIRST_FIELD', value: '', operator: 'EQUAL' },
+        { field: 'SECOND_FIELD', value: '', operator: 'EQUAL' },
+      ],
+    });
+    expect('value' in emittedQuery[0]).toEqual(false);
+    expect('isNegated' in emittedQuery[0]).toEqual(false);
+  });
+});

--- a/src/utils/ingest-query.util.ts
+++ b/src/utils/ingest-query.util.ts
@@ -1,5 +1,6 @@
 import { assignIds } from './assign-ids.util';
 import { createEmptyRootGroup } from './create-empty-root-group.util';
+import { ensureSingleRootGroup } from './ensure-single-root-group.util';
 import { normalizeTree } from './normalize-tree.util';
 import {
   DenormalizedQuery,
@@ -9,12 +10,16 @@ import {
 
 export const ingestQuery = (
   inputQuery: DenormalizedQuery,
-  rootGroupType: QueryGroupType = 'with-modifiers'
+  rootGroupType: QueryGroupType = 'with-modifiers',
+  singleRootGroup = false
 ): NormalizedQuery => {
   const queryWithIds = assignIds(inputQuery || []);
+  const preparedInput = singleRootGroup
+    ? ensureSingleRootGroup(queryWithIds, rootGroupType)
+    : queryWithIds;
   const normalizedInput =
-    queryWithIds.length > 0
-      ? queryWithIds
+    preparedInput.length > 0
+      ? preparedInput
       : createEmptyRootGroup(rootGroupType);
 
   try {


### PR DESCRIPTION
- Added property to restrict usage to a single root group
- When multiple groups or rules or combination of both is in the root, once toggled to single group, existing data is wrapped to a single parent group 