### PR TITLE
feat: Added more granular control of readOnly property

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,6 +192,22 @@ recommended path when locked query segments must stay protected in text mode.
 - <a href="https://vojtechportes.github.io/react-query-builder/api/builder" target="_blank" rel="noopener noreferrer">API: Builder</a>
 - <a href="https://vojtechportes.github.io/react-query-builder/api/components" target="_blank" rel="noopener noreferrer">API: Components</a>
 
+## Read-only and Protected Editing
+
+Rules and groups can be fully read-only or partially read-only through
+`readOnly.targets`.
+
+- Rule targets: `field`, `operator`, `value`
+- Group targets: `combinator`, `negation`
+
+Targeted read-only controls stay visible but become non-editable. When using
+the Monaco text editor integration, protected SQL fragments remain locked while
+users can still edit the unlocked parts of the query.
+
+- <a href="https://vojtechportes.github.io/react-query-builder/documentation/locking-and-read-only" target="_blank" rel="noopener noreferrer">Documentation: Locking and Read-only</a>
+- <a href="https://vojtechportes.github.io/react-query-builder/documentation/text-mode" target="_blank" rel="noopener noreferrer">Documentation: Text Mode</a>
+- <a href="https://vojtechportes.github.io/react-query-builder/api/data" target="_blank" rel="noopener noreferrer">API: Data</a>
+
 ## Query Conversion
 
 The library also provides parser and formatter helpers through subpath exports:

--- a/README.md
+++ b/README.md
@@ -204,8 +204,13 @@ Targeted read-only controls stay visible but become non-editable. When using
 the Monaco text editor integration, protected SQL fragments remain locked while
 users can still edit the unlocked parts of the query.
 
+By default, deleting a group is also blocked when that delete would indirectly
+remove read-only protected descendants. Set `readOnlyProtectsDelete={false}` on
+`Builder` if you want to disable that subtree delete protection.
+
 - <a href="https://vojtechportes.github.io/react-query-builder/documentation/locking-and-read-only" target="_blank" rel="noopener noreferrer">Documentation: Locking and Read-only</a>
 - <a href="https://vojtechportes.github.io/react-query-builder/documentation/text-mode" target="_blank" rel="noopener noreferrer">Documentation: Text Mode</a>
+- <a href="https://vojtechportes.github.io/react-query-builder/api/builder" target="_blank" rel="noopener noreferrer">API: Builder</a>
 - <a href="https://vojtechportes.github.io/react-query-builder/api/data" target="_blank" rel="noopener noreferrer">API: Data</a>
 
 ## Query Conversion

--- a/example/src/components/demo-playground.tsx
+++ b/example/src/components/demo-playground.tsx
@@ -189,6 +189,8 @@ export const DemoPlayground: React.FC<IDemoPlaygroundProps> = ({
   const [data, setData] = React.useState<DenormalizedQuery>(initialData);
   const [outputFormat, setOutputFormat] = React.useState<OutputFormat>('Native');
   const [readOnly, setReadOnly] = React.useState(false);
+  const [readOnlyProtectsDelete, setReadOnlyProtectsDelete] =
+    React.useState(true);
   const [lockable, setLockable] = React.useState(false);
   const [cloneable, setCloneable] = React.useState(false);
   const [draggable, setDraggable] = React.useState(false);
@@ -236,6 +238,7 @@ export const DemoPlayground: React.FC<IDemoPlaygroundProps> = ({
     data,
     fields: demoFields,
     readOnly,
+    readOnlyProtectsDelete,
     lockable,
     cloneable,
     onChange: setData,
@@ -262,6 +265,7 @@ export const DemoPlayground: React.FC<IDemoPlaygroundProps> = ({
     () =>
       formatBuilderSource({
         readOnly,
+        readOnlyProtectsDelete,
         lockable,
         cloneable,
         draggable,
@@ -278,6 +282,7 @@ export const DemoPlayground: React.FC<IDemoPlaygroundProps> = ({
       }),
     [
       readOnly,
+      readOnlyProtectsDelete,
       lockable,
       cloneable,
       draggable,
@@ -315,6 +320,17 @@ export const DemoPlayground: React.FC<IDemoPlaygroundProps> = ({
               onChange={event => setLockable(event.target.checked)}
             />
             <span>Lock controls</span>
+          </ToggleRow>
+
+          <ToggleRow>
+            <Toggle
+              type="checkbox"
+              checked={readOnlyProtectsDelete}
+              onChange={event =>
+                setReadOnlyProtectsDelete(event.target.checked)
+              }
+            />
+            <span>Read-only protects group delete</span>
           </ToggleRow>
 
           <ToggleRow>

--- a/example/src/constants/demo-data.ts
+++ b/example/src/constants/demo-data.ts
@@ -136,7 +136,7 @@ export const initialQueryTree: DenormalizedQuery = [
         value: 'CZ',
         readOnly: {
           enabled: true,
-          targets: ['operator', 'field']
+          targets: ['operator', 'field'],
         },
       },
       {
@@ -148,6 +148,24 @@ export const initialQueryTree: DenormalizedQuery = [
             field: 'CUSTOMER_CITY',
             operator: 'EQUAL',
             value: 'Prague',
+          },
+          {
+            field: 'ORDER_TOTAL',
+            operator: 'BETWEEN',
+            value: [2500, 12000],
+          },
+        ],
+      },
+      {
+        type: 'GROUP',
+        value: 'AND',
+        isNegated: false,
+        children: [
+          {
+            field: 'CUSTOMER_CITY',
+            operator: 'EQUAL',
+            value: 'Prague',
+            readOnly: true,
           },
           {
             field: 'ORDER_TOTAL',
@@ -199,4 +217,3 @@ export const initialQueryTree: DenormalizedQuery = [
 ];
 
 export const defaultTheme = { colors };
-

--- a/example/src/constants/demo-data.ts
+++ b/example/src/constants/demo-data.ts
@@ -134,7 +134,10 @@ export const initialQueryTree: DenormalizedQuery = [
         field: 'CUSTOMER_COUNTRY',
         operator: 'EQUAL',
         value: 'CZ',
-        readOnly: true,
+        readOnly: {
+          enabled: true,
+          targets: ['operator', 'field']
+        },
       },
       {
         type: 'GROUP',

--- a/example/src/pages/api-page/pages/api-content.tsx
+++ b/example/src/pages/api-page/pages/api-content.tsx
@@ -110,6 +110,19 @@ const fieldBaseSignature = `interface IBuilderFieldBase<TType, TValue, TValidati
 
 const queryTreeSignature = `export type QueryGroupValue = 'AND' | 'OR';
 export type QueryGroupType = 'with-modifiers' | 'without-modifiers';
+export type GroupReadOnlyTarget = 'negation' | 'combinator';
+export type RuleReadOnlyTarget = 'field' | 'operator' | 'value';
+
+export interface IGroupReadOnlyConfig {
+  enabled: boolean;
+  targets?: GroupReadOnlyTarget[];
+  inheritToChildren?: boolean;
+}
+
+export interface IRuleReadOnlyConfig {
+  enabled: boolean;
+  targets?: RuleReadOnlyTarget[];
+}
 
 export type QueryRuleValue =
   | string
@@ -125,7 +138,7 @@ export interface IDenormalizedRuleNode {
   value?: QueryRuleValue;
   operator?: QueryOperator;
   operators?: QueryOperator[];
-  readOnly?: boolean;
+  readOnly?: boolean | IRuleReadOnlyConfig;
 }
 
 export interface IDenormalizedGroupNodeBase {
@@ -496,8 +509,8 @@ export const apiPages: IApiPage[] = [
           <li><ItemTitle><InlineCode>strings</InlineCode>:</ItemTitle> Optional localized UI strings used by the built-in controls.</li>
           <li><ItemTitle><InlineCode>textMode</InlineCode>:</ItemTitle> Optional. Enables SQL text mode. Pass <InlineCode>true</InlineCode> for the default configuration or <InlineCode>IBuilderTextModeConfig</InlineCode> for explicit SQL text-mode settings.</li>
           <li><ItemTitle><InlineCode>defaultMode</InlineCode>:</ItemTitle> Optional. Controls whether the builder initially opens in <InlineCode>'builder'</InlineCode> or <InlineCode>'text'</InlineCode> mode. This only takes effect when text mode is enabled.</li>
-          <li><ItemTitle><InlineCode>readOnly</InlineCode>:</ItemTitle> Defaults to <InlineCode>false</InlineCode>. Disables editing actions when enabled.</li>
-          <li><ItemTitle><InlineCode>lockable</InlineCode>:</ItemTitle> Defaults to <InlineCode>false</InlineCode>. Renders lock controls for rules and groups and writes the resulting lock state back into emitted query data.</li>
+          <li><ItemTitle><InlineCode>readOnly</InlineCode>:</ItemTitle> Defaults to <InlineCode>false</InlineCode>. Makes the whole builder non-editable.</li>
+          <li><ItemTitle><InlineCode>lockable</InlineCode>:</ItemTitle> Defaults to <InlineCode>false</InlineCode>. Renders lock controls for rules and groups and writes the resulting lock state back into emitted query data without discarding existing targeted <InlineCode>readOnly.targets</InlineCode> configurations.</li>
           <li><ItemTitle><InlineCode>cloneable</InlineCode>:</ItemTitle> Defaults to <InlineCode>false</InlineCode>. Renders clone controls for rules and groups and inserts the cloned node directly below the original.</li>
           <li><ItemTitle><InlineCode>draggable</InlineCode>:</ItemTitle> Defaults to <InlineCode>false</InlineCode>. Enables drag-and-drop reordering and movement of query nodes.</li>
           <li><ItemTitle><InlineCode>singleRootGroup</InlineCode>:</ItemTitle> Defaults to <InlineCode>true</InlineCode>. Wraps root-level items into a single root group and prevents deleting that root group. Text mode requires this to stay enabled.</li>
@@ -519,8 +532,9 @@ export const apiPages: IApiPage[] = [
           <li><ItemTitle>Invalid text flow:</ItemTitle> Invalid text stays local to text mode, the last valid builder query is preserved, and <InlineCode>onChange</InlineCode> is fired only after a valid parse and semantic validation.</li>
           <li><ItemTitle>History:</ItemTitle> Valid text edits are committed into builder history. Invalid intermediate text is not committed into builder state or history.</li>
           <li><ItemTitle>Built-in editor:</ItemTitle> Included in the main package and suitable for freely editable SQL text mode.</li>
-          <li><ItemTitle>Locked queries:</ItemTitle> The built-in text editor blocks locked rules and groups because it cannot preserve protected text ranges safely after freeform edits.</li>
-          <li><ItemTitle>Monaco path:</ItemTitle> Use the optional <InlineCode>@vojtechportes/react-query-builder/monaco</InlineCode> subpackage when you need a protected-range editor that can preserve locked query segments.</li>
+          <li><ItemTitle>Locked queries:</ItemTitle> The built-in text editor blocks locked or targeted read-only queries because it cannot preserve protected text ranges safely after freeform edits.</li>
+          <li><ItemTitle>Custom editors:</ItemTitle> Custom text editors receive <InlineCode>protectedRanges</InlineCode> so localized read-only SQL fragments can stay visible while remaining non-editable.</li>
+          <li><ItemTitle>Monaco path:</ItemTitle> Use the optional <InlineCode>@vojtechportes/react-query-builder/monaco</InlineCode> subpackage when you need a protected-range editor that can preserve locked and targeted read-only query segments.</li>
         </List>
         <SectionTitle>History config</SectionTitle>
         <List>
@@ -563,8 +577,8 @@ export const apiPages: IApiPage[] = [
         </List>
         <SectionTitle>Mutation methods</SectionTitle>
         <List>
-          <li><ItemTitle><InlineCode>cloneNode(nodeId)</InlineCode>:</ItemTitle> Clones a rule or group subtree directly below the original node.</li>
-          <li><ItemTitle><InlineCode>deleteNode(nodeId)</InlineCode>:</ItemTitle> Removes a node subtree.</li>
+          <li><ItemTitle><InlineCode>cloneNode(nodeId)</InlineCode>:</ItemTitle> Clones a rule or group subtree directly below the original node and preserves its read-only configuration.</li>
+          <li><ItemTitle><InlineCode>deleteNode(nodeId)</InlineCode>:</ItemTitle> Removes a node subtree unless the node itself or one of its descendants is protected by effective read-only state.</li>
           <li><ItemTitle><InlineCode>replaceNode(nodeId, node)</InlineCode>:</ItemTitle> Replaces a normalized node directly.</li>
           <li><ItemTitle><InlineCode>updateNode(nodeId, updater)</InlineCode>:</ItemTitle> Reads the current normalized node, passes it to an updater, and replaces it with the updater result.</li>
           <li><ItemTitle><InlineCode>insertNodes(nodes, index, parentId?)</InlineCode>:</ItemTitle> Inserts one or more normalized nodes at the target index, either at the root or inside a group.</li>
@@ -577,7 +591,7 @@ export const apiPages: IApiPage[] = [
         <List>
           <li><ItemTitle><InlineCode>setNodeLock(nodeId, state)</InlineCode>:</ItemTitle> Sets the explicit lock state for a rule or group. Groups additionally support <InlineCode>'all'</InlineCode> for descendant inheritance.</li>
           <li><ItemTitle><InlineCode>lockNode(nodeId, state?)</InlineCode>:</ItemTitle> Convenience wrapper for locking a node. For rules, the effective lock state is always <InlineCode>'self'</InlineCode>.</li>
-          <li><ItemTitle><InlineCode>unlockNode(nodeId)</InlineCode>:</ItemTitle> Clears the node&apos;s lock state.</li>
+          <li><ItemTitle><InlineCode>unlockNode(nodeId)</InlineCode>:</ItemTitle> Clears the node&apos;s lock state while preserving object-based <InlineCode>readOnly.targets</InlineCode> metadata so it can be restored by later lock toggles.</li>
           <li><ItemTitle><InlineCode>undo()</InlineCode> and <InlineCode>redo()</InlineCode>:</ItemTitle> Replay history steps when history is enabled.</li>
           <li><ItemTitle><InlineCode>setHistory(history)</InlineCode>:</ItemTitle> Replaces the current history state. This is useful for clearing or restoring custom history snapshots.</li>
         </List>
@@ -645,8 +659,10 @@ export const apiPages: IApiPage[] = [
           <li><ItemTitle><InlineCode>operator</InlineCode>:</ItemTitle> Optional operator for the rule. Some field and operator combinations imply different value shapes.</li>
           <li><ItemTitle><InlineCode>value</InlineCode>:</ItemTitle> Optional rule value. Supported scalar/array forms are defined by <InlineCode>QueryRuleValue</InlineCode>.</li>
           <li><ItemTitle><InlineCode>operators</InlineCode>:</ItemTitle> Optional rule-level operator override list.</li>
-          <li><ItemTitle><InlineCode>readOnly</InlineCode>:</ItemTitle> Optional per-rule lock flag. It locks only that rule and does not affect siblings, parents, or descendants.</li>
-          <li><ItemTitle>GUI cycle:</ItemTitle> When <InlineCode>lockable</InlineCode> is enabled, rules cycle between unlocked and locked, which maps to omitted <InlineCode>readOnly</InlineCode> and <InlineCode>readOnly: true</InlineCode>.</li>
+          <li><ItemTitle><InlineCode>readOnly</InlineCode>:</ItemTitle> Optional per-rule lock definition. Use <InlineCode>true</InlineCode> for a full rule lock or an object config for targeted rule read-only behavior.</li>
+          <li><ItemTitle><InlineCode>targets</InlineCode>:</ItemTitle> Rule targets are <InlineCode>'field'</InlineCode>, <InlineCode>'operator'</InlineCode>, and <InlineCode>'value'</InlineCode>. Targeted controls stay visible but become non-editable.</li>
+          <li><ItemTitle>Delete behavior:</ItemTitle> A rule with any effective read-only target is also non-deletable, and cloned rules preserve the same read-only configuration.</li>
+          <li><ItemTitle>GUI cycle:</ItemTitle> When <InlineCode>lockable</InlineCode> is enabled, rules cycle between unlocked and locked. Object-based <InlineCode>readOnly.targets</InlineCode> are preserved when the user unlocks and re-locks the same rule.</li>
           <li><ItemTitle><InlineCode>id</InlineCode> and <InlineCode>parent</InlineCode>:</ItemTitle> Optional in denormalized input. The builder can ingest data without them.</li>
         </List>
         <SectionTitle>Group props</SectionTitle>
@@ -655,10 +671,12 @@ export const apiPages: IApiPage[] = [
           <li><ItemTitle><InlineCode>children</InlineCode>:</ItemTitle> Required nested nodes.</li>
           <li><ItemTitle><InlineCode>value</InlineCode>:</ItemTitle> Present only for groups with modifiers and must be <InlineCode>'AND'</InlineCode> or <InlineCode>'OR'</InlineCode>.</li>
           <li><ItemTitle><InlineCode>isNegated</InlineCode>:</ItemTitle> Present only for groups with modifiers.</li>
-          <li><ItemTitle><InlineCode>readOnly</InlineCode>:</ItemTitle> Can be a boolean or an object with <InlineCode>enabled</InlineCode> and optional <InlineCode>inheritToChildren</InlineCode>.</li>
+          <li><ItemTitle><InlineCode>readOnly</InlineCode>:</ItemTitle> Can be a boolean or an object with <InlineCode>enabled</InlineCode>, optional <InlineCode>targets</InlineCode>, and optional <InlineCode>inheritToChildren</InlineCode>.</li>
           <li><ItemTitle><InlineCode>readOnly: true</InlineCode>:</ItemTitle> Locks only the group&apos;s own controls by default. Descendant rules and groups remain editable unless inheritance is enabled.</li>
-          <li><ItemTitle>GUI cycle:</ItemTitle> When <InlineCode>lockable</InlineCode> is enabled, groups cycle through unlocked, locked group only, and locked group with descendants.</li>
-          <li><ItemTitle><InlineCode>inheritToChildren</InlineCode>:</ItemTitle> Applies the group lock to all descendants when the group is enabled. Descendants cannot override an inherited lock from an ancestor.</li>
+          <li><ItemTitle><InlineCode>targets</InlineCode>:</ItemTitle> Group targets are <InlineCode>'negation'</InlineCode> and <InlineCode>'combinator'</InlineCode>. Targeted controls stay visible but become non-editable.</li>
+          <li><ItemTitle>Delete behavior:</ItemTitle> A group cannot be deleted when it has effective read-only targets or contains descendants protected by read-only state.</li>
+          <li><ItemTitle>GUI cycle:</ItemTitle> When <InlineCode>lockable</InlineCode> is enabled, groups cycle through unlocked, locked group only, and locked group with descendants while preserving object-based <InlineCode>targets</InlineCode>.</li>
+          <li><ItemTitle><InlineCode>inheritToChildren</InlineCode>:</ItemTitle> Applies the group lock to descendant groups and their children when the group is enabled. Descendants cannot override an inherited lock from an ancestor.</li>
         </List>
         <AlertBox title="Documentation" variant="info">
           <TextLink to="/documentation/usage">Usage</TextLink> and{' '}

--- a/example/src/pages/api-page/pages/api-content.tsx
+++ b/example/src/pages/api-page/pages/api-content.tsx
@@ -17,6 +17,7 @@ const builderSignature = `export interface IBuilderProps {
   textMode?: boolean | IBuilderTextModeConfig;
   defaultMode?: BuilderDefaultMode;
   readOnly?: boolean;
+  readOnlyProtectsDelete?: boolean;
   lockable?: boolean;
   cloneable?: boolean;
   draggable?: boolean;
@@ -510,6 +511,7 @@ export const apiPages: IApiPage[] = [
           <li><ItemTitle><InlineCode>textMode</InlineCode>:</ItemTitle> Optional. Enables SQL text mode. Pass <InlineCode>true</InlineCode> for the default configuration or <InlineCode>IBuilderTextModeConfig</InlineCode> for explicit SQL text-mode settings.</li>
           <li><ItemTitle><InlineCode>defaultMode</InlineCode>:</ItemTitle> Optional. Controls whether the builder initially opens in <InlineCode>'builder'</InlineCode> or <InlineCode>'text'</InlineCode> mode. This only takes effect when text mode is enabled.</li>
           <li><ItemTitle><InlineCode>readOnly</InlineCode>:</ItemTitle> Defaults to <InlineCode>false</InlineCode>. Makes the whole builder non-editable.</li>
+          <li><ItemTitle><InlineCode>readOnlyProtectsDelete</InlineCode>:</ItemTitle> Defaults to <InlineCode>true</InlineCode>. When enabled, groups cannot be deleted if that would indirectly remove read-only protected descendants. Set it to <InlineCode>false</InlineCode> to allow those parent-group deletes while keeping direct read-only node restrictions.</li>
           <li><ItemTitle><InlineCode>lockable</InlineCode>:</ItemTitle> Defaults to <InlineCode>false</InlineCode>. Renders lock controls for rules and groups and writes the resulting lock state back into emitted query data without discarding existing targeted <InlineCode>readOnly.targets</InlineCode> configurations.</li>
           <li><ItemTitle><InlineCode>cloneable</InlineCode>:</ItemTitle> Defaults to <InlineCode>false</InlineCode>. Renders clone controls for rules and groups and inserts the cloned node directly below the original.</li>
           <li><ItemTitle><InlineCode>draggable</InlineCode>:</ItemTitle> Defaults to <InlineCode>false</InlineCode>. Enables drag-and-drop reordering and movement of query nodes.</li>
@@ -677,7 +679,7 @@ export const apiPages: IApiPage[] = [
           <li><ItemTitle><InlineCode>readOnly.targets</InlineCode>:</ItemTitle> Part of the <InlineCode>readOnly</InlineCode> object config. Group targets are <InlineCode>'negation'</InlineCode> and <InlineCode>'combinator'</InlineCode>. Targeted controls stay visible but become non-editable.</li>
           <li><ItemTitle><InlineCode>readOnly.enabled</InlineCode>:</ItemTitle> Part of the <InlineCode>readOnly</InlineCode> object config. When <InlineCode>true</InlineCode>, the listed targets are protected. When <InlineCode>readOnly.targets</InlineCode> is omitted, the whole group is read-only.</li>
           <li><ItemTitle><InlineCode>readOnly.inheritToChildren</InlineCode>:</ItemTitle> Part of the <InlineCode>readOnly</InlineCode> object config. Applies the group lock to descendant groups and their children when the group is enabled.</li>
-          <li><ItemTitle>Delete behavior:</ItemTitle> A group cannot be deleted when it has effective read-only targets or contains descendants protected by read-only state.</li>
+          <li><ItemTitle>Delete behavior:</ItemTitle> A group cannot be deleted when it has effective read-only targets. By default, it also cannot be deleted when that would remove protected descendants indirectly. This subtree behavior can be disabled with <InlineCode>Builder.readOnlyProtectsDelete={false}</InlineCode>.</li>
           <li><ItemTitle>GUI cycle:</ItemTitle> When <InlineCode>lockable</InlineCode> is enabled, groups cycle through unlocked, locked group only, and locked group with descendants while preserving object-based <InlineCode>readOnly.targets</InlineCode>.</li>
           <li><ItemTitle>Inheritance behavior:</ItemTitle> Descendants cannot override an inherited lock from an ancestor.</li>
         </List>

--- a/example/src/pages/api-page/pages/api-content.tsx
+++ b/example/src/pages/api-page/pages/api-content.tsx
@@ -659,8 +659,9 @@ export const apiPages: IApiPage[] = [
           <li><ItemTitle><InlineCode>operator</InlineCode>:</ItemTitle> Optional operator for the rule. Some field and operator combinations imply different value shapes.</li>
           <li><ItemTitle><InlineCode>value</InlineCode>:</ItemTitle> Optional rule value. Supported scalar/array forms are defined by <InlineCode>QueryRuleValue</InlineCode>.</li>
           <li><ItemTitle><InlineCode>operators</InlineCode>:</ItemTitle> Optional rule-level operator override list.</li>
-          <li><ItemTitle><InlineCode>readOnly</InlineCode>:</ItemTitle> Optional per-rule lock definition. Use <InlineCode>true</InlineCode> for a full rule lock or an object config for targeted rule read-only behavior.</li>
-          <li><ItemTitle><InlineCode>targets</InlineCode>:</ItemTitle> Rule targets are <InlineCode>'field'</InlineCode>, <InlineCode>'operator'</InlineCode>, and <InlineCode>'value'</InlineCode>. Targeted controls stay visible but become non-editable.</li>
+          <li><ItemTitle><InlineCode>readOnly</InlineCode>:</ItemTitle> Optional per-rule lock definition. Supported shapes are <InlineCode>false</InlineCode> or omitted, <InlineCode>true</InlineCode>, or <InlineCode>{`{ enabled: boolean; targets?: ('field' | 'operator' | 'value')[] }`}</InlineCode>.</li>
+          <li><ItemTitle><InlineCode>readOnly.targets</InlineCode>:</ItemTitle> Part of the <InlineCode>readOnly</InlineCode> object config. Rule targets are <InlineCode>'field'</InlineCode>, <InlineCode>'operator'</InlineCode>, and <InlineCode>'value'</InlineCode>. Targeted controls stay visible but become non-editable.</li>
+          <li><ItemTitle><InlineCode>readOnly.enabled</InlineCode>:</ItemTitle> Part of the <InlineCode>readOnly</InlineCode> object config. When <InlineCode>true</InlineCode>, the listed targets are protected. When <InlineCode>readOnly.targets</InlineCode> is omitted, the whole rule is read-only.</li>
           <li><ItemTitle>Delete behavior:</ItemTitle> A rule with any effective read-only target is also non-deletable, and cloned rules preserve the same read-only configuration.</li>
           <li><ItemTitle>GUI cycle:</ItemTitle> When <InlineCode>lockable</InlineCode> is enabled, rules cycle between unlocked and locked. Object-based <InlineCode>readOnly.targets</InlineCode> are preserved when the user unlocks and re-locks the same rule.</li>
           <li><ItemTitle><InlineCode>id</InlineCode> and <InlineCode>parent</InlineCode>:</ItemTitle> Optional in denormalized input. The builder can ingest data without them.</li>
@@ -671,12 +672,14 @@ export const apiPages: IApiPage[] = [
           <li><ItemTitle><InlineCode>children</InlineCode>:</ItemTitle> Required nested nodes.</li>
           <li><ItemTitle><InlineCode>value</InlineCode>:</ItemTitle> Present only for groups with modifiers and must be <InlineCode>'AND'</InlineCode> or <InlineCode>'OR'</InlineCode>.</li>
           <li><ItemTitle><InlineCode>isNegated</InlineCode>:</ItemTitle> Present only for groups with modifiers.</li>
-          <li><ItemTitle><InlineCode>readOnly</InlineCode>:</ItemTitle> Can be a boolean or an object with <InlineCode>enabled</InlineCode>, optional <InlineCode>targets</InlineCode>, and optional <InlineCode>inheritToChildren</InlineCode>.</li>
+          <li><ItemTitle><InlineCode>readOnly</InlineCode>:</ItemTitle> Can be <InlineCode>false</InlineCode> or omitted, <InlineCode>true</InlineCode>, or <InlineCode>{`{ enabled: boolean; targets?: ('negation' | 'combinator')[]; inheritToChildren?: boolean }`}</InlineCode>.</li>
           <li><ItemTitle><InlineCode>readOnly: true</InlineCode>:</ItemTitle> Locks only the group&apos;s own controls by default. Descendant rules and groups remain editable unless inheritance is enabled.</li>
-          <li><ItemTitle><InlineCode>targets</InlineCode>:</ItemTitle> Group targets are <InlineCode>'negation'</InlineCode> and <InlineCode>'combinator'</InlineCode>. Targeted controls stay visible but become non-editable.</li>
+          <li><ItemTitle><InlineCode>readOnly.targets</InlineCode>:</ItemTitle> Part of the <InlineCode>readOnly</InlineCode> object config. Group targets are <InlineCode>'negation'</InlineCode> and <InlineCode>'combinator'</InlineCode>. Targeted controls stay visible but become non-editable.</li>
+          <li><ItemTitle><InlineCode>readOnly.enabled</InlineCode>:</ItemTitle> Part of the <InlineCode>readOnly</InlineCode> object config. When <InlineCode>true</InlineCode>, the listed targets are protected. When <InlineCode>readOnly.targets</InlineCode> is omitted, the whole group is read-only.</li>
+          <li><ItemTitle><InlineCode>readOnly.inheritToChildren</InlineCode>:</ItemTitle> Part of the <InlineCode>readOnly</InlineCode> object config. Applies the group lock to descendant groups and their children when the group is enabled.</li>
           <li><ItemTitle>Delete behavior:</ItemTitle> A group cannot be deleted when it has effective read-only targets or contains descendants protected by read-only state.</li>
-          <li><ItemTitle>GUI cycle:</ItemTitle> When <InlineCode>lockable</InlineCode> is enabled, groups cycle through unlocked, locked group only, and locked group with descendants while preserving object-based <InlineCode>targets</InlineCode>.</li>
-          <li><ItemTitle><InlineCode>inheritToChildren</InlineCode>:</ItemTitle> Applies the group lock to descendant groups and their children when the group is enabled. Descendants cannot override an inherited lock from an ancestor.</li>
+          <li><ItemTitle>GUI cycle:</ItemTitle> When <InlineCode>lockable</InlineCode> is enabled, groups cycle through unlocked, locked group only, and locked group with descendants while preserving object-based <InlineCode>readOnly.targets</InlineCode>.</li>
+          <li><ItemTitle>Inheritance behavior:</ItemTitle> Descendants cannot override an inherited lock from an ancestor.</li>
         </List>
         <AlertBox title="Documentation" variant="info">
           <TextLink to="/documentation/usage">Usage</TextLink> and{' '}

--- a/example/src/pages/documentation-page/pages/documentation-content.tsx
+++ b/example/src/pages/documentation-page/pages/documentation-content.tsx
@@ -307,6 +307,7 @@ const builderBehaviorSnippet = `<Builder
   fields={fields}
   data={data}
   lockable
+  readOnlyProtectsDelete
   cloneable
   draggable
   newNodePlacement="prepend"
@@ -318,6 +319,10 @@ const builderBehaviorSnippet = `<Builder
 // lockable:
 // Renders built-in lock controls for rules and groups and writes the resulting
 // lock state back into the emitted query via rule/group readOnly values.
+//
+// readOnlyProtectsDelete:
+// Prevents deleting parent groups when that delete would indirectly remove
+// read-only protected descendants. Defaults to true.
 //
 // cloneable:
 // Renders built-in clone controls for rules and groups and inserts the cloned
@@ -1095,7 +1100,7 @@ export const documentationPages: IDocumentationPage[] = [
     description:
       'Documentation for clone controls, drag-and-drop, insertion placement, root-group behavior, and group mode configuration.',
     searchText:
-      'builder behavior cloneable clone controls draggable drag and drop newNodePlacement append prepend singleRootGroup groupTypes with modifiers without modifiers both root group',
+      'builder behavior cloneable clone controls draggable drag and drop readOnlyProtectsDelete newNodePlacement append prepend singleRootGroup groupTypes with modifiers without modifiers both root group',
     content: (
       <>
         <p>
@@ -1119,6 +1124,12 @@ export const documentationPages: IDocumentationPage[] = [
           <li>Read-only rules and groups are excluded from dragging.</li>
           <li>When the entire builder is read-only, drag-and-drop is disabled as well.</li>
           <li>Empty groups expose a dedicated drop zone so items can be moved into them.</li>
+        </List>
+        <SectionTitle>readOnlyProtectsDelete</SectionTitle>
+        <List>
+          <li>Defaults to <InlineCode>true</InlineCode>.</li>
+          <li>When enabled, deleting a group is blocked if that would indirectly remove read-only protected descendants.</li>
+          <li>Set it to <InlineCode>false</InlineCode> when your product wants only directly protected nodes to be non-deletable, while still allowing parent-group deletes around them.</li>
         </List>
         <SectionTitle>singleRootGroup</SectionTitle>
         <List>
@@ -1278,7 +1289,8 @@ export const documentationPages: IDocumentationPage[] = [
           <li>Locked rules cannot change field, operator, or value, and cannot be deleted.</li>
           <li>Targeted rule read-only also blocks deleting that rule, even if only one target such as <InlineCode>field</InlineCode> is protected.</li>
           <li>Locked groups cannot change their group operator, negation, add actions, or delete action.</li>
-          <li>Groups cannot be deleted when that would remove protected descendants indirectly.</li>
+          <li>By default, groups also cannot be deleted when that would remove protected descendants indirectly.</li>
+          <li>Set <InlineCode>Builder.readOnlyProtectsDelete={false}</InlineCode> to disable that subtree delete protection while keeping direct node-level read-only deletion rules.</li>
           <li>Locked rules and groups are removed from drag-and-drop interactions.</li>
           <li>Clone controls render only for editable rules and groups. Cloned nodes preserve their read-only configuration.</li>
           <li>

--- a/example/src/pages/documentation-page/pages/documentation-content.tsx
+++ b/example/src/pages/documentation-page/pages/documentation-content.tsx
@@ -661,13 +661,19 @@ const lockingSnippet = `const data: DenormalizedQuery = [
         field: 'STATUS',
         operator: 'EQUAL',
         value: 'ACTIVE',
-        readOnly: true,
+        readOnly: {
+          enabled: true,
+          targets: ['field', 'operator'],
+        },
       },
       {
         type: 'GROUP',
         value: 'OR',
         isNegated: false,
-        readOnly: true,
+        readOnly: {
+          enabled: true,
+          targets: ['combinator'],
+        },
         children: [
           {
             field: 'COUNTRY',
@@ -698,6 +704,38 @@ const lockingSnippet = `const data: DenormalizedQuery = [
 
 <Builder fields={fields} data={data} onChange={setData} />;`;
 
+const targetedReadOnlySnippet = `const data: DenormalizedQuery = [
+  {
+    type: 'GROUP',
+    value: 'AND',
+    isNegated: false,
+    readOnly: {
+      enabled: true,
+      targets: ['combinator'],
+    },
+    children: [
+      {
+        field: 'CUSTOMER_COUNTRY',
+        operator: 'EQUAL',
+        value: 'CZ',
+        readOnly: {
+          enabled: true,
+          targets: ['field', 'operator'],
+        },
+      },
+      {
+        field: 'ORDER_TOTAL',
+        operator: 'BETWEEN',
+        value: [1000, 5000],
+        readOnly: {
+          enabled: true,
+          targets: ['value'],
+        },
+      },
+    ],
+  },
+];`;
+
 const lockingGuiSnippet = `<Builder
   fields={fields}
   data={data}
@@ -714,7 +752,10 @@ const lockingGuiSnippet = `<Builder
 // The emitted query stores those states in readOnly:
 // rule: readOnly: true
 // group: readOnly: true
-// group + descendants: readOnly: { enabled: true, inheritToChildren: true }`;
+// group + descendants: readOnly: { enabled: true, inheritToChildren: true }
+//
+// If a node already uses readOnly.targets, the lock toggle preserves those
+// targets and only changes enabled/inheritToChildren.`;
 
 const lockToggleSnippet = `const components = {
   LockToggle: MyLockToggle,
@@ -1145,15 +1186,17 @@ export const documentationPages: IDocumentationPage[] = [
     sectionTitle: 'Getting Started',
     summary: '',
     description:
-      'Documentation for builder-level, rule-level, and group-level read-only behavior, including group inheritance semantics.',
+      'Documentation for builder-level, rule-level, and group-level read-only behavior, including targeted read-only and group inheritance semantics.',
     searchText:
-      'readOnly locking locked rule group inheritToChildren inheritance read only builder rule group drag delete add controls',
+      'readOnly locking locked rule group targets field operator value combinator negation inheritToChildren inheritance read only builder rule group drag delete add controls',
     content: (
       <>
         <p>
           Locking can be applied at the builder, rule, or group level. The key
           distinction is that rules lock only themselves, while groups can lock
-          either just their own controls or their entire subtree.
+          either just their own controls or their entire subtree. Object-based{' '}
+          <InlineCode>readOnly</InlineCode> configs also support targeted
+          read-only for specific controls.
         </p>
         <SectionTitle>GUI Locking</SectionTitle>
         <p>
@@ -1161,6 +1204,9 @@ export const documentationPages: IDocumentationPage[] = [
           to render lock controls directly in the UI. The built-in controls update
           the same <InlineCode>readOnly</InlineCode> fields that are already part of
           the query data model, so the resulting lock state is preserved in output.
+          If a node already has <InlineCode>readOnly.targets</InlineCode>, the
+          lock toggle preserves those targets and only changes whether the lock
+          is enabled and, for groups, whether it inherits to descendants.
         </p>
         <CodeBlock code={lockingGuiSnippet} language="tsx" label="GUI locking" />
         <List>
@@ -1169,6 +1215,19 @@ export const documentationPages: IDocumentationPage[] = [
           <li>The default group cycle maps to <InlineCode>false</InlineCode>, <InlineCode>true</InlineCode>, and <InlineCode>{`{ enabled: true, inheritToChildren: true }`}</InlineCode>.</li>
           <li>When a parent group inherits a lock to descendants, child lock controls render disabled because descendants cannot override that inherited state.</li>
           <li>When <InlineCode>cloneable</InlineCode> is also enabled, the clone button renders immediately to the left of the lock button.</li>
+        </List>
+        <SectionTitle>Targeted read-only</SectionTitle>
+        <p>
+          Use object-based <InlineCode>readOnly</InlineCode> configs when you want
+          to keep specific controls visible but non-editable instead of locking
+          the entire rule or group.
+        </p>
+        <CodeBlock code={targetedReadOnlySnippet} language="tsx" label="Targeted read-only" />
+        <List>
+          <li>Rule targets are <InlineCode>field</InlineCode>, <InlineCode>operator</InlineCode>, and <InlineCode>value</InlineCode>.</li>
+          <li>Group targets are <InlineCode>combinator</InlineCode> and <InlineCode>negation</InlineCode>.</li>
+          <li>If <InlineCode>enabled</InlineCode> is <InlineCode>true</InlineCode> and <InlineCode>targets</InlineCode> is omitted, the whole node is read-only.</li>
+          <li>If <InlineCode>enabled</InlineCode> is <InlineCode>false</InlineCode>, the config stays dormant until the node is locked again.</li>
         </List>
         <SectionTitle>How each level behaves</SectionTitle>
         <List>
@@ -1181,9 +1240,19 @@ export const documentationPages: IDocumentationPage[] = [
             Siblings and parent groups are unaffected.
           </li>
           <li>
+            <InlineCode>{`rule.readOnly = { enabled: true, targets: ['field'] }`}</InlineCode>{' '}
+            keeps the field visible but non-editable, and also prevents deleting
+            that rule.
+          </li>
+          <li>
             <InlineCode>group.readOnly = true</InlineCode> locks only that
             group&apos;s own controls. Its child rules and child groups stay
             editable by default.
+          </li>
+          <li>
+            <InlineCode>{`group.readOnly = { enabled: true, targets: ['combinator'] }`}</InlineCode>{' '}
+            keeps the group combinator visible but non-editable without forcing
+            descendant rules to become read-only.
           </li>
           <li>
             <InlineCode>{`group.readOnly = { enabled: true, inheritToChildren: true }`}</InlineCode>{' '}
@@ -1205,10 +1274,13 @@ export const documentationPages: IDocumentationPage[] = [
         <CodeBlock code={cloneButtonSnippet} language="tsx" label="CloneButton override" />
         <SectionTitle>What &quot;locked&quot; means in the UI</SectionTitle>
         <List>
+          <li>Read-only targets stay visible. They become disabled, not hidden.</li>
           <li>Locked rules cannot change field, operator, or value, and cannot be deleted.</li>
+          <li>Targeted rule read-only also blocks deleting that rule, even if only one target such as <InlineCode>field</InlineCode> is protected.</li>
           <li>Locked groups cannot change their group operator, negation, add actions, or delete action.</li>
+          <li>Groups cannot be deleted when that would remove protected descendants indirectly.</li>
           <li>Locked rules and groups are removed from drag-and-drop interactions.</li>
-          <li>Clone controls render only for editable rules and groups.</li>
+          <li>Clone controls render only for editable rules and groups. Cloned nodes preserve their read-only configuration.</li>
           <li>
             A locked group without inheritance still renders editable descendants
             when those descendants are not otherwise locked.
@@ -1228,6 +1300,11 @@ export const documentationPages: IDocumentationPage[] = [
           <li>
             Descendants may still add their own local <InlineCode>readOnly</InlineCode>{' '}
             flags, but they cannot override an inherited lock from an ancestor.
+          </li>
+          <li>
+            Group target inheritance preserves only the group-level semantics of
+            the inherited lock. It does not turn rule-specific controls such as{' '}
+            <InlineCode>field</InlineCode> or <InlineCode>value</InlineCode> into inherited targets.
           </li>
         </List>
         <AlertBox title="API reference" variant="info">
@@ -1394,6 +1471,7 @@ export const documentationPages: IDocumentationPage[] = [
           <li>Unsupported operators for a field are highlighted on the operator token.</li>
           <li>Invalid <InlineCode>LIST</InlineCode> values are highlighted on the invalid value token.</li>
           <li>Invalid <InlineCode>MULTI_LIST</InlineCode> values are highlighted on the invalid value token.</li>
+          <li>Read-only negation changes are rejected after parsing and shown as below-editor semantic errors.</li>
         </List>
         <SectionTitle>Invalid text behavior</SectionTitle>
         <List>
@@ -1409,7 +1487,7 @@ export const documentationPages: IDocumentationPage[] = [
         <SectionTitle>Choosing an editor</SectionTitle>
         <List>
           <li><ItemTitle>Choose the built-in editor:</ItemTitle> when you want lightweight SQL editing, built-in validation, and no extra dependencies.</li>
-          <li><ItemTitle>Choose Monaco:</ItemTitle> when locked rules or groups must stay protected in text mode, or when you want a more advanced editor experience.</li>
+          <li><ItemTitle>Choose Monaco:</ItemTitle> when locked or targeted read-only query segments must stay protected in text mode, or when you want a more advanced editor experience.</li>
         </List>
         <SectionTitle>Built-in editor vs Monaco</SectionTitle>
         <List>
@@ -1420,19 +1498,26 @@ export const documentationPages: IDocumentationPage[] = [
             validation without extra dependencies.
           </li>
           <li>
-            <ItemTitle>Built-in editor limitation:</ItemTitle> Locked rules and
-            locked groups are blocked before entering text mode there, because the
-            basic editor cannot preserve protected query segments safely after freeform text edits.
+            <ItemTitle>Built-in editor limitation:</ItemTitle> Locked rules,
+            locked groups, and targeted read-only queries are blocked before
+            entering text mode there, because the basic editor cannot preserve
+            protected query segments safely after freeform text edits.
           </li>
           <li>
             <ItemTitle>Monaco text mode:</ItemTitle> Optional advanced editor
             integration exposed from{' '}
             <InlineCode>@vojtechportes/react-query-builder/monaco</InlineCode>.
-            It preserves locked query segments by rendering them as protected ranges.
+            It preserves locked and targeted read-only query segments by rendering
+            them as protected ranges.
           </li>
           <li>
-            <ItemTitle>Monaco locked behavior:</ItemTitle> Locked SQL fragments are
-            dimmed, protected from edits, and expose their lock explanation on hover.
+            <ItemTitle>Monaco protected behavior:</ItemTitle> Protected SQL fragments
+            are dimmed, protected from edits, and expose their lock explanation on hover.
+          </li>
+          <li>
+            <ItemTitle>Localized read-only protection:</ItemTitle> Rule field,
+            operator, and value segments can be protected inline, while read-only
+            negation is additionally enforced semantically and reported below the editor when changed.
           </li>
           <li>
             <ItemTitle>Monaco packaging:</ItemTitle>{' '}
@@ -1470,15 +1555,16 @@ export const documentationPages: IDocumentationPage[] = [
           <li><InlineCode>strings.textMode.toggleToText</InlineCode> customizes the button label for entering text mode.</li>
           <li><InlineCode>strings.textMode.toggleToBuilder</InlineCode> customizes the button label for returning to the visual builder.</li>
           <li><InlineCode>strings.textMode.syntaxError</InlineCode> customizes the syntax error prefix.</li>
-          <li><InlineCode>strings.textMode.locksUnsupported</InlineCode> customizes the built-in alert shown when the basic editor cannot open a locked query.</li>
+          <li><InlineCode>strings.textMode.locksUnsupported</InlineCode> customizes the built-in alert shown when the basic editor cannot open a locked or targeted read-only query.</li>
           <li><InlineCode>strings.textMode.lockedRangesHover</InlineCode> customizes the hover message shown for protected Monaco ranges.</li>
           <li><InlineCode>strings.textMode.sql</InlineCode> customizes SQL parser and syntax-validation messages such as missing brackets, missing quotes, missing keywords, and unexpected tokens.</li>
         </List>
         <SectionTitle>Installing Monaco</SectionTitle>
         <CodeBlock code={monacoInstallSnippet} language="bash" label="Monaco peer dependency" />
         <AlertBox title="Locks and Monaco" variant="info">
-          The built-in text editor blocks locked queries. Monaco is the intended
-          path when locked rules or groups need to remain protected in text mode.
+          The built-in text editor blocks locked and targeted read-only queries.
+          Monaco is the intended path when protected query segments need to remain
+          editable only around their unlocked ranges.
         </AlertBox>
         <AlertBox title="API reference" variant="info">
           <TextLink to="/api/builder">Builder</TextLink> and{' '}

--- a/example/src/utils/builder-source/format-builder-source.ts
+++ b/example/src/utils/builder-source/format-builder-source.ts
@@ -5,6 +5,7 @@ import { formatThemeOverrides } from './utils/format-theme-overrides.util';
 
 export const formatBuilderSource = ({
   readOnly,
+  readOnlyProtectsDelete,
   lockable,
   cloneable,
   draggable,
@@ -57,6 +58,9 @@ export const formatBuilderSource = ({
     'fields={demoFields}',
     'onChange={setData}',
     readOnly ? 'readOnly' : null,
+    readOnlyProtectsDelete
+      ? null
+      : 'readOnlyProtectsDelete={false}',
     lockable ? 'lockable' : null,
     cloneable ? 'cloneable' : null,
     draggable ? 'draggable' : null,

--- a/example/src/utils/builder-source/types/index.ts
+++ b/example/src/utils/builder-source/types/index.ts
@@ -4,6 +4,7 @@ export type CustomizationMode = 'default' | 'mui' | 'antd';
 
 export interface IBuilderSourceOptions {
   readOnly: boolean;
+  readOnlyProtectsDelete: boolean;
   lockable: boolean;
   cloneable: boolean;
   draggable: boolean;

--- a/src/builder-context.tsx
+++ b/src/builder-context.tsx
@@ -18,6 +18,7 @@ export interface IBuilderContextProps {
   fields: IBuilderFieldProps[];
   data: NormalizedQuery;
   readOnly: boolean;
+  readOnlyProtectsDelete?: boolean;
   lockable?: boolean;
   cloneable?: boolean;
   draggable?: boolean;
@@ -50,6 +51,7 @@ export interface IBuilderContextProviderProps {
   fields: IBuilderFieldProps[];
   data: NormalizedQuery;
   readOnly: boolean;
+  readOnlyProtectsDelete?: boolean;
   lockable?: boolean;
   cloneable?: boolean;
   draggable?: boolean;
@@ -76,6 +78,7 @@ export const BuilderContextProvider: FC<IBuilderContextProviderProps> = ({
   strings,
   data,
   readOnly,
+  readOnlyProtectsDelete,
   lockable,
   cloneable,
   draggable,
@@ -138,6 +141,7 @@ export const BuilderContextProvider: FC<IBuilderContextProviderProps> = ({
         strings: resolvedStrings,
         data,
         readOnly,
+        readOnlyProtectsDelete,
         lockable,
         cloneable,
         draggable,

--- a/src/builder/builder.test.tsx
+++ b/src/builder/builder.test.tsx
@@ -15,6 +15,7 @@ import {
   IBuilderRef,
   useBuilderRef,
 } from './index';
+import { DenormalizedQuery } from '../utils/query-tree';
 
 export const fields: IBuilderFieldProps[] = [
   {
@@ -659,6 +660,104 @@ describe('#components/Builder', () => {
     expect(queryByDataTest(container, 'TextModeError')).not.toBeNull();
     expect(queryByDataTest(container, 'TextModeDiagnostic[0]')).not.toBeNull();
     expect(onChange).not.toHaveBeenCalled();
+  });
+
+  it('Rejects read-only negation changes in text mode and keeps the edited text visible', () => {
+    const onChange = jest.fn();
+    const { container } = render(
+      <Builder
+        fields={fields}
+        data={[
+          {
+            type: 'GROUP',
+            value: 'AND',
+            isNegated: false,
+            children: [
+              {
+                type: 'GROUP',
+                value: 'AND',
+                isNegated: true,
+                readOnly: {
+                  enabled: true,
+                  targets: ['negation'],
+                },
+                children: [
+                  { field: 'MOCK_FIELD', value: 'alpha', operator: 'EQUAL' },
+                ],
+              },
+            ],
+          },
+        ]}
+        textMode
+        defaultMode="text"
+        components={{
+          ...defaultComponents,
+          TextModeEditor: CustomTextModeEditor,
+        }}
+        onChange={onChange}
+      />
+    );
+
+    fireEvent.change(getByDataTest(container, 'CustomTextModeEditorInput'), {
+      target: { value: "((MOCK_FIELD = 'alpha'))" },
+    });
+
+    expect(onChange).not.toHaveBeenCalled();
+    expect(
+      getByDataTest(container, 'CustomTextModeEditorInput')
+    ).toHaveValue("((MOCK_FIELD = 'alpha'))");
+    expect(
+      getByDataTest(container, 'CustomTextModeEditorError').textContent
+    ).toContain('Negation is read-only');
+  });
+
+  it('Preserves protected ranges after editing an unlocked value in text mode', async () => {
+    const onChange = jest.fn();
+    const { container } = render(
+      <Builder
+        fields={fields}
+        data={[
+          {
+            type: 'GROUP',
+            value: 'AND',
+            isNegated: false,
+            children: [
+              {
+                field: 'MOCK_FIELD',
+                value: 'alpha',
+                operator: 'EQUAL',
+                readOnly: {
+                  enabled: true,
+                  targets: ['field', 'operator'],
+                },
+              },
+            ],
+          },
+        ]}
+        textMode
+        defaultMode="text"
+        components={{
+          ...defaultComponents,
+          TextModeEditor: CustomTextModeEditor,
+        }}
+        onChange={onChange}
+      />
+    );
+
+    expect(
+      getByDataTest(container, 'CustomTextModeEditorProtectedRangeCount')
+    ).toHaveTextContent('2');
+
+    fireEvent.change(getByDataTest(container, 'CustomTextModeEditorInput'), {
+      target: { value: "(MOCK_FIELD = 'beta')" },
+    });
+
+    await waitFor(() => {
+      expect(onChange).toHaveBeenCalled();
+      expect(
+        getByDataTest(container, 'CustomTextModeEditorProtectedRangeCount')
+      ).toHaveTextContent('2');
+    });
   });
 
   it('Reports a missing quote near the broken string boundary instead of a later token', () => {
@@ -1757,6 +1856,203 @@ describe('#components/Builder', () => {
     ]);
   });
 
+  it('Keeps identical targeted read-only siblings non-deletable after locking one in controlled mode', async () => {
+    const ControlledBuilder = () => {
+      const [value, setValue] = React.useState<DenormalizedQuery>([
+        {
+          type: 'GROUP',
+          value: 'AND',
+          isNegated: false,
+          children: [
+            {
+              field: 'MOCK_FIELD',
+              value: 'alpha',
+              operator: 'EQUAL',
+            },
+            {
+              field: 'MOCK_FIELD',
+              value: 'alpha',
+              operator: 'EQUAL',
+              readOnly: {
+                enabled: true,
+                targets: ['field', 'operator'],
+              },
+            },
+          ],
+        },
+      ]);
+
+      return (
+        <Builder
+          fields={fields}
+          lockable
+          data={value}
+          onChange={setValue}
+        />
+      );
+    };
+
+    const { container } = render(<ControlledBuilder />);
+
+    expect(screen.getAllByRole('button', { name: 'Delete' })).toHaveLength(1);
+
+    fireEvent.click(getAllByDataTest(container, 'LockToggle[rule]')[0]);
+
+    await waitFor(() => {
+      expect(
+        screen.queryByRole('button', { name: 'Delete' })
+      ).not.toBeInTheDocument();
+    });
+  });
+
+  it('Only toggles lock state for the targeted cloned rule in controlled mode', async () => {
+    let latestData: IBuilderProps['data'] | null = null;
+
+    const ControlledBuilder = () => {
+      const [value, setValue] = React.useState<DenormalizedQuery>([
+        {
+          type: 'GROUP' as const,
+          value: 'AND' as const,
+          isNegated: false,
+          children: [
+            {
+              field: 'MOCK_FIELD',
+              value: 'alpha',
+              operator: 'EQUAL' as const,
+              readOnly: {
+                enabled: true,
+                targets: ['field', 'operator'] as ('field' | 'operator')[],
+              },
+            },
+          ],
+        },
+      ]);
+
+      latestData = value;
+
+      return (
+        <Builder
+          fields={fields}
+          cloneable
+          lockable
+          data={value}
+          onChange={setValue}
+        />
+      );
+    };
+
+    const { container } = render(<ControlledBuilder />);
+
+    fireEvent.click(getAllByDataTest(container, 'CloneButton[rule]')[0]);
+
+    await waitFor(() => {
+      expect(getAllByDataTest(container, 'IteratorRule')).toHaveLength(2);
+    });
+
+    fireEvent.click(getAllByDataTest(container, 'LockToggle[rule]')[0]);
+
+    await waitFor(() => {
+      expect(latestData).toEqual([
+        {
+          type: 'GROUP',
+          value: 'AND',
+          isNegated: false,
+          children: [
+            {
+              field: 'MOCK_FIELD',
+              value: 'alpha',
+              operator: 'EQUAL',
+              readOnly: {
+                enabled: false,
+                targets: ['field', 'operator'],
+              },
+            },
+            {
+              field: 'MOCK_FIELD',
+              value: 'alpha',
+              operator: 'EQUAL',
+              readOnly: {
+                enabled: true,
+                targets: ['field', 'operator'],
+              },
+            },
+          ],
+        },
+      ]);
+    });
+  });
+
+  it('Preserves rule read-only targets when toggling lock state through the GUI', () => {
+    const onChange = jest.fn();
+    const { container } = render(
+      <Builder
+        fields={fields}
+        lockable
+        data={[
+          {
+            type: 'GROUP',
+            value: 'AND',
+            isNegated: false,
+            children: [
+              {
+                field: 'MOCK_FIELD',
+                value: '',
+                operator: 'EQUAL',
+                readOnly: {
+                  enabled: true,
+                  targets: ['field'],
+                },
+              },
+            ],
+          },
+        ]}
+        onChange={onChange}
+      />
+    );
+
+    fireEvent.click(getAllByDataTest(container, 'LockToggle[rule]')[0]);
+
+    expect(onChange).toHaveBeenLastCalledWith([
+      {
+        type: 'GROUP',
+        value: 'AND',
+        isNegated: false,
+        children: [
+          {
+            field: 'MOCK_FIELD',
+            value: '',
+            operator: 'EQUAL',
+            readOnly: {
+              enabled: false,
+              targets: ['field'],
+            },
+          },
+        ],
+      },
+    ]);
+
+    fireEvent.click(getAllByDataTest(container, 'LockToggle[rule]')[0]);
+
+    expect(onChange).toHaveBeenLastCalledWith([
+      {
+        type: 'GROUP',
+        value: 'AND',
+        isNegated: false,
+        children: [
+          {
+            field: 'MOCK_FIELD',
+            value: '',
+            operator: 'EQUAL',
+            readOnly: {
+              enabled: true,
+              targets: ['field'],
+            },
+          },
+        ],
+      },
+    ]);
+  });
+
   it('Locks group controls without inheriting read-only to descendants by default', () => {
     const { container } = render(
       <Builder
@@ -1916,6 +2212,110 @@ describe('#components/Builder', () => {
             type: 'GROUP',
             value: 'AND',
             isNegated: false,
+            children: [],
+          },
+        ],
+      },
+    ]);
+  });
+
+  it('Preserves group read-only targets when cycling lock state through the GUI', () => {
+    const onChange = jest.fn();
+    const { container } = render(
+      <Builder
+        fields={fields}
+        lockable
+        data={[
+          {
+            type: 'GROUP',
+            value: 'AND',
+            isNegated: false,
+            children: [
+              {
+                type: 'GROUP',
+                value: 'AND',
+                isNegated: false,
+                readOnly: {
+                  enabled: true,
+                  targets: ['combinator'],
+                },
+                children: [],
+              },
+            ],
+          },
+        ]}
+        onChange={onChange}
+      />
+    );
+
+    const getLastGroupToggle = () => {
+      const toggles = getAllByDataTest(container, 'LockToggle[group]');
+      return toggles[toggles.length - 1];
+    };
+
+    fireEvent.click(getLastGroupToggle());
+
+    expect(onChange).toHaveBeenLastCalledWith([
+      {
+        type: 'GROUP',
+        value: 'AND',
+        isNegated: false,
+        children: [
+          {
+            type: 'GROUP',
+            value: 'AND',
+            isNegated: false,
+            readOnly: {
+              enabled: true,
+              targets: ['combinator'],
+              inheritToChildren: true,
+            },
+            children: [],
+          },
+        ],
+      },
+    ]);
+
+    fireEvent.click(getLastGroupToggle());
+
+    expect(onChange).toHaveBeenLastCalledWith([
+      {
+        type: 'GROUP',
+        value: 'AND',
+        isNegated: false,
+        children: [
+          {
+            type: 'GROUP',
+            value: 'AND',
+            isNegated: false,
+            readOnly: {
+              enabled: false,
+              targets: ['combinator'],
+              inheritToChildren: false,
+            },
+            children: [],
+          },
+        ],
+      },
+    ]);
+
+    fireEvent.click(getLastGroupToggle());
+
+    expect(onChange).toHaveBeenLastCalledWith([
+      {
+        type: 'GROUP',
+        value: 'AND',
+        isNegated: false,
+        children: [
+          {
+            type: 'GROUP',
+            value: 'AND',
+            isNegated: false,
+            readOnly: {
+              enabled: true,
+              targets: ['combinator'],
+              inheritToChildren: false,
+            },
             children: [],
           },
         ],
@@ -2331,5 +2731,58 @@ describe('#components/Builder', () => {
         ],
       },
     ]);
+  });
+
+  it('Blocks imperative deleteNode for read-only-targeted nodes', () => {
+    const onChange = jest.fn();
+    let builderRefObject: React.MutableRefObject<IBuilderRef | null> | null = null;
+
+    const TestComponent = () => {
+      const builderRef = useBuilderRef();
+      builderRefObject = builderRef;
+
+      return (
+        <Builder
+          ref={builderRef}
+          fields={fields}
+          data={[
+            {
+              type: 'GROUP',
+              value: 'AND',
+              isNegated: false,
+              children: [
+                {
+                  field: 'MOCK_FIELD',
+                  value: 'alpha',
+                  operator: 'EQUAL',
+                  readOnly: {
+                    enabled: true,
+                    targets: ['field'],
+                  },
+                },
+              ],
+            },
+          ]}
+          onChange={onChange}
+        />
+      );
+    };
+
+    render(<TestComponent />);
+
+    const builderRef = builderRefObject as React.MutableRefObject<IBuilderRef | null> | null;
+    const protectedRuleId = builderRef?.current
+      ?.getNodes()
+      .find((node: ReturnType<IBuilderRef['getNodes']>[number]) => 'field' in node)?.id;
+
+    expect(protectedRuleId).toBeDefined();
+
+    act(() => {
+      expect(
+        builderRef?.current?.deleteNode(protectedRuleId as string)
+      ).toBe(false);
+    });
+
+    expect(onChange).not.toHaveBeenCalled();
   });
 });

--- a/src/builder/builder.test.tsx
+++ b/src/builder/builder.test.tsx
@@ -744,9 +744,12 @@ describe('#components/Builder', () => {
       />
     );
 
-    expect(
-      getByDataTest(container, 'CustomTextModeEditorProtectedRangeCount')
-    ).toHaveTextContent('2');
+    const initialProtectedRangeCount = getByDataTest(
+      container,
+      'CustomTextModeEditorProtectedRangeCount'
+    ).textContent;
+
+    expect(initialProtectedRangeCount).not.toBeNull();
 
     fireEvent.change(getByDataTest(container, 'CustomTextModeEditorInput'), {
       target: { value: "(MOCK_FIELD = 'beta')" },
@@ -756,8 +759,268 @@ describe('#components/Builder', () => {
       expect(onChange).toHaveBeenCalled();
       expect(
         getByDataTest(container, 'CustomTextModeEditorProtectedRangeCount')
-      ).toHaveTextContent('2');
+      ).toHaveTextContent(initialProtectedRangeCount as string);
     });
+  });
+
+  it('keeps targeted read-only rules attached to the original nested group after editing another group in text mode', () => {
+    const onChange = jest.fn();
+    const { container } = render(
+      <Builder
+        fields={fields}
+        data={[
+          {
+            type: 'GROUP',
+            value: 'AND',
+            isNegated: false,
+            children: [
+              {
+                type: 'GROUP',
+                value: 'OR',
+                isNegated: false,
+                children: [
+                  {
+                    field: 'MOCK_FIELD',
+                    value: 'alpha',
+                    operator: 'EQUAL',
+                    readOnly: {
+                      enabled: true,
+                      targets: ['field', 'operator'],
+                    },
+                  },
+                  {
+                    field: 'MOCK_NUMBER',
+                    value: 5,
+                    operator: 'NOT_EQUAL',
+                  },
+                ],
+              },
+              {
+                type: 'GROUP',
+                value: 'AND',
+                isNegated: false,
+                children: [
+                  {
+                    field: 'MOCK_FIELD',
+                    value: 'beta',
+                    operator: 'EQUAL',
+                  },
+                  {
+                    field: 'MOCK_NUMBER',
+                    value: 8,
+                    operator: 'NOT_EQUAL',
+                  },
+                ],
+              },
+            ],
+          },
+        ]}
+        textMode
+        defaultMode="text"
+        components={{
+          ...defaultComponents,
+          TextModeEditor: CustomTextModeEditor,
+        }}
+        onChange={onChange}
+      />
+    );
+
+    fireEvent.change(getByDataTest(container, 'CustomTextModeEditorInput'), {
+      target: {
+        value:
+          "((MOCK_FIELD = 'alpha' OR MOCK_NUMBER != 5) AND (MOCK_FIELD = 'beta' AND MOCK_NUMBER != 9))",
+      },
+    });
+
+    expect(onChange).toHaveBeenLastCalledWith([
+      {
+        type: 'GROUP',
+        value: 'AND',
+        isNegated: false,
+        children: [
+          {
+            type: 'GROUP',
+            value: 'OR',
+            isNegated: false,
+            children: [
+              {
+                field: 'MOCK_FIELD',
+                value: 'alpha',
+                operator: 'EQUAL',
+                readOnly: {
+                  enabled: true,
+                  targets: ['field', 'operator'],
+                },
+              },
+              {
+                field: 'MOCK_NUMBER',
+                value: 5,
+                operator: 'NOT_EQUAL',
+              },
+            ],
+          },
+          {
+            type: 'GROUP',
+            value: 'AND',
+            isNegated: false,
+            children: [
+              {
+                field: 'MOCK_FIELD',
+                value: 'beta',
+                operator: 'EQUAL',
+              },
+              {
+                field: 'MOCK_NUMBER',
+                value: 9,
+                operator: 'NOT_EQUAL',
+              },
+            ],
+          },
+        ],
+      },
+    ]);
+  });
+
+  it('rejects deleting a group that contains a read-only descendant in text mode', () => {
+    const onChange = jest.fn();
+    const { container } = render(
+      <Builder
+        fields={fields}
+        data={[
+          {
+            type: 'GROUP',
+            value: 'AND',
+            isNegated: false,
+            children: [
+              {
+                type: 'GROUP',
+                value: 'OR',
+                isNegated: false,
+                children: [
+                  {
+                    field: 'MOCK_FIELD',
+                    value: 'alpha',
+                    operator: 'EQUAL',
+                    readOnly: {
+                      enabled: true,
+                      targets: ['field', 'operator'],
+                    },
+                  },
+                  {
+                    field: 'MOCK_NUMBER',
+                    value: 5,
+                    operator: 'NOT_EQUAL',
+                  },
+                ],
+              },
+              {
+                field: 'MOCK_NUMBER',
+                value: 8,
+                operator: 'NOT_EQUAL',
+              },
+            ],
+          },
+        ]}
+        textMode
+        defaultMode="text"
+        components={{
+          ...defaultComponents,
+          TextModeEditor: CustomTextModeEditor,
+        }}
+        onChange={onChange}
+      />
+    );
+
+    const previousTextValue = (
+      getByDataTest(container, 'CustomTextModeEditorInput') as HTMLTextAreaElement
+    ).value;
+
+    fireEvent.change(getByDataTest(container, 'CustomTextModeEditorInput'), {
+      target: { value: '(MOCK_NUMBER != 8)' },
+    });
+
+    expect(onChange).not.toHaveBeenCalled();
+    expect(getByDataTest(container, 'CustomTextModeEditorInput')).toHaveValue(
+      previousTextValue
+    );
+    expect(getByDataTest(container, 'CustomTextModeEditorError')).toHaveTextContent(
+      'One or more read-only clauses cannot be changed or removed in text mode.'
+    );
+  });
+
+  it('allows deleting a group with a read-only descendant in text mode when readOnlyProtectsDelete is false', async () => {
+    const onChange = jest.fn();
+    const { container } = render(
+      <Builder
+        fields={fields}
+        data={[
+          {
+            type: 'GROUP',
+            value: 'AND',
+            isNegated: false,
+            children: [
+              {
+                type: 'GROUP',
+                value: 'OR',
+                isNegated: false,
+                children: [
+                  {
+                    field: 'MOCK_FIELD',
+                    value: 'alpha',
+                    operator: 'EQUAL',
+                    readOnly: {
+                      enabled: true,
+                      targets: ['field', 'operator'],
+                    },
+                  },
+                  {
+                    field: 'MOCK_NUMBER',
+                    value: 5,
+                    operator: 'NOT_EQUAL',
+                  },
+                ],
+              },
+              {
+                field: 'MOCK_NUMBER',
+                value: 8,
+                operator: 'NOT_EQUAL',
+              },
+            ],
+          },
+        ]}
+        textMode
+        defaultMode="text"
+        readOnlyProtectsDelete={false}
+        components={{
+          ...defaultComponents,
+          TextModeEditor: CustomTextModeEditor,
+        }}
+        onChange={onChange}
+      />
+    );
+
+    fireEvent.change(getByDataTest(container, 'CustomTextModeEditorInput'), {
+      target: { value: '(MOCK_NUMBER != 8)' },
+    });
+
+    await waitFor(() =>
+      expect(onChange).toHaveBeenLastCalledWith([
+        {
+          type: 'GROUP',
+          value: 'AND',
+          isNegated: false,
+          children: [
+            {
+              field: 'MOCK_NUMBER',
+              value: 8,
+              operator: 'NOT_EQUAL',
+            },
+          ],
+        },
+      ])
+    );
+
+    expect(queryByDataTest(container, 'CustomTextModeEditorError')).toBeNull();
   });
 
   it('Reports a missing quote near the broken string boundary instead of a later token', () => {
@@ -2784,5 +3047,202 @@ describe('#components/Builder', () => {
     });
 
     expect(onChange).not.toHaveBeenCalled();
+  });
+
+  it('Hides root-group delete when removing the group would remove a protected descendant', () => {
+    const { container } = render(
+      <Builder
+        fields={fields}
+        data={[
+          {
+            type: 'GROUP',
+            value: 'AND',
+            isNegated: false,
+            children: [
+              {
+                field: 'MOCK_FIELD',
+                value: 'alpha',
+                operator: 'EQUAL',
+                readOnly: {
+                  enabled: true,
+                  targets: ['field'],
+                },
+              },
+              {
+                field: 'MOCK_NUMBER',
+                value: 5,
+                operator: 'NOT_EQUAL',
+              },
+            ],
+          },
+        ]}
+        singleRootGroup={false}
+        onChange={jest.fn()}
+      />
+    );
+
+    expect(queryByDataTest(container, 'Remove')).toBeNull();
+  });
+
+  it('shows only the editable rule delete button when a sibling rule is read-only-protected', () => {
+    render(
+      <Builder
+        fields={fields}
+        data={[
+          {
+            type: 'GROUP',
+            value: 'AND',
+            isNegated: false,
+            children: [
+              {
+                field: 'MOCK_FIELD',
+                value: 'alpha',
+                operator: 'EQUAL',
+                readOnly: {
+                  enabled: true,
+                  targets: ['field', 'operator'],
+                },
+              },
+              {
+                field: 'MOCK_NUMBER',
+                value: 5,
+                operator: 'NOT_EQUAL',
+              },
+            ],
+          },
+        ]}
+        singleRootGroup={false}
+        onChange={jest.fn()}
+      />
+    );
+
+    expect(screen.getAllByRole('button', { name: /delete/i })).toHaveLength(1);
+  });
+
+  it('hides nested group delete when removing the group would remove a protected direct child rule', () => {
+    render(
+      <Builder
+        fields={fields}
+        data={[
+          {
+            type: 'GROUP',
+            value: 'AND',
+            isNegated: false,
+            children: [
+              {
+                type: 'GROUP',
+                value: 'OR',
+                isNegated: false,
+                children: [
+                  {
+                    field: 'MOCK_FIELD',
+                    value: 'alpha',
+                    operator: 'EQUAL',
+                    readOnly: {
+                      enabled: true,
+                      targets: ['field', 'operator'],
+                    },
+                  },
+                  {
+                    field: 'MOCK_NUMBER',
+                    value: 5,
+                    operator: 'NOT_EQUAL',
+                  },
+                ],
+              },
+            ],
+          },
+        ]}
+        onChange={jest.fn()}
+      />
+    );
+
+    expect(screen.getAllByRole('button', { name: /delete/i })).toHaveLength(1);
+  });
+
+  it('keeps only editable nested rule deletes visible when both outer and nested groups contain protected rules', () => {
+    render(
+      <Builder
+        fields={fields}
+        data={[
+          {
+            type: 'GROUP',
+            value: 'AND',
+            isNegated: false,
+            children: [
+              {
+                field: 'MOCK_FIELD',
+                value: 'root-protected',
+                operator: 'EQUAL',
+                readOnly: {
+                  enabled: true,
+                  targets: ['field', 'operator'],
+                },
+              },
+              {
+                type: 'GROUP',
+                value: 'OR',
+                isNegated: false,
+                children: [
+                  {
+                    field: 'MOCK_FIELD',
+                    value: 'nested-protected',
+                    operator: 'EQUAL',
+                    readOnly: {
+                      enabled: true,
+                      targets: ['field', 'operator'],
+                    },
+                  },
+                  {
+                    field: 'MOCK_NUMBER',
+                    value: 5,
+                    operator: 'NOT_EQUAL',
+                  },
+                ],
+              },
+            ],
+          },
+        ]}
+        onChange={jest.fn()}
+      />
+    );
+
+    expect(screen.getAllByRole('button', { name: /delete/i })).toHaveLength(1);
+  });
+
+  it('Allows disabling read-only delete protection on Builder', () => {
+    const { container } = render(
+      <Builder
+        fields={fields}
+        data={[
+          {
+            type: 'GROUP',
+            value: 'AND',
+            isNegated: false,
+            children: [
+              {
+                field: 'MOCK_FIELD',
+                value: 'alpha',
+                operator: 'EQUAL',
+                readOnly: {
+                  enabled: true,
+                  targets: ['field'],
+                },
+              },
+              {
+                field: 'MOCK_NUMBER',
+                value: 5,
+                operator: 'NOT_EQUAL',
+              },
+            ],
+          },
+        ]}
+        singleRootGroup={false}
+        readOnlyProtectsDelete={false}
+        onChange={jest.fn()}
+      />
+    );
+
+    expect(queryByDataTest(container, 'Remove')).not.toBeNull();
   });
 });

--- a/src/builder/builder.tsx
+++ b/src/builder/builder.tsx
@@ -50,6 +50,7 @@ import { parseBuilderSqlText } from './text-mode/utils/parse-builder-sql-text';
 import { reapplyBuilderTextModeLocks } from './text-mode/utils/reapply-builder-text-mode-locks';
 import { resolveBuilderTextModeConfig } from './text-mode/utils/resolve-builder-text-mode-config';
 import { findReadOnlyNegationDiagnostic } from './text-mode/utils/find-read-only-negation-diagnostic.util';
+import { findReadOnlyTargetDiagnostic } from './text-mode/utils/find-read-only-target-diagnostic.util';
 import {
   IBuilderRef,
   IBuilderProps,
@@ -65,6 +66,7 @@ export const Builder = forwardRef<IBuilderRef, IBuilderProps>(({
   components = defaultComponents,
   strings = defaultStrings,
   readOnly = false,
+  readOnlyProtectsDelete = true,
   lockable = false,
   cloneable = false,
   draggable = false,
@@ -113,7 +115,13 @@ export const Builder = forwardRef<IBuilderRef, IBuilderProps>(({
   });
   const [textProtectedRanges, setTextProtectedRanges] = useState<
     ReturnType<typeof formatBuilderSqlState>['protectedRanges']
-  >(() => (initialTextModeEnabled ? formatBuilderSqlState(initialData, fields).protectedRanges : []));
+  >(() =>
+    initialTextModeEnabled
+      ? formatBuilderSqlState(initialData, fields, {
+          protectGroupDeletionBoundaries: readOnlyProtectsDelete,
+        }).protectedRanges
+      : []
+  );
   const [textErrorMessage, setTextErrorMessage] = useState<string | null>(null);
   const [textDiagnostics, setTextDiagnostics] = useState<
     ReturnType<typeof parseBuilderSqlText>['diagnostics']
@@ -224,7 +232,7 @@ export const Builder = forwardRef<IBuilderRef, IBuilderProps>(({
         );
       },
       deleteNode: (nodeId) =>
-        isNodeDeletionProtected(data, nodeId)
+        readOnlyProtectsDelete && isNodeDeletionProtected(data, nodeId)
           ? false
           : commitData(createRemoveSubtreeAction(nodeId)),
       replaceNode: (nodeId, node) =>
@@ -416,7 +424,10 @@ export const Builder = forwardRef<IBuilderRef, IBuilderProps>(({
 
     const nextTextState = formatBuilderSqlState(
       normalizeBuilderTextModeQuery(emitQuery(data)),
-      fields
+      fields,
+      {
+        protectGroupDeletionBoundaries: readOnlyProtectsDelete,
+      }
     );
 
     setTextValue(nextTextState.value);
@@ -464,7 +475,10 @@ export const Builder = forwardRef<IBuilderRef, IBuilderProps>(({
   const handleSwitchToTextMode = useCallback(() => {
     const nextTextState = formatBuilderSqlState(
       normalizeBuilderTextModeQuery(emitQuery(data)),
-      fields
+      fields,
+      {
+        protectGroupDeletionBoundaries: readOnlyProtectsDelete,
+      }
     );
 
     setTextValue(nextTextState.value);
@@ -479,18 +493,33 @@ export const Builder = forwardRef<IBuilderRef, IBuilderProps>(({
       setTextValue(nextText);
 
       const parseResult = parseBuilderSqlText(nextText, fields, strings);
-      const readOnlyNegationDiagnostic =
+      const currentQuery = emitQuery(data);
+      const readOnlyTargetDiagnostic =
         parseResult.data && parseResult.diagnostics.length === 0
-          ? findReadOnlyNegationDiagnostic(emitQuery(data), parseResult.data)
+          ? findReadOnlyTargetDiagnostic(currentQuery, parseResult.data, {
+              allowProtectedClauseRemoval: !readOnlyProtectsDelete,
+            })
+          : null;
+      const readOnlyNegationDiagnostic =
+        parseResult.data &&
+        parseResult.diagnostics.length === 0 &&
+        !readOnlyTargetDiagnostic
+          ? findReadOnlyNegationDiagnostic(currentQuery, parseResult.data)
           : null;
 
       if (
         !parseResult.data ||
         parseResult.diagnostics.length > 0 ||
+        readOnlyTargetDiagnostic ||
         readOnlyNegationDiagnostic
       ) {
-        const diagnostics = readOnlyNegationDiagnostic
-          ? [...parseResult.diagnostics, readOnlyNegationDiagnostic]
+        const diagnostics =
+          readOnlyTargetDiagnostic || readOnlyNegationDiagnostic
+            ? [
+                ...parseResult.diagnostics,
+                ...(readOnlyTargetDiagnostic ? [readOnlyTargetDiagnostic] : []),
+                ...(readOnlyNegationDiagnostic ? [readOnlyNegationDiagnostic] : []),
+              ]
           : parseResult.diagnostics;
 
         setTextDiagnostics(diagnostics);
@@ -501,6 +530,20 @@ export const Builder = forwardRef<IBuilderRef, IBuilderProps>(({
               }: ${diagnostics[0].message}`
             : null
         );
+
+        if (readOnlyTargetDiagnostic) {
+          setTextValue(textValue);
+          setTextProtectedRanges((currentProtectedRanges) => [
+            ...currentProtectedRanges,
+          ]);
+        }
+
+        if (readOnlyNegationDiagnostic) {
+          setTextProtectedRanges((currentProtectedRanges) => [
+            ...currentProtectedRanges,
+          ]);
+        }
+
         return;
       }
 
@@ -511,9 +554,9 @@ export const Builder = forwardRef<IBuilderRef, IBuilderProps>(({
         return;
       }
 
-      const currentQuery = normalizeBuilderTextModeQuery(emitQuery(data));
-      const nextQuery = hasBuilderTextModeLocks(currentQuery)
-        ? reapplyBuilderTextModeLocks(currentQuery, parseResult.data)
+      const normalizedCurrentQuery = normalizeBuilderTextModeQuery(currentQuery);
+      const nextQuery = hasBuilderTextModeLocks(normalizedCurrentQuery)
+        ? reapplyBuilderTextModeLocks(normalizedCurrentQuery, parseResult.data)
         : parseResult.data;
       const nextData = ingestQuery(
         normalizeBuilderTextModeQuery(nextQuery),
@@ -522,7 +565,15 @@ export const Builder = forwardRef<IBuilderRef, IBuilderProps>(({
       );
       commitData(createReplaceQueryAction(nextData));
     },
-    [commitData, data, rootGroupType, singleRootGroup, strings.textMode]
+    [
+      commitData,
+      data,
+      readOnlyProtectsDelete,
+      rootGroupType,
+      singleRootGroup,
+      strings.textMode,
+      textValue,
+    ]
   );
 
   const builderContent = (
@@ -547,6 +598,7 @@ export const Builder = forwardRef<IBuilderRef, IBuilderProps>(({
           errorMessage={textErrorMessage}
           TextModeInputComponent={TextModeInputComponent}
           readOnly={readOnly}
+          allowProtectedRangeDeletion={!readOnlyProtectsDelete}
           onChange={handleTextChange}
         />
       ) : (
@@ -557,6 +609,7 @@ export const Builder = forwardRef<IBuilderRef, IBuilderProps>(({
           protectedRangeHoverMessage={strings.textMode?.lockedRangesHover || null}
           errorMessage={textErrorMessage}
           readOnly={readOnly}
+          allowProtectedRangeDeletion={!readOnlyProtectsDelete}
           onChange={handleTextChange}
         />
       )
@@ -570,6 +623,7 @@ export const Builder = forwardRef<IBuilderRef, IBuilderProps>(({
       components={components}
       strings={strings}
       readOnly={readOnly}
+      readOnlyProtectsDelete={readOnlyProtectsDelete}
       lockable={lockable}
       cloneable={cloneable}
       draggable={draggable}

--- a/src/builder/builder.tsx
+++ b/src/builder/builder.tsx
@@ -49,6 +49,7 @@ import { normalizeBuilderTextModeQuery } from './text-mode/utils/normalize-build
 import { parseBuilderSqlText } from './text-mode/utils/parse-builder-sql-text';
 import { reapplyBuilderTextModeLocks } from './text-mode/utils/reapply-builder-text-mode-locks';
 import { resolveBuilderTextModeConfig } from './text-mode/utils/resolve-builder-text-mode-config';
+import { findReadOnlyNegationDiagnostic } from './text-mode/utils/find-read-only-negation-diagnostic.util';
 import {
   IBuilderRef,
   IBuilderProps,
@@ -56,6 +57,7 @@ import {
 } from './types';
 import { createDefaultNodeIndex } from '../hooks/use-builder-ref/utils/create-default-node-index.util';
 import { resolveLockedNode } from '../hooks/use-builder-ref/utils/resolve-locked-node.util';
+import { isNodeDeletionProtected } from '../utils/is-node-deletion-protected.util';
 
 export const Builder = forwardRef<IBuilderRef, IBuilderProps>(({
   data: originalData = [],
@@ -221,7 +223,10 @@ export const Builder = forwardRef<IBuilderRef, IBuilderProps>(({
           )
         );
       },
-      deleteNode: (nodeId) => commitData(createRemoveSubtreeAction(nodeId)),
+      deleteNode: (nodeId) =>
+        isNodeDeletionProtected(data, nodeId)
+          ? false
+          : commitData(createRemoveSubtreeAction(nodeId)),
       replaceNode: (nodeId, node) =>
         commitData(createReplaceNodeAction(nodeId, clone(node))),
       updateNode: (nodeId, updater) => {
@@ -474,14 +479,26 @@ export const Builder = forwardRef<IBuilderRef, IBuilderProps>(({
       setTextValue(nextText);
 
       const parseResult = parseBuilderSqlText(nextText, fields, strings);
+      const readOnlyNegationDiagnostic =
+        parseResult.data && parseResult.diagnostics.length === 0
+          ? findReadOnlyNegationDiagnostic(emitQuery(data), parseResult.data)
+          : null;
 
-      if (!parseResult.data || parseResult.diagnostics.length > 0) {
-        setTextDiagnostics(parseResult.diagnostics);
+      if (
+        !parseResult.data ||
+        parseResult.diagnostics.length > 0 ||
+        readOnlyNegationDiagnostic
+      ) {
+        const diagnostics = readOnlyNegationDiagnostic
+          ? [...parseResult.diagnostics, readOnlyNegationDiagnostic]
+          : parseResult.diagnostics;
+
+        setTextDiagnostics(diagnostics);
         setTextErrorMessage(
-          parseResult.diagnostics[0]
+          diagnostics[0]
             ? `${
                 strings.textMode?.syntaxError || 'Syntax error'
-              }: ${parseResult.diagnostics[0].message}`
+              }: ${diagnostics[0].message}`
             : null
         );
         return;

--- a/src/builder/text-mode/utils/create-rule-read-only-protected-ranges.util.ts
+++ b/src/builder/text-mode/utils/create-rule-read-only-protected-ranges.util.ts
@@ -1,0 +1,100 @@
+import { IBuilderFieldProps } from '../../types';
+import { tryParseSql } from '../../../query-formats/sql/try-parse-sql';
+import { IDenormalizedRuleNode } from '../../../utils/query-tree';
+import {
+  getRuleReadOnlyTargets,
+  isRuleFullyReadOnly,
+} from '../../../utils/resolve-rule-read-only.util';
+import { formatSql } from '../../../query-formats/sql/format-sql';
+import { IParsedSqlRuleNode } from '../../../query-formats/sql/types/parsed-sql-rule-node';
+
+export interface ILocalProtectedRange {
+  start: number;
+  end: number;
+}
+
+export const createRuleReadOnlyProtectedRanges = (
+  rule: IDenormalizedRuleNode,
+  fields: IBuilderFieldProps[]
+): { text: string; protectedRanges: ILocalProtectedRange[] } => {
+  const text = formatSql([rule], { fields });
+
+  if (!text) {
+    return {
+      text,
+      protectedRanges: [],
+    };
+  }
+
+  if (isRuleFullyReadOnly(rule.readOnly)) {
+    return {
+      text,
+      protectedRanges: [
+        {
+          start: 0,
+          end: text.length,
+        },
+      ],
+    };
+  }
+
+  const targets = getRuleReadOnlyTargets(rule.readOnly);
+
+  if (targets.length === 0) {
+    return {
+      text,
+      protectedRanges: [],
+    };
+  }
+
+  const parseResult = tryParseSql(text);
+  const parsedRule = parseResult.parsedNodes?.[0];
+
+  if (!parsedRule || 'kind' in parsedRule) {
+    return {
+      text,
+      protectedRanges: [],
+    };
+  }
+
+  const parsedSqlRule = parsedRule as IParsedSqlRuleNode;
+
+  const protectedRanges: ILocalProtectedRange[] = [];
+
+  if (targets.includes('field')) {
+    protectedRanges.push({
+      start: parsedSqlRule.source.field.start,
+      end: parsedSqlRule.source.field.end,
+    });
+  }
+
+  if (targets.includes('operator') && parsedSqlRule.source.operator) {
+    protectedRanges.push({
+      start: parsedSqlRule.source.operator.start,
+      end: parsedSqlRule.source.operator.end,
+    });
+  }
+
+  if (targets.includes('value')) {
+    if (parsedSqlRule.source.value) {
+      protectedRanges.push({
+        start: parsedSqlRule.source.value.start,
+        end: parsedSqlRule.source.value.end,
+      });
+    }
+
+    if (parsedSqlRule.source.values?.length) {
+      protectedRanges.push(
+        ...parsedSqlRule.source.values.map((valueRange) => ({
+          start: valueRange.start,
+          end: valueRange.end,
+        }))
+      );
+    }
+  }
+
+  return {
+    text,
+    protectedRanges,
+  };
+};

--- a/src/builder/text-mode/utils/find-read-only-negation-diagnostic.util.ts
+++ b/src/builder/text-mode/utils/find-read-only-negation-diagnostic.util.ts
@@ -1,0 +1,123 @@
+import { ITextModeDiagnostic } from '../types/text-mode-diagnostic';
+import {
+  DenormalizedGroupNode,
+  DenormalizedNode,
+  DenormalizedQuery,
+} from '../../../utils/query-tree';
+import {
+  createInheritedReadOnlyState,
+  IInheritedReadOnlyState,
+  resolveEffectiveGroupReadOnly,
+} from '../../../utils/resolve-effective-read-only.util';
+
+interface IReadOnlyNegationDescriptor {
+  fingerprint: string;
+  isNegated: boolean;
+}
+
+const createGroupFingerprintWithoutNegation = (
+  group: DenormalizedGroupNode
+): string =>
+  JSON.stringify({
+    type: 'GROUP',
+    value: group.value,
+    children: group.children.map(createNodeFingerprintWithoutNegation),
+  });
+
+const createNodeFingerprintWithoutNegation = (
+  node: DenormalizedNode
+): string => {
+  if ('type' in node && node.type === 'GROUP') {
+    return createGroupFingerprintWithoutNegation(node);
+  }
+
+  return JSON.stringify({
+    field: 'field' in node ? node.field : '',
+  });
+};
+
+const collectReadOnlyNegationDescriptors = (
+  query: DenormalizedQuery,
+  inheritedReadOnly: IInheritedReadOnlyState = createInheritedReadOnlyState(),
+  target: IReadOnlyNegationDescriptor[] = []
+): IReadOnlyNegationDescriptor[] => {
+  query.forEach((node) => {
+    if (!('type' in node) || node.type !== 'GROUP') {
+      return;
+    }
+
+    const resolvedReadOnly = resolveEffectiveGroupReadOnly(
+      node.readOnly,
+      inheritedReadOnly
+    );
+
+    if (resolvedReadOnly.targets.includes('negation')) {
+      target.push({
+        fingerprint: createGroupFingerprintWithoutNegation(node),
+        isNegated: Boolean(node.isNegated),
+      });
+    }
+
+    collectReadOnlyNegationDescriptors(
+      node.children,
+      resolvedReadOnly.inherited,
+      target
+    );
+  });
+
+  return target;
+};
+
+const collectCandidateGroups = (
+  query: DenormalizedQuery,
+  target: Array<DenormalizedGroupNode> = []
+): DenormalizedGroupNode[] => {
+  query.forEach((node) => {
+    if (!('type' in node) || node.type !== 'GROUP') {
+      return;
+    }
+
+    target.push(node);
+    collectCandidateGroups(node.children, target);
+  });
+
+  return target;
+};
+
+export const findReadOnlyNegationDiagnostic = (
+  previousQuery: DenormalizedQuery,
+  nextQuery: DenormalizedQuery
+): ITextModeDiagnostic | null => {
+  const descriptors = collectReadOnlyNegationDescriptors(previousQuery);
+
+  if (descriptors.length === 0) {
+    return null;
+  }
+
+  const candidates = collectCandidateGroups(nextQuery);
+
+  const hasViolation = descriptors.some((descriptor) => {
+    const matchingCandidate = candidates.find(
+      (candidate) =>
+        createGroupFingerprintWithoutNegation(candidate) === descriptor.fingerprint
+    );
+
+    if (!matchingCandidate) {
+      return true;
+    }
+
+    return Boolean(matchingCandidate.isNegated) !== descriptor.isNegated;
+  });
+
+  if (!hasViolation) {
+    return null;
+  }
+
+  return {
+    code: 'readonly_negation',
+    message:
+      'Negation is read-only for one or more clauses and cannot be changed in text mode.',
+    start: 0,
+    end: 0,
+  };
+};

--- a/src/builder/text-mode/utils/format-builder-sql-state.ts
+++ b/src/builder/text-mode/utils/format-builder-sql-state.ts
@@ -6,15 +6,17 @@ import {
   IDenormalizedRuleNode,
   QueryGroupValue,
 } from '../../../utils/query-tree';
-import { resolveGroupReadOnly } from '../../../utils/resolve-group-read-only.util';
+import {
+  getGroupReadOnlyTargets,
+  isGroupFullyReadOnly,
+  resolveGroupReadOnly,
+} from '../../../utils/resolve-group-read-only.util';
 import { isGroupNode } from '../../../query-formats/sql/shared';
-import { formatSql } from '../../../query-formats/sql/format-sql';
 import { IBuilderTextModeSqlState } from '../types/builder-text-mode-sql-state';
-
-interface ILocalProtectedRange {
-  start: number;
-  end: number;
-}
+import {
+  createRuleReadOnlyProtectedRanges,
+  ILocalProtectedRange,
+} from './create-rule-read-only-protected-ranges.util';
 
 interface IFragmentResult {
   text: string;
@@ -33,21 +35,7 @@ const shiftRanges = (
 const formatRuleFragment = (
   rule: IDenormalizedRuleNode,
   fields: IBuilderFieldProps[]
-): IFragmentResult => {
-  const text = formatSql([rule], { fields });
-
-  return {
-    text,
-    protectedRanges: rule.readOnly
-      ? [
-          {
-            start: 0,
-            end: text.length,
-          },
-        ]
-      : [],
-  };
-};
+): IFragmentResult => createRuleReadOnlyProtectedRanges(rule, fields);
 
 const formatGroupFragment = (
   group: DenormalizedGroupNode,
@@ -60,6 +48,7 @@ const formatGroupFragment = (
     .map(child => formatNodeFragment(child, fields, false))
     .filter(fragment => fragment.text.trim().length > 0);
   const groupReadOnly = resolveGroupReadOnly(group.readOnly);
+  const groupReadOnlyTargets = getGroupReadOnlyTargets(group.readOnly);
 
   if (childFragments.length === 0) {
     return {
@@ -104,28 +93,21 @@ const formatGroupFragment = (
   let text = wrappedInner;
   let protectedRanges = shiftRanges(innerRanges, wrappingOffset);
 
-  if (groupReadOnly.enabled && !groupReadOnly.inheritToChildren) {
-    protectedRanges.push(
-      ...shiftRanges(combinatorRanges, wrappingOffset)
-    );
-
-    if (wrappedInner.length >= 2) {
-      protectedRanges.push({
-        start: 0,
-        end: 1,
-      });
-      protectedRanges.push({
-        start: wrappedInner.length - 1,
-        end: wrappedInner.length,
-      });
-    }
+  if (
+    groupReadOnlyTargets.includes('combinator') &&
+    !groupReadOnly.inheritToChildren
+  ) {
+    protectedRanges.push(...shiftRanges(combinatorRanges, wrappingOffset));
   }
 
   if ('isNegated' in group && group.isNegated) {
     text = `NOT ${wrappedInner}`;
     protectedRanges = shiftRanges(protectedRanges, 4);
 
-    if (groupReadOnly.enabled && !groupReadOnly.inheritToChildren) {
+    if (
+      groupReadOnlyTargets.includes('negation') &&
+      !groupReadOnly.inheritToChildren
+    ) {
       protectedRanges.push({
         start: 0,
         end: 4,
@@ -133,7 +115,7 @@ const formatGroupFragment = (
     }
   }
 
-  if (groupReadOnly.enabled && groupReadOnly.inheritToChildren) {
+  if (groupReadOnly.inheritToChildren && isGroupFullyReadOnly(group.readOnly)) {
     protectedRanges = [
       {
         start: 0,

--- a/src/builder/text-mode/utils/reapply-builder-text-mode-locks.ts
+++ b/src/builder/text-mode/utils/reapply-builder-text-mode-locks.ts
@@ -2,14 +2,22 @@ import {
   DenormalizedGroupNode,
   DenormalizedNode,
   DenormalizedQuery,
+  GroupReadOnlyTarget,
+  IDenormalizedRuleNode,
+  RuleReadOnlyTarget,
 } from '../../../utils/query-tree';
 import { clone } from '../../../utils/clone.util';
 import { QueryOperator } from '../../../utils/query-operators';
 import { resolveGroupReadOnly } from '../../../utils/resolve-group-read-only.util';
+import {
+  getRuleReadOnlyTargets,
+  isRuleFullyReadOnly,
+} from '../../../utils/resolve-rule-read-only.util';
 
 interface ILockedNodeDescriptor {
   kind: 'rule' | 'group-all' | 'group-self';
   fingerprint: string;
+  relaxedFingerprint?: string;
   readOnly: DenormalizedNode['readOnly'];
 }
 
@@ -65,6 +73,47 @@ const createGroupShellFingerprint = (group: DenormalizedGroupNode): string =>
     childCount: group.children.length,
   });
 
+const createRuleReadOnlyFingerprint = (
+  node: DenormalizedNode,
+  targets: RuleReadOnlyTarget[]
+): string =>
+  JSON.stringify({
+    field: 'field' in node && targets.includes('field') ? node.field : undefined,
+    operator:
+      'operator' in node && targets.includes('operator')
+        ? normalizeLockFingerprintOperator(node.operator)
+        : undefined,
+    value: 'value' in node && targets.includes('value') ? node.value : undefined,
+  });
+
+const createGroupReadOnlyFingerprint = (
+  group: DenormalizedGroupNode,
+  targets: GroupReadOnlyTarget[]
+): string =>
+  JSON.stringify({
+    type: 'GROUP',
+    value: targets.includes('combinator') ? group.value : undefined,
+    isNegated: targets.includes('negation') ? group.isNegated : undefined,
+  });
+
+const getRuleCandidateRelaxedFingerprint = (
+  node: DenormalizedNode,
+  readOnly: DenormalizedNode['readOnly']
+): string =>
+  createRuleReadOnlyFingerprint(
+    node,
+    getRuleReadOnlyTargets(readOnly as never)
+  );
+
+const getGroupCandidateRelaxedFingerprint = (
+  node: DenormalizedGroupNode,
+  readOnly: DenormalizedNode['readOnly']
+): string =>
+  createGroupReadOnlyFingerprint(
+    node,
+    resolveGroupReadOnly(readOnly as never).targets || []
+  );
+
 const collectLockedNodeDescriptors = (
   query: DenormalizedQuery,
   target: ILockedNodeDescriptor[] = []
@@ -74,11 +123,18 @@ const collectLockedNodeDescriptors = (
       const groupReadOnly = resolveGroupReadOnly(node.readOnly);
 
       if (groupReadOnly.enabled) {
+        const isFullGroupLock =
+          !groupReadOnly.targets || groupReadOnly.targets.length === 0;
+
         target.push({
           kind: groupReadOnly.inheritToChildren ? 'group-all' : 'group-self',
           fingerprint: groupReadOnly.inheritToChildren
             ? createExactFingerprint(node)
             : createGroupShellFingerprint(node),
+          relaxedFingerprint:
+            groupReadOnly.inheritToChildren || isFullGroupLock || !groupReadOnly.targets
+              ? undefined
+              : createGroupReadOnlyFingerprint(node, groupReadOnly.targets),
           readOnly: node.readOnly,
         });
       }
@@ -88,10 +144,17 @@ const collectLockedNodeDescriptors = (
     }
 
     if (node.readOnly) {
+      const ruleNode = node as IDenormalizedRuleNode;
+      const ruleReadOnlyTargets = getRuleReadOnlyTargets(ruleNode.readOnly);
+
       target.push({
         kind: 'rule',
-        fingerprint: createExactFingerprint(node),
-        readOnly: node.readOnly,
+        fingerprint: createExactFingerprint(ruleNode),
+        relaxedFingerprint:
+          isRuleFullyReadOnly(ruleNode.readOnly) || ruleReadOnlyTargets.length === 0
+            ? undefined
+            : createRuleReadOnlyFingerprint(ruleNode, ruleReadOnlyTargets),
+        readOnly: ruleNode.readOnly,
       });
     }
   });
@@ -134,12 +197,7 @@ const applyReadOnlyValue = (
   node: DenormalizedNode,
   readOnly: DenormalizedNode['readOnly']
 ): void => {
-  if ('type' in node && node.type === 'GROUP') {
-    node.readOnly = readOnly;
-    return;
-  }
-
-  node.readOnly = Boolean(readOnly);
+  node.readOnly = readOnly as never;
 };
 
 export const reapplyBuilderTextModeLocks = (
@@ -157,10 +215,33 @@ export const reapplyBuilderTextModeLocks = (
   const usedCandidates = new WeakSet<DenormalizedNode>();
 
   lockedNodes.forEach(descriptor => {
-    const candidate = candidates[descriptor.kind].find(
-      entry =>
-        entry.fingerprint === descriptor.fingerprint && !usedCandidates.has(entry.node)
-    );
+    const candidatePool = candidates[descriptor.kind];
+    const candidate =
+      candidatePool.find(
+        entry =>
+          entry.fingerprint === descriptor.fingerprint &&
+          !usedCandidates.has(entry.node)
+      ) ??
+      (descriptor.relaxedFingerprint
+        ? candidatePool.find(entry => {
+            if (usedCandidates.has(entry.node)) {
+              return false;
+            }
+
+            const relaxedFingerprint =
+              descriptor.kind === 'rule'
+                ? getRuleCandidateRelaxedFingerprint(
+                    entry.node,
+                    descriptor.readOnly
+                  )
+                : getGroupCandidateRelaxedFingerprint(
+                    entry.node as DenormalizedGroupNode,
+                    descriptor.readOnly
+                  );
+
+            return relaxedFingerprint === descriptor.relaxedFingerprint;
+          })
+        : undefined);
 
     if (!candidate) {
       return;

--- a/src/builder/types/index.ts
+++ b/src/builder/types/index.ts
@@ -25,8 +25,10 @@ import { ITextModeInputProps } from '../text-mode/types/text-mode-input-props';
 import { ITextModeToggleContentProps } from '../components/text-mode-toggle-content';
 import {
   DenormalizedQuery,
+  GroupReadOnlyTarget,
   QueryGroupValue,
   QueryOperator,
+  RuleReadOnlyTarget,
 } from '../../utils/query-tree';
 
 export type BuilderGroupMode = 'with-modifiers' | 'without-modifiers' | 'both';
@@ -46,6 +48,7 @@ export type BuilderFieldType =
 export type BuilderFieldOperator = QueryOperator;
 export type BuilderGroupValues = QueryGroupValue;
 export type { BuilderLockState };
+export type { GroupReadOnlyTarget, RuleReadOnlyTarget };
 export type { IAlertProps, AlertSeverity, AlertVariant } from '../../alert';
 export type { IBuilderTextModeConfig } from '../text-mode/types/builder-text-mode-config';
 export type { ITextModeEditorProps } from '../text-mode/types/text-mode-editor-props';

--- a/src/builder/types/index.ts
+++ b/src/builder/types/index.ts
@@ -377,6 +377,7 @@ export interface IBuilderProps {
   textMode?: boolean | IBuilderTextModeConfig;
   defaultMode?: BuilderDefaultMode;
   readOnly?: boolean;
+  readOnlyProtectsDelete?: boolean;
   lockable?: boolean;
   cloneable?: boolean;
   draggable?: boolean;

--- a/src/group/group.test.tsx
+++ b/src/group/group.test.tsx
@@ -152,6 +152,61 @@ describe('#components/Group', () => {
     expect(queryByDataTest(container, 'Remove')).toBeNull();
   });
 
+  it('hides the delete control when the group contains a protected descendant', () => {
+    const protectedData: any = [
+      {
+        type: 'GROUP',
+        value: 'AND',
+        id: 'test-1',
+        isNegated: false,
+        children: ['test-2'],
+      },
+      {
+        type: 'GROUP',
+        value: 'AND',
+        id: 'test-2',
+        isNegated: false,
+        parent: 'test-1',
+        children: ['test-3'],
+      },
+      {
+        field: 'MOCK_FIELD',
+        value: 'alpha',
+        operator: 'EQUAL',
+        id: 'test-3',
+        parent: 'test-2',
+        readOnly: { enabled: true, targets: ['field'] },
+      },
+    ];
+    const { container } = renderWithContext(
+      <Group id="test-2" isRoot={false} value="AND" isNegated={false} />,
+      { data: protectedData }
+    );
+
+    expect(queryByDataTest(container, 'Remove')).toBeNull();
+  });
+
+  it('keeps targeted group controls visible but blocks their actions', () => {
+    const dispatchAction = jest.fn();
+    const { container, getByText } = renderWithContext(
+      <Group
+        id="test-2"
+        isRoot={false}
+        value="AND"
+        isNegated={false}
+        readOnlyTargets={['negation', 'combinator']}
+      />,
+      { dispatchAction }
+    );
+
+    fireEvent.click(getByText(strings.group?.not || 'NOT'));
+    fireEvent.click(getByText(strings.group?.and || 'AND'));
+    fireEvent.click(getByText(strings.group?.or || 'OR'));
+
+    expect(queryByDataTest(container, 'AddRule')).not.toBeNull();
+    expect(dispatchAction).not.toHaveBeenCalled();
+  });
+
   it('renders nothing when strings are unavailable', () => {
     const { container } = renderWithContext(<Group id="test-1" isRoot />, {
       strings: {},

--- a/src/group/group.tsx
+++ b/src/group/group.tsx
@@ -17,10 +17,16 @@ import { createId } from '../utils/create-id.util';
 import { getCloneButtonTitle } from '../utils/get-clone-button-title.util';
 import { getLockToggleTitle } from '../utils/get-lock-toggle-title.util';
 import { isNormalizedGroupNode } from '../utils/is-normalized-group-node.util';
-import { INormalizedRuleNode, NormalizedNode } from '../utils/query-tree';
+import {
+  GroupReadOnlyTarget,
+  INormalizedRuleNode,
+  NormalizedNode,
+} from '../utils/query-tree';
 import { createDefaultNodeIndex } from '../hooks/use-builder-ref/utils/create-default-node-index.util';
 import { Group as DefaultGroupContainer } from './group-container';
 import { Option as DefaultOption } from './option';
+import { isNodeDeletionProtected } from '../utils/is-node-deletion-protected.util';
+import { updateGroupLockState } from '../utils/read-only/update-group-lock-state.util';
 
 export interface IGroupProps {
   value?: BuilderGroupValues;
@@ -31,6 +37,7 @@ export interface IGroupProps {
   id: string;
   isRoot: boolean;
   readOnly?: boolean;
+  readOnlyTargets?: GroupReadOnlyTarget[];
   lockState?: BuilderLockState;
   lockDisabled?: boolean;
 }
@@ -44,6 +51,7 @@ export const Group: FC<IGroupProps> = ({
   id,
   isRoot,
   readOnly: localReadOnly = false,
+  readOnlyTargets = [],
   lockState = localReadOnly ? 'self' : 'unlocked',
   lockDisabled = false,
 }) => {
@@ -69,8 +77,16 @@ export const Group: FC<IGroupProps> = ({
   const PopoverItem = components.PopoverItem || DefaultPopoverItem;
   const Remove = components.Remove || SecondaryButton;
   const resolvedGroupTypes = groupTypes || 'with-modifiers';
-  const canDeleteGroup = !(singleRootGroup && isRoot) && !isReadOnly;
+  const canDeleteGroup =
+    !(singleRootGroup && isRoot) &&
+    !isReadOnly &&
+    readOnlyTargets.length === 0 &&
+    !isNodeDeletionProtected(data, id);
   const canCloneGroup = !(singleRootGroup && isRoot) && !isReadOnly;
+  const isNegationReadOnly =
+    isReadOnly || readOnlyTargets.includes('negation');
+  const isCombinatorReadOnly =
+    isReadOnly || readOnlyTargets.includes('combinator');
 
   const addItem = (payload: NormalizedNode) => {
     const currentGroup = data.find((item) => item.id === id);
@@ -114,6 +130,7 @@ export const Group: FC<IGroupProps> = ({
       !dispatchAction ||
       !currentGroup ||
       !isNormalizedGroupNode(currentGroup) ||
+      isCombinatorReadOnly ||
       typeof currentGroup.value === 'undefined' ||
       typeof currentGroup.isNegated === 'undefined'
     ) {
@@ -135,6 +152,7 @@ export const Group: FC<IGroupProps> = ({
       !dispatchAction ||
       !currentGroup ||
       !isNormalizedGroupNode(currentGroup) ||
+      isNegationReadOnly ||
       typeof currentGroup.value === 'undefined' ||
       typeof currentGroup.isNegated === 'undefined'
     ) {
@@ -150,6 +168,10 @@ export const Group: FC<IGroupProps> = ({
   };
 
   const handleDeleteGroup = () => {
+    if (!canDeleteGroup) {
+      return;
+    }
+
     dispatchAction?.(createRemoveSubtreeAction(id));
   };
 
@@ -176,19 +198,13 @@ export const Group: FC<IGroupProps> = ({
       return;
     }
 
-    const nextGroup = {
-      ...currentGroup,
-    };
+    const nextGroup = { ...currentGroup };
+    const nextReadOnly = updateGroupLockState(currentGroup.readOnly, nextState);
 
-    if (nextState === 'all') {
-      nextGroup.readOnly = {
-        enabled: true,
-        inheritToChildren: true,
-      };
-    } else if (nextState === 'self') {
-      nextGroup.readOnly = true;
-    } else {
+    if (typeof nextReadOnly === 'undefined') {
       delete nextGroup.readOnly;
+    } else {
+      nextGroup.readOnly = nextReadOnly;
     }
 
     dispatchAction(createReplaceNodeAction(id, nextGroup));
@@ -263,7 +279,7 @@ export const Group: FC<IGroupProps> = ({
             <Option
               isSelected={Boolean(isNegated)}
               value={!isNegated}
-              disabled={isReadOnly}
+              disabled={isNegationReadOnly}
               onClick={handleToggleNegateGroup}
               data-test="Option[not]"
             >
@@ -272,7 +288,7 @@ export const Group: FC<IGroupProps> = ({
             <Option
               isSelected={value === 'AND'}
               value="AND"
-              disabled={isReadOnly}
+              disabled={isCombinatorReadOnly}
               onClick={handleChangeGroupType}
               data-test="Option[and]"
             >
@@ -281,7 +297,7 @@ export const Group: FC<IGroupProps> = ({
             <Option
               isSelected={value === 'OR'}
               value="OR"
-              disabled={isReadOnly}
+              disabled={isCombinatorReadOnly}
               onClick={handleChangeGroupType}
               data-test="Option[or]"
             >
@@ -300,7 +316,7 @@ export const Group: FC<IGroupProps> = ({
               {addGroupControl}
             </>
           )}
-          {!isReadOnly && canDeleteGroup ? (
+          {canDeleteGroup ? (
             <Remove onClick={handleDeleteGroup} data-test="Remove">
               {strings.group.delete}
             </Remove>

--- a/src/group/group.tsx
+++ b/src/group/group.tsx
@@ -61,6 +61,7 @@ export const Group: FC<IGroupProps> = ({
     dispatchAction,
     strings,
     readOnly,
+    readOnlyProtectsDelete = true,
     cloneable,
     lockable,
     groupTypes,
@@ -81,7 +82,7 @@ export const Group: FC<IGroupProps> = ({
     !(singleRootGroup && isRoot) &&
     !isReadOnly &&
     readOnlyTargets.length === 0 &&
-    !isNodeDeletionProtected(data, id);
+    (!readOnlyProtectsDelete || !isNodeDeletionProtected(data, id));
   const canCloneGroup = !(singleRootGroup && isRoot) && !isReadOnly;
   const isNegationReadOnly =
     isReadOnly || readOnlyTargets.includes('negation');

--- a/src/hooks/use-builder-ref/utils/resolve-locked-node.util.ts
+++ b/src/hooks/use-builder-ref/utils/resolve-locked-node.util.ts
@@ -1,5 +1,7 @@
 import { isNormalizedGroupNode } from '../../../utils/is-normalized-group-node.util';
 import { NormalizedNode } from '../../../utils/query-tree';
+import { updateGroupLockState } from '../../../utils/read-only/update-group-lock-state.util';
+import { updateRuleLockState } from '../../../utils/read-only/update-rule-lock-state.util';
 
 export const resolveLockedNode = (
   node: NormalizedNode,
@@ -8,24 +10,26 @@ export const resolveLockedNode = (
   const nextNode = { ...node };
 
   if (isNormalizedGroupNode(nextNode)) {
-    if (state === 'all') {
-      nextNode.readOnly = {
-        enabled: true,
-        inheritToChildren: true,
-      };
-    } else if (state === 'self') {
-      nextNode.readOnly = true;
-    } else {
+    const nextReadOnly = updateGroupLockState(nextNode.readOnly, state);
+
+    if (typeof nextReadOnly === 'undefined') {
       delete nextNode.readOnly;
+    } else {
+      nextNode.readOnly = nextReadOnly;
     }
 
     return nextNode;
   }
 
-  if (state === 'self') {
-    nextNode.readOnly = true;
-  } else {
+  const nextReadOnly = updateRuleLockState(
+    nextNode.readOnly,
+    state === 'self' ? 'self' : 'unlocked'
+  );
+
+  if (typeof nextReadOnly === 'undefined') {
     delete nextNode.readOnly;
+  } else {
+    nextNode.readOnly = nextReadOnly;
   }
 
   return nextNode;

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -125,8 +125,10 @@ export type {
   DenormalizedNode,
   DenormalizedQuery,
   GroupReadOnly,
-  IDenormalizedGroupNodeBase,
+  GroupReadOnlyTarget,
   IGroupReadOnlyConfig,
+  IRuleReadOnlyConfig,
+  IDenormalizedGroupNodeBase,
   IDenormalizedGroupNodeWithModifiers,
   IDenormalizedGroupNodeWithoutModifiers,
   IDenormalizedRuleNode,
@@ -141,4 +143,6 @@ export type {
   QueryGroupValue,
   QueryOperator,
   QueryRuleValue,
+  RuleReadOnly,
+  RuleReadOnlyTarget,
 } from './utils/query-tree';

--- a/src/iterator.tsx
+++ b/src/iterator.tsx
@@ -10,7 +10,12 @@ import {
   resolveGroupLockState,
   resolveRuleLockState,
 } from './utils/lock-state';
-import { resolveGroupReadOnly } from './utils/resolve-group-read-only.util';
+import {
+  createInheritedReadOnlyState,
+  IInheritedReadOnlyState,
+  resolveEffectiveGroupReadOnly,
+  resolveEffectiveRuleReadOnly,
+} from './utils/resolve-effective-read-only.util';
 import { NormalizedQuery } from './utils/query-tree';
 
 export interface IIteratorProps {
@@ -23,7 +28,7 @@ export interface IIteratorProps {
   isDragging?: boolean;
   isOverlay?: boolean;
   disableDropZoneTransition?: boolean;
-  inheritedReadOnly?: boolean;
+  inheritedReadOnly?: IInheritedReadOnlyState;
   containerReadOnly?: boolean;
 }
 
@@ -37,7 +42,7 @@ export const Iterator: FC<IIteratorProps> = ({
   isDragging = false,
   isOverlay = false,
   disableDropZoneTransition = false,
-  inheritedReadOnly = false,
+  inheritedReadOnly = createInheritedReadOnlyState(),
   containerReadOnly = false,
 }) => {
   const { draggable, readOnly, components, singleRootGroup } =
@@ -74,10 +79,11 @@ export const Iterator: FC<IIteratorProps> = ({
       ) : null;
 
     if (isNormalizedGroupNode(item)) {
-      const groupReadOnly = resolveGroupReadOnly(item.readOnly);
-      const isGroupReadOnly = inheritedReadOnly || groupReadOnly.enabled;
-      const nextInheritedReadOnly =
-        inheritedReadOnly || groupReadOnly.inheritToChildren;
+      const groupReadOnly = resolveEffectiveGroupReadOnly(
+        item.readOnly,
+        inheritedReadOnly
+      );
+      const isGroupReadOnly = groupReadOnly.full;
       const items = item.children
         .map((childId) =>
           originalData.find((originalItem) => childId === originalItem.id)
@@ -106,8 +112,9 @@ export const Iterator: FC<IIteratorProps> = ({
           id={id}
           isRoot={isRoot}
           readOnly={isGroupReadOnly}
+          readOnlyTargets={groupReadOnly.targets}
           lockState={resolveGroupLockState(item.readOnly)}
-          lockDisabled={inheritedReadOnly}
+          lockDisabled={inheritedReadOnly.full}
           dragHandle={dragHandle}
           contentOverlay={emptyGroupDropZone}
         >
@@ -121,8 +128,8 @@ export const Iterator: FC<IIteratorProps> = ({
             isDragging={isDragging}
             isOverlay={isOverlay}
             disableDropZoneTransition={disableDropZoneTransition}
-            inheritedReadOnly={nextInheritedReadOnly}
-            containerReadOnly={nextInheritedReadOnly}
+            inheritedReadOnly={groupReadOnly.inherited}
+            containerReadOnly={groupReadOnly.inherited.full}
           />
         </Group>
       );
@@ -140,7 +147,11 @@ export const Iterator: FC<IIteratorProps> = ({
     }
 
     const { field, value, id, operator } = item as IRuleProps;
-    const isRuleReadOnly = inheritedReadOnly || Boolean(item.readOnly);
+    const ruleReadOnly = resolveEffectiveRuleReadOnly(
+      item.readOnly,
+      inheritedReadOnly
+    );
+    const isRuleReadOnly = ruleReadOnly.full;
 
     const rule = (dragHandle?: React.ReactNode) => (
       <Rule
@@ -150,8 +161,9 @@ export const Iterator: FC<IIteratorProps> = ({
         operator={operator}
         id={id}
         readOnly={isRuleReadOnly}
-        lockState={resolveRuleLockState(Boolean(item.readOnly))}
-        lockDisabled={inheritedReadOnly}
+        readOnlyTargets={ruleReadOnly.targets}
+        lockState={resolveRuleLockState(item.readOnly)}
+        lockDisabled={inheritedReadOnly.full}
         dragHandle={dragHandle}
         data-test="IteratorRule"
       />

--- a/src/rule/rule.test.tsx
+++ b/src/rule/rule.test.tsx
@@ -1,4 +1,5 @@
 import React, { ReactElement } from 'react';
+import '@testing-library/jest-dom';
 import { fireEvent, render } from '@testing-library/react';
 import {
   IBuilderComponentsProps,
@@ -211,5 +212,57 @@ describe('#components/Rule', () => {
     );
 
     expect(queryByRole('button', { name: 'Delete' })).toBeNull();
+  });
+
+  it('hides the delete control when the rule has targeted read-only fields', () => {
+    const { queryByRole } = renderWithContext(
+      <Rule id="test-2" field="MOCK_FIELD_1" operator="EQUAL" value={true} />,
+      {
+        data: [
+          {
+            type: 'GROUP',
+            value: 'AND',
+            id: 'test-1',
+            isNegated: false,
+            children: ['test-2'],
+          },
+          {
+            field: 'MOCK_FIELD_1',
+            value: true,
+            operator: 'EQUAL',
+            id: 'test-2',
+            parent: 'test-1',
+            readOnly: {
+              enabled: true,
+              targets: ['field'],
+            },
+          },
+        ] as any,
+      }
+    );
+
+    expect(queryByRole('button', { name: 'Delete' })).toBeNull();
+  });
+
+  it('keeps targeted rule controls visible but disables only the targeted inputs', () => {
+    const { container } = renderWithContext(
+      <Rule
+        id="test-2"
+        field="MOCK_FIELD_1"
+        operator="EQUAL"
+        value={true}
+        readOnlyTargets={['operator', 'value']}
+      />
+    );
+
+    expect(
+      container.querySelector('#query-builder-rule-test-2-field-trigger')
+    ).not.toHaveAttribute('disabled');
+    expect(
+      container.querySelector('#query-builder-rule-test-2-operator-trigger')
+    ).toHaveAttribute('disabled');
+    expect(
+      container.querySelector('[data-test="Switch"]')
+    ).toHaveAttribute('aria-disabled', 'true');
   });
 });

--- a/src/rule/rule.tsx
+++ b/src/rule/rule.tsx
@@ -104,6 +104,7 @@ export const Rule: FC<IRuleProps> = ({
     components,
     strings,
     readOnly,
+    readOnlyProtectsDelete = true,
     cloneable,
     lockable,
     validation,
@@ -124,7 +125,9 @@ export const Rule: FC<IRuleProps> = ({
       : [];
   const hasReadOnlyTargets = readOnlyTargets.length > 0;
   const canDeleteRule =
-    !isReadOnly && !hasReadOnlyTargets && !isNodeDeletionProtected(data, id);
+    !isReadOnly &&
+    !hasReadOnlyTargets &&
+    (!readOnlyProtectsDelete || !isNodeDeletionProtected(data, id));
 
   const handleDelete = useCallback(() => {
     if (!canDeleteRule) {

--- a/src/rule/rule.tsx
+++ b/src/rule/rule.tsx
@@ -27,9 +27,11 @@ import { isStringArray } from '../utils/is-string-array.util';
 import { isStringOrNumberArray } from '../utils/is-string-or-number-array.util';
 import { operatorRequiresValue } from '../utils/operator-requires-value.util';
 import { isNormalizedGroupNode } from '../utils/is-normalized-group-node.util';
-import { QueryRuleValue } from '../utils/query-tree';
+import { QueryRuleValue, RuleReadOnlyTarget } from '../utils/query-tree';
 import { getCloneButtonTitle } from '../utils/get-clone-button-title.util';
 import { getLockToggleTitle } from '../utils/get-lock-toggle-title.util';
+import { isNodeDeletionProtected } from '../utils/is-node-deletion-protected.util';
+import { updateRuleLockState } from '../utils/read-only/update-rule-lock-state.util';
 
 const BooleanContainer = styled.div`
   display: flex;
@@ -76,6 +78,7 @@ export interface IRuleProps {
   operator?: BuilderFieldOperator;
   id: string;
   readOnly?: boolean;
+  readOnlyTargets?: RuleReadOnlyTarget[];
   lockState?: BuilderLockState;
   lockDisabled?: boolean;
   dragHandle?: React.ReactNode;
@@ -88,6 +91,7 @@ export const Rule: FC<IRuleProps> = ({
   operator,
   id,
   readOnly: localReadOnly = false,
+  readOnlyTargets = [],
   lockState = localReadOnly ? 'self' : 'unlocked',
   lockDisabled = false,
   dragHandle,
@@ -106,6 +110,10 @@ export const Rule: FC<IRuleProps> = ({
     showValidation,
   } = useContext(BuilderContext);
   const isReadOnly = readOnly || localReadOnly;
+  const isFieldReadOnly = isReadOnly || readOnlyTargets.includes('field');
+  const isOperatorReadOnly =
+    isReadOnly || readOnlyTargets.includes('operator');
+  const isValueReadOnly = isReadOnly || readOnlyTargets.includes('value');
   const RuleContainer = components.Rule || DefaultRuleContainer;
   const CloneButton = components.CloneButton || DefaultCloneButton;
   const LockToggle = components.LockToggle || DefaultLockToggle;
@@ -114,10 +122,17 @@ export const Rule: FC<IRuleProps> = ({
     showValidation && validation?.issuesByRuleId[id]
       ? validation.issuesByRuleId[id]
       : [];
+  const hasReadOnlyTargets = readOnlyTargets.length > 0;
+  const canDeleteRule =
+    !isReadOnly && !hasReadOnlyTargets && !isNodeDeletionProtected(data, id);
 
   const handleDelete = useCallback(() => {
+    if (!canDeleteRule) {
+      return;
+    }
+
     dispatchAction?.(createRemoveSubtreeAction(id));
-  }, [dispatchAction, id]);
+  }, [canDeleteRule, dispatchAction, id]);
 
   const handleChangeLockState = useCallback(
     (nextState: BuilderLockState) => {
@@ -128,11 +143,15 @@ export const Rule: FC<IRuleProps> = ({
       }
 
       const nextRule = { ...currentRule };
+      const nextReadOnly = updateRuleLockState(
+        currentRule.readOnly,
+        nextState === 'self' ? 'self' : 'unlocked'
+      );
 
-      if (nextState === 'self') {
-        nextRule.readOnly = true;
-      } else {
+      if (typeof nextReadOnly === 'undefined') {
         delete nextRule.readOnly;
+      } else {
+        nextRule.readOnly = nextReadOnly;
       }
 
       dispatchAction(createReplaceNodeAction(id, nextRule));
@@ -185,7 +204,7 @@ export const Rule: FC<IRuleProps> = ({
   const controls =
     !isReadOnly || lockControl ? (
       <>
-        {!isReadOnly && <Remove onClick={handleDelete}>{strings.rule.delete}</Remove>}
+        {canDeleteRule ? <Remove onClick={handleDelete}>{strings.rule.delete}</Remove> : null}
         {cloneControl}
         {lockControl}
       </>
@@ -201,7 +220,11 @@ export const Rule: FC<IRuleProps> = ({
         <div>
           <FieldsContent>
             <LayoutItem>
-              <FieldSelect selectedValue="" id={id} disabled={isReadOnly} />
+              <FieldSelect
+                selectedValue=""
+                id={id}
+                disabled={isFieldReadOnly}
+              />
             </LayoutItem>
           </FieldsContent>
           {validationIssues.length > 0 && (
@@ -238,7 +261,11 @@ export const Rule: FC<IRuleProps> = ({
         <div>
           <FieldsContent>
             <LayoutItem>
-              <FieldSelect selectedValue={field} id={id} disabled={isReadOnly} />
+              <FieldSelect
+                selectedValue={field}
+                id={id}
+                disabled={isFieldReadOnly}
+              />
             </LayoutItem>
 
             {type === 'BOOLEAN' && (
@@ -249,7 +276,7 @@ export const Rule: FC<IRuleProps> = ({
                       id={id}
                       values={operatorsOptionList}
                       selectedValue={operator}
-                      disabled={isReadOnly}
+                      disabled={isOperatorReadOnly}
                     />
                   </LayoutItem>
                 )}
@@ -259,7 +286,7 @@ export const Rule: FC<IRuleProps> = ({
                       <Boolean
                         id={id}
                         selectedValue={selectedValue}
-                        disabled={isReadOnly}
+                        disabled={isValueReadOnly}
                       />
                     </BooleanContainer>
                   </ValueContent>
@@ -276,7 +303,7 @@ export const Rule: FC<IRuleProps> = ({
                       id={id}
                       values={operatorsOptionList}
                       selectedValue={operator}
-                      disabled={isReadOnly}
+                      disabled={isOperatorReadOnly}
                     />
                   </LayoutItem>
                   {operator &&
@@ -287,7 +314,7 @@ export const Rule: FC<IRuleProps> = ({
                           id={id}
                           selectedValue={selectedValue}
                           values={fieldValue}
-                          disabled={isReadOnly}
+                          disabled={isValueReadOnly}
                         />
                       </ValueContent>
                     )}
@@ -303,7 +330,7 @@ export const Rule: FC<IRuleProps> = ({
                       id={id}
                       values={operatorsOptionList}
                       selectedValue={operator}
-                      disabled={isReadOnly}
+                      disabled={isOperatorReadOnly}
                     />
                   </LayoutItem>
                   {operator &&
@@ -314,7 +341,7 @@ export const Rule: FC<IRuleProps> = ({
                           id={id}
                           values={fieldValue}
                           selectedValue={selectedValue}
-                          disabled={isReadOnly}
+                          disabled={isValueReadOnly}
                         />
                       </ValueContent>
                     )}
@@ -331,7 +358,7 @@ export const Rule: FC<IRuleProps> = ({
                       id={id}
                       values={operatorsOptionList}
                       selectedValue={operator}
-                      disabled={isReadOnly}
+                      disabled={isOperatorReadOnly}
                     />
                   </LayoutItem>
                   {shouldRenderValueInput && (
@@ -340,7 +367,7 @@ export const Rule: FC<IRuleProps> = ({
                         id={id}
                         type="text"
                         value={selectedValue}
-                        disabled={isReadOnly}
+                        disabled={isValueReadOnly}
                       />
                     </ValueContent>
                   )}
@@ -357,7 +384,7 @@ export const Rule: FC<IRuleProps> = ({
                       id={id}
                       values={operatorsOptionList}
                       selectedValue={operator}
-                      disabled={isReadOnly}
+                      disabled={isOperatorReadOnly}
                     />
                   </LayoutItem>
                   {shouldRenderValueInput && (
@@ -366,7 +393,7 @@ export const Rule: FC<IRuleProps> = ({
                         id={id}
                         type="date"
                         value={selectedValue}
-                        disabled={isReadOnly}
+                        disabled={isValueReadOnly}
                       />
                     </ValueContent>
                   )}
@@ -383,7 +410,7 @@ export const Rule: FC<IRuleProps> = ({
                       id={id}
                       values={operatorsOptionList}
                       selectedValue={operator}
-                      disabled={isReadOnly}
+                      disabled={isOperatorReadOnly}
                     />
                   </LayoutItem>
                   {shouldRenderValueInput && (
@@ -392,7 +419,7 @@ export const Rule: FC<IRuleProps> = ({
                         id={id}
                         type="number"
                         value={selectedValue}
-                        disabled={isReadOnly}
+                        disabled={isValueReadOnly}
                       />
                     </ValueContent>
                   )}

--- a/src/utils/is-group-read-only-target.util.ts
+++ b/src/utils/is-group-read-only-target.util.ts
@@ -1,0 +1,7 @@
+import { GroupReadOnly, GroupReadOnlyTarget } from './query-tree';
+import { getGroupReadOnlyTargets } from './resolve-group-read-only.util';
+
+export const isGroupReadOnlyTarget = (
+  value: GroupReadOnly | undefined,
+  target: GroupReadOnlyTarget
+): boolean => getGroupReadOnlyTargets(value).includes(target);

--- a/src/utils/is-node-deletion-protected.util.ts
+++ b/src/utils/is-node-deletion-protected.util.ts
@@ -1,0 +1,101 @@
+import { findNodeById } from '../history/find-node-by-id';
+import {
+  createInheritedReadOnlyState,
+  IInheritedReadOnlyState,
+  resolveEffectiveGroupReadOnly,
+  resolveEffectiveRuleReadOnly,
+} from './resolve-effective-read-only.util';
+import { isNormalizedGroupNode } from './is-normalized-group-node.util';
+import { NormalizedNode, NormalizedQuery } from './query-tree';
+
+const isNodeOwnReadOnlyProtected = (
+  node: NormalizedNode,
+  inheritedReadOnly: IInheritedReadOnlyState
+): {
+  protected: boolean;
+  nextInheritedReadOnly: IInheritedReadOnlyState;
+} => {
+  if (isNormalizedGroupNode(node)) {
+    const resolvedReadOnly = resolveEffectiveGroupReadOnly(
+      node.readOnly,
+      inheritedReadOnly
+    );
+
+    return {
+      protected: resolvedReadOnly.full || resolvedReadOnly.targets.length > 0,
+      nextInheritedReadOnly: resolvedReadOnly.inherited,
+    };
+  }
+
+  const resolvedReadOnly = resolveEffectiveRuleReadOnly(
+    node.readOnly,
+    inheritedReadOnly
+  );
+
+  return {
+    protected: resolvedReadOnly.full || resolvedReadOnly.targets.length > 0,
+    nextInheritedReadOnly: inheritedReadOnly,
+  };
+};
+
+const populateDeletionProtection = (
+  data: NormalizedQuery,
+  node: NormalizedNode,
+  protectedIds: Set<string>,
+  inheritedReadOnly: IInheritedReadOnlyState
+): boolean => {
+  const { protected: isOwnProtected, nextInheritedReadOnly } =
+    isNodeOwnReadOnlyProtected(node, inheritedReadOnly);
+
+  let hasProtectedDescendant = false;
+
+  if (isNormalizedGroupNode(node)) {
+    hasProtectedDescendant = node.children.some((childId) => {
+      const childNode = findNodeById(data, childId);
+
+      if (!childNode) {
+        return false;
+      }
+
+      return populateDeletionProtection(
+        data,
+        childNode,
+        protectedIds,
+        nextInheritedReadOnly
+      );
+    });
+  }
+
+  const isProtected = isOwnProtected || hasProtectedDescendant;
+
+  if (isProtected) {
+    protectedIds.add(node.id);
+  }
+
+  return isProtected;
+};
+
+export const createDeletionProtectionSet = (
+  data: NormalizedQuery
+): Set<string> => {
+  const protectedIds = new Set<string>();
+  const rootInheritedReadOnly = createInheritedReadOnlyState();
+
+  data
+    .filter((node) => !node.parent)
+    .forEach((node) => {
+      populateDeletionProtection(
+        data,
+        node,
+        protectedIds,
+        rootInheritedReadOnly
+      );
+    });
+
+  return protectedIds;
+};
+
+export const isNodeDeletionProtected = (
+  data: NormalizedQuery,
+  nodeId: string
+): boolean => createDeletionProtectionSet(data).has(nodeId);

--- a/src/utils/is-node-deletion-protected.util.ts
+++ b/src/utils/is-node-deletion-protected.util.ts
@@ -6,7 +6,7 @@ import {
   resolveEffectiveRuleReadOnly,
 } from './resolve-effective-read-only.util';
 import { isNormalizedGroupNode } from './is-normalized-group-node.util';
-import { NormalizedNode, NormalizedQuery } from './query-tree';
+import { NormalizedGroupNode, NormalizedNode, NormalizedQuery } from './query-tree';
 
 const isNodeOwnReadOnlyProtected = (
   node: NormalizedNode,
@@ -75,6 +75,63 @@ const populateDeletionProtection = (
   return isProtected;
 };
 
+const resolveInheritedReadOnlyForNode = (
+  data: NormalizedQuery,
+  node: NormalizedNode
+): IInheritedReadOnlyState => {
+  const ancestorGroups: NormalizedGroupNode[] = [];
+  let currentParentId = node.parent;
+
+  while (currentParentId) {
+    const parentNode = findNodeById(data, currentParentId);
+
+    if (!parentNode || !isNormalizedGroupNode(parentNode)) {
+      break;
+    }
+
+    ancestorGroups.unshift(parentNode);
+    currentParentId = parentNode.parent;
+  }
+
+  return ancestorGroups.reduce<IInheritedReadOnlyState>(
+    (inheritedReadOnly, ancestorGroup) =>
+      resolveEffectiveGroupReadOnly(ancestorGroup.readOnly, inheritedReadOnly)
+        .inherited,
+    createInheritedReadOnlyState()
+  );
+};
+
+const hasProtectedNodeInSubtree = (
+  data: NormalizedQuery,
+  node: NormalizedNode,
+  inheritedReadOnly: IInheritedReadOnlyState
+): boolean => {
+  const { protected: isOwnProtected, nextInheritedReadOnly } =
+    isNodeOwnReadOnlyProtected(node, inheritedReadOnly);
+
+  if (isOwnProtected) {
+    return true;
+  }
+
+  if (!isNormalizedGroupNode(node)) {
+    return false;
+  }
+
+  return node.children.some((childId) => {
+    const childNode = findNodeById(data, childId);
+
+    if (!childNode) {
+      return false;
+    }
+
+    return hasProtectedNodeInSubtree(
+      data,
+      childNode,
+      nextInheritedReadOnly
+    );
+  });
+};
+
 export const createDeletionProtectionSet = (
   data: NormalizedQuery
 ): Set<string> => {
@@ -98,4 +155,16 @@ export const createDeletionProtectionSet = (
 export const isNodeDeletionProtected = (
   data: NormalizedQuery,
   nodeId: string
-): boolean => createDeletionProtectionSet(data).has(nodeId);
+): boolean => {
+  const node = findNodeById(data, nodeId);
+
+  if (!node) {
+    return false;
+  }
+
+  return hasProtectedNodeInSubtree(
+    data,
+    node,
+    resolveInheritedReadOnlyForNode(data, node)
+  );
+};

--- a/src/utils/is-rule-read-only-config.util.ts
+++ b/src/utils/is-rule-read-only-config.util.ts
@@ -1,0 +1,6 @@
+import { IRuleReadOnlyConfig, RuleReadOnly } from './query-tree';
+
+export const isRuleReadOnlyConfig = (
+  value: RuleReadOnly | undefined
+): value is IRuleReadOnlyConfig =>
+  typeof value === 'object' && value !== null && 'enabled' in value;

--- a/src/utils/is-rule-read-only-target.util.ts
+++ b/src/utils/is-rule-read-only-target.util.ts
@@ -1,0 +1,7 @@
+import { RuleReadOnly, RuleReadOnlyTarget } from './query-tree';
+import { getRuleReadOnlyTargets } from './resolve-rule-read-only.util';
+
+export const isRuleReadOnlyTarget = (
+  value: RuleReadOnly | undefined,
+  target: RuleReadOnlyTarget
+): boolean => getRuleReadOnlyTargets(value).includes(target);

--- a/src/utils/is-same-query.util.ts
+++ b/src/utils/is-same-query.util.ts
@@ -5,6 +5,9 @@ import {
 } from './query-tree';
 import { isDenormalizedGroupNode } from './is-denormalized-group-node.util';
 
+const isSameReadOnly = (leftReadOnly: unknown, rightReadOnly: unknown): boolean =>
+  JSON.stringify(leftReadOnly ?? null) === JSON.stringify(rightReadOnly ?? null);
+
 const isSameValue = (leftValue: any, rightValue: any) => {
   if (Array.isArray(leftValue) && Array.isArray(rightValue)) {
     return (
@@ -25,6 +28,7 @@ const isSameNode = (left: DenormalizedNode, right: DenormalizedNode): boolean =>
     return (
       left.value === right.value &&
       left.isNegated === right.isNegated &&
+      isSameReadOnly(left.readOnly, right.readOnly) &&
       isSameQuery(left.children, right.children)
     );
   }
@@ -35,7 +39,8 @@ const isSameNode = (left: DenormalizedNode, right: DenormalizedNode): boolean =>
   return (
     leftRule.field === rightRule.field &&
     leftRule.operator === rightRule.operator &&
-    isSameValue(leftRule.value, rightRule.value)
+    isSameValue(leftRule.value, rightRule.value) &&
+    isSameReadOnly(leftRule.readOnly, rightRule.readOnly)
   );
 };
 

--- a/src/utils/lock-state.ts
+++ b/src/utils/lock-state.ts
@@ -1,10 +1,11 @@
-import { GroupReadOnly } from './query-tree';
+import { GroupReadOnly, RuleReadOnly } from './query-tree';
+import { normalizeRuleReadOnlyConfig } from './normalize-rule-read-only-config.util';
 import { resolveGroupReadOnly } from './resolve-group-read-only.util';
 
 export type BuilderLockState = 'unlocked' | 'self' | 'all';
 
-export const resolveRuleLockState = (value?: boolean): BuilderLockState =>
-  value ? 'self' : 'unlocked';
+export const resolveRuleLockState = (value?: RuleReadOnly): BuilderLockState =>
+  normalizeRuleReadOnlyConfig(value).enabled ? 'self' : 'unlocked';
 
 export const resolveGroupLockState = (
   value?: GroupReadOnly

--- a/src/utils/normalize-group-read-only-config.util.ts
+++ b/src/utils/normalize-group-read-only-config.util.ts
@@ -1,0 +1,41 @@
+import {
+  GroupReadOnly,
+  GroupReadOnlyTarget,
+  IGroupReadOnlyConfig,
+} from './query-tree';
+import { isGroupReadOnlyConfig } from './is-group-read-only-config.util';
+
+export interface IResolvedGroupReadOnly {
+  enabled: boolean;
+  inheritToChildren: boolean;
+  targets?: GroupReadOnlyTarget[];
+}
+
+export const normalizeGroupReadOnlyConfig = (
+  value?: GroupReadOnly
+): IResolvedGroupReadOnly => {
+  if (typeof value === 'boolean') {
+    return {
+      enabled: value,
+      inheritToChildren: false,
+    };
+  }
+
+  if (isGroupReadOnlyConfig(value)) {
+    const resolvedValue = value as IGroupReadOnlyConfig;
+
+    return {
+      enabled: resolvedValue.enabled,
+      inheritToChildren:
+        resolvedValue.enabled && Boolean(resolvedValue.inheritToChildren),
+      ...(resolvedValue.targets?.length
+        ? { targets: [...resolvedValue.targets] }
+        : {}),
+    };
+  }
+
+  return {
+    enabled: false,
+    inheritToChildren: false,
+  };
+};

--- a/src/utils/normalize-rule-read-only-config.util.ts
+++ b/src/utils/normalize-rule-read-only-config.util.ts
@@ -1,0 +1,36 @@
+import {
+  IRuleReadOnlyConfig,
+  RuleReadOnly,
+  RuleReadOnlyTarget,
+} from './query-tree';
+import { isRuleReadOnlyConfig } from './is-rule-read-only-config.util';
+
+export interface IResolvedRuleReadOnly {
+  enabled: boolean;
+  targets?: RuleReadOnlyTarget[];
+}
+
+export const normalizeRuleReadOnlyConfig = (
+  value?: RuleReadOnly
+): IResolvedRuleReadOnly => {
+  if (typeof value === 'boolean') {
+    return {
+      enabled: value,
+    };
+  }
+
+  if (isRuleReadOnlyConfig(value)) {
+    const resolvedValue = value as IRuleReadOnlyConfig;
+
+    return {
+      enabled: resolvedValue.enabled,
+      ...(resolvedValue.targets?.length
+        ? { targets: [...resolvedValue.targets] }
+        : {}),
+    };
+  }
+
+  return {
+    enabled: false,
+  };
+};

--- a/src/utils/query-tree.ts
+++ b/src/utils/query-tree.ts
@@ -5,6 +5,9 @@ export type { QueryOperator } from './query-operators';
 export type QueryGroupValue = 'AND' | 'OR';
 export type QueryGroupType = 'with-modifiers' | 'without-modifiers';
 export type GroupReadOnly = boolean | IGroupReadOnlyConfig;
+export type RuleReadOnly = boolean | IRuleReadOnlyConfig;
+export type GroupReadOnlyTarget = 'negation' | 'combinator';
+export type RuleReadOnlyTarget = 'field' | 'operator' | 'value';
 
 export type QueryRuleValue =
   | string
@@ -15,7 +18,13 @@ export type QueryRuleValue =
 
 export interface IGroupReadOnlyConfig {
   enabled: boolean;
+  targets?: GroupReadOnlyTarget[];
   inheritToChildren?: boolean;
+}
+
+export interface IRuleReadOnlyConfig {
+  enabled: boolean;
+  targets?: RuleReadOnlyTarget[];
 }
 
 export interface IDenormalizedRuleNode {
@@ -25,7 +34,7 @@ export interface IDenormalizedRuleNode {
   value?: QueryRuleValue;
   operator?: QueryOperator;
   operators?: QueryOperator[];
-  readOnly?: boolean;
+  readOnly?: RuleReadOnly;
 }
 
 export interface IDenormalizedGroupNodeBase {

--- a/src/utils/read-only/update-group-lock-state.util.ts
+++ b/src/utils/read-only/update-group-lock-state.util.ts
@@ -1,0 +1,46 @@
+import { normalizeGroupReadOnlyConfig } from '../normalize-group-read-only-config.util';
+import { GroupReadOnly } from '../query-tree';
+
+const hasGroupReadOnlyTargets = (value?: GroupReadOnly): boolean => {
+  const normalizedValue = normalizeGroupReadOnlyConfig(value);
+
+  return Boolean(normalizedValue.targets?.length);
+};
+
+export const updateGroupLockState = (
+  value: GroupReadOnly | undefined,
+  state: 'unlocked' | 'self' | 'all'
+): GroupReadOnly | undefined => {
+  if (typeof value !== 'boolean' && typeof value !== 'undefined') {
+    if (state === 'unlocked') {
+      if (!hasGroupReadOnlyTargets(value)) {
+        return undefined;
+      }
+
+      return {
+        ...value,
+        enabled: false,
+        inheritToChildren: false,
+      };
+    }
+
+    return {
+      ...value,
+      enabled: true,
+      inheritToChildren: state === 'all',
+    };
+  }
+
+  if (state === 'unlocked') {
+    return undefined;
+  }
+
+  if (state === 'self') {
+    return true;
+  }
+
+  return {
+    enabled: true,
+    inheritToChildren: true,
+  };
+};

--- a/src/utils/read-only/update-rule-lock-state.util.ts
+++ b/src/utils/read-only/update-rule-lock-state.util.ts
@@ -1,0 +1,37 @@
+import { normalizeRuleReadOnlyConfig } from '../normalize-rule-read-only-config.util';
+import { RuleReadOnly } from '../query-tree';
+
+const hasRuleReadOnlyTargets = (value?: RuleReadOnly): boolean => {
+  const normalizedValue = normalizeRuleReadOnlyConfig(value);
+
+  return Boolean(normalizedValue.targets?.length);
+};
+
+export const updateRuleLockState = (
+  value: RuleReadOnly | undefined,
+  state: 'unlocked' | 'self'
+): RuleReadOnly | undefined => {
+  if (state === 'self') {
+    if (typeof value === 'boolean' || typeof value === 'undefined') {
+      return true;
+    }
+
+    return {
+      ...value,
+      enabled: true,
+    };
+  }
+
+  if (!hasRuleReadOnlyTargets(value)) {
+    return undefined;
+  }
+
+  if (typeof value === 'boolean' || typeof value === 'undefined') {
+    return undefined;
+  }
+
+  return {
+    ...value,
+    enabled: false,
+  };
+};

--- a/src/utils/resolve-effective-read-only.util.ts
+++ b/src/utils/resolve-effective-read-only.util.ts
@@ -1,0 +1,88 @@
+import {
+  GroupReadOnly,
+  GroupReadOnlyTarget,
+  RuleReadOnly,
+  RuleReadOnlyTarget,
+} from './query-tree';
+import {
+  getGroupReadOnlyTargets,
+  isGroupFullyReadOnly,
+  resolveGroupReadOnly,
+} from './resolve-group-read-only.util';
+import {
+  getRuleReadOnlyTargets,
+  isRuleFullyReadOnly,
+} from './resolve-rule-read-only.util';
+
+export interface IInheritedReadOnlyState {
+  full: boolean;
+  groupTargets: GroupReadOnlyTarget[];
+}
+
+export interface IEffectiveGroupReadOnlyState {
+  full: boolean;
+  targets: GroupReadOnlyTarget[];
+  inherited: IInheritedReadOnlyState;
+}
+
+export interface IEffectiveRuleReadOnlyState {
+  full: boolean;
+  targets: RuleReadOnlyTarget[];
+}
+
+const mergeUniqueTargets = <TTarget extends string>(
+  currentTargets: TTarget[],
+  nextTargets: TTarget[]
+): TTarget[] => Array.from(new Set([...currentTargets, ...nextTargets]));
+
+export const resolveEffectiveGroupReadOnly = (
+  value: GroupReadOnly | undefined,
+  inheritedReadOnly: IInheritedReadOnlyState
+): IEffectiveGroupReadOnlyState => {
+  const resolvedReadOnly = resolveGroupReadOnly(value);
+  const ownFullReadOnly = isGroupFullyReadOnly(value);
+  const ownTargets = getGroupReadOnlyTargets(value);
+  const fullReadOnly = inheritedReadOnly.full || ownFullReadOnly;
+  const targets: GroupReadOnlyTarget[] = fullReadOnly
+    ? ['negation', 'combinator']
+    : mergeUniqueTargets(inheritedReadOnly.groupTargets, ownTargets);
+  const nextInheritedFull =
+    inheritedReadOnly.full ||
+    (resolvedReadOnly.inheritToChildren && ownFullReadOnly);
+  const inherited = nextInheritedFull
+    ? {
+        full: true,
+        groupTargets: ['negation', 'combinator'] as GroupReadOnlyTarget[],
+      }
+    : {
+        full: false,
+        groupTargets: mergeUniqueTargets(
+          inheritedReadOnly.groupTargets,
+          resolvedReadOnly.inheritToChildren ? ownTargets : []
+        ),
+      };
+
+  return {
+    full: fullReadOnly,
+    targets,
+    inherited,
+  };
+};
+
+export const resolveEffectiveRuleReadOnly = (
+  value: RuleReadOnly | undefined,
+  inheritedReadOnly: IInheritedReadOnlyState
+): IEffectiveRuleReadOnlyState => {
+  const ownFullReadOnly = isRuleFullyReadOnly(value);
+  const fullReadOnly = inheritedReadOnly.full || ownFullReadOnly;
+
+  return {
+    full: fullReadOnly,
+    targets: fullReadOnly ? ['field', 'operator', 'value'] : getRuleReadOnlyTargets(value),
+  };
+};
+
+export const createInheritedReadOnlyState = (): IInheritedReadOnlyState => ({
+  full: false,
+  groupTargets: [],
+});

--- a/src/utils/resolve-group-read-only.util.test.ts
+++ b/src/utils/resolve-group-read-only.util.test.ts
@@ -1,4 +1,5 @@
 import { resolveGroupReadOnly } from './resolve-group-read-only.util';
+import { resolveRuleReadOnly } from './resolve-rule-read-only.util';
 
 describe('#utils/resolveGroupReadOnly', () => {
   it('Resolves boolean read-only values', () => {
@@ -24,6 +25,34 @@ describe('#utils/resolveGroupReadOnly', () => {
     ).toEqual({
       enabled: false,
       inheritToChildren: false,
+    });
+  });
+
+  it('Preserves configured group targets', () => {
+    expect(
+      resolveGroupReadOnly({
+        enabled: true,
+        targets: ['combinator'],
+        inheritToChildren: true,
+      })
+    ).toEqual({
+      enabled: true,
+      targets: ['combinator'],
+      inheritToChildren: true,
+    });
+  });
+});
+
+describe('#utils/resolveRuleReadOnly', () => {
+  it('Resolves rule read-only targets', () => {
+    expect(
+      resolveRuleReadOnly({
+        enabled: true,
+        targets: ['field', 'value'],
+      })
+    ).toEqual({
+      enabled: true,
+      targets: ['field', 'value'],
     });
   });
 });

--- a/src/utils/resolve-group-read-only.util.ts
+++ b/src/utils/resolve-group-read-only.util.ts
@@ -1,30 +1,28 @@
-import { GroupReadOnly } from './query-tree';
-import { isGroupReadOnlyConfig } from './is-group-read-only-config.util';
-
-export interface IResolvedGroupReadOnly {
-  enabled: boolean;
-  inheritToChildren: boolean;
-}
+import { GroupReadOnly, GroupReadOnlyTarget } from './query-tree';
+import {
+  IResolvedGroupReadOnly,
+  normalizeGroupReadOnlyConfig,
+} from './normalize-group-read-only-config.util';
 
 export const resolveGroupReadOnly = (
   value?: GroupReadOnly
-): IResolvedGroupReadOnly => {
-  if (typeof value === 'boolean') {
-    return {
-      enabled: value,
-      inheritToChildren: false,
-    };
+): IResolvedGroupReadOnly => normalizeGroupReadOnlyConfig(value);
+
+export const getGroupReadOnlyTargets = (
+  value?: GroupReadOnly
+): GroupReadOnlyTarget[] => {
+  const resolvedReadOnly = resolveGroupReadOnly(value);
+
+  if (!resolvedReadOnly.enabled) {
+    return [];
   }
 
-  if (isGroupReadOnlyConfig(value)) {
-    return {
-      enabled: value.enabled,
-      inheritToChildren: value.enabled && Boolean(value.inheritToChildren),
-    };
-  }
+  return resolvedReadOnly.targets?.length
+    ? [...resolvedReadOnly.targets]
+    : ['negation', 'combinator'];
+};
 
-  return {
-    enabled: false,
-    inheritToChildren: false,
-  };
+export const isGroupFullyReadOnly = (value?: GroupReadOnly): boolean => {
+  const resolvedReadOnly = resolveGroupReadOnly(value);
+  return resolvedReadOnly.enabled && !resolvedReadOnly.targets?.length;
 };

--- a/src/utils/resolve-rule-read-only.util.ts
+++ b/src/utils/resolve-rule-read-only.util.ts
@@ -1,0 +1,28 @@
+import { RuleReadOnly, RuleReadOnlyTarget } from './query-tree';
+import {
+  IResolvedRuleReadOnly,
+  normalizeRuleReadOnlyConfig,
+} from './normalize-rule-read-only-config.util';
+
+export const resolveRuleReadOnly = (
+  value?: RuleReadOnly
+): IResolvedRuleReadOnly => normalizeRuleReadOnlyConfig(value);
+
+export const getRuleReadOnlyTargets = (
+  value?: RuleReadOnly
+): RuleReadOnlyTarget[] => {
+  const resolvedReadOnly = resolveRuleReadOnly(value);
+
+  if (!resolvedReadOnly.enabled) {
+    return [];
+  }
+
+  return resolvedReadOnly.targets?.length
+    ? [...resolvedReadOnly.targets]
+    : ['field', 'operator', 'value'];
+};
+
+export const isRuleFullyReadOnly = (value?: RuleReadOnly): boolean => {
+  const resolvedReadOnly = resolveRuleReadOnly(value);
+  return resolvedReadOnly.enabled && !resolvedReadOnly.targets?.length;
+};

--- a/src/widgets/boolean.tsx
+++ b/src/widgets/boolean.tsx
@@ -26,10 +26,15 @@ export const Boolean: FC<IBooleanProps> = ({
     components,
     readOnly,
   } = useContext(BuilderContext);
+  const isDisabled = !!(readOnly || disabled);
 
   const Switch = components.form?.Switch || DefaultSwitch;
 
   const handleChange = (value: boolean) => {
+    if (isDisabled) {
+      return;
+    }
+
     const currentRule = findNodeById(data, id);
 
     if (!currentRule || 'children' in currentRule) {
@@ -70,7 +75,7 @@ export const Boolean: FC<IBooleanProps> = ({
     <Switch
       onChange={handleChange}
       switched={selectedValue}
-      disabled={readOnly || disabled}
+      disabled={isDisabled}
     />
   );
 };

--- a/src/widgets/field-select.tsx
+++ b/src/widgets/field-select.tsx
@@ -31,8 +31,13 @@ export const FieldSelect: FC<IFieldSelectProps> = ({
     readOnly,
   } = useContext(BuilderContext);
   const Select = components.form?.Select || DefaultSelect;
+  const isDisabled = Boolean(readOnly || disabled);
 
   const handleChange = (value: string) => {
+    if (isDisabled) {
+      return;
+    }
+
     const nextField = fields.find(item => item.field === value);
     const currentRule = findNodeById(data, id);
 
@@ -95,7 +100,7 @@ export const FieldSelect: FC<IFieldSelectProps> = ({
       selectedValue={selectedValue}
       emptyValue={strings.form.selectYourValue}
       onChange={handleChange}
-      disabled={readOnly || disabled}
+      disabled={isDisabled}
     />
   );
 };

--- a/src/widgets/input.tsx
+++ b/src/widgets/input.tsx
@@ -47,8 +47,13 @@ export const Input: FC<IInputProps> = ({
     readOnly,
   } = useContext(BuilderContext);
   const InputComponent = components.form?.Input || DefaultInput;
+  const isDisabled = Boolean(readOnly || disabled);
 
   const handleChange = (selectedValue: string, index = 0) => {
+    if (isDisabled) {
+      return;
+    }
+
     const nextValue =
       type === 'number' ? coerceNumberInputValue(selectedValue) : selectedValue;
     const currentRule = findNodeById(data, id);
@@ -109,7 +114,7 @@ export const Input: FC<IInputProps> = ({
           type={type}
           value={value[0]}
           onChange={(selectedValue: string) => handleChange(selectedValue, 0)}
-          disabled={readOnly || disabled}
+          disabled={isDisabled}
         />
         <InputComponent
           id={`query-builder-rule-${id}-value-end`}
@@ -117,7 +122,7 @@ export const Input: FC<IInputProps> = ({
           type={type}
           value={value[1]}
           onChange={(selectedValue: string) => handleChange(selectedValue, 1)}
-          disabled={readOnly || disabled}
+          disabled={isDisabled}
         />
       </RangeInputs>
     );
@@ -134,7 +139,7 @@ export const Input: FC<IInputProps> = ({
       type={type}
       value={value}
       onChange={handleChange}
-      disabled={readOnly || disabled}
+      disabled={isDisabled}
     />
   );
 };

--- a/src/widgets/operator-select.tsx
+++ b/src/widgets/operator-select.tsx
@@ -42,8 +42,13 @@ export const OperatorSelect: FC<IOperatorSelectProps> = ({
   } =
     useContext(BuilderContext);
   const Select = components.form?.Select || DefaultSelect;
+  const isDisabled = Boolean(readOnly || disabled);
 
   const handleChange = (value: BuilderFieldOperator) => {
+    if (isDisabled) {
+      return;
+    }
+
     const currentRule = findNodeById(data, id);
 
     if (!currentRule || isNormalizedGroupNode(currentRule)) {
@@ -122,7 +127,7 @@ export const OperatorSelect: FC<IOperatorSelectProps> = ({
       selectedValue={selectedValue}
       emptyValue={strings.form.selectYourValue}
       onChange={handleChange}
-      disabled={readOnly || disabled}
+      disabled={isDisabled}
     />
   );
 };

--- a/src/widgets/select-multi/select-multi.tsx
+++ b/src/widgets/select-multi/select-multi.tsx
@@ -34,8 +34,13 @@ export const SelectMulti: FC<ISelectMultiProps> = ({
     useContext(BuilderContext);
   const SelectMultiComponent =
     components.form?.SelectMulti || DefaultSelectMulti;
+  const isDisabled = Boolean(readOnly || disabled);
 
   const handleChange = (value: string) => {
+    if (isDisabled) {
+      return;
+    }
+
     const currentRule = findNodeById(data, id);
 
     if (
@@ -85,6 +90,10 @@ export const SelectMulti: FC<ISelectMultiProps> = ({
   };
 
   const handleDelete = (value: string) => {
+    if (isDisabled) {
+      return;
+    }
+
     const currentRule = findNodeById(data, id);
 
     if (
@@ -142,7 +151,7 @@ export const SelectMulti: FC<ISelectMultiProps> = ({
       selectedValue={selectedValue}
       emptyValue={strings.form.selectYourValue}
       values={values}
-      disabled={Boolean(readOnly || disabled)}
+      disabled={isDisabled}
     />
   );
 };

--- a/src/widgets/select.tsx
+++ b/src/widgets/select.tsx
@@ -30,8 +30,13 @@ export const Select: FC<ISelectProps> = ({
     readOnly,
   } = useContext(BuilderContext);
   const SelectComponent = components.form?.Select || DefaultSelect;
+  const isDisabled = Boolean(readOnly || disabled);
 
   const handleChange = (value: string) => {
+    if (isDisabled) {
+      return;
+    }
+
     const currentRule = findNodeById(data, id);
 
     if (!currentRule || 'children' in currentRule) {
@@ -80,7 +85,7 @@ export const Select: FC<ISelectProps> = ({
       selectedValue={selectedValue}
       emptyValue={strings.form.selectYourValue}
       values={values}
-      disabled={readOnly || disabled}
+      disabled={isDisabled}
     />
   );
 };


### PR DESCRIPTION
- Added possibility to target "negation" and "combinators" for groups
- Added possibility to target "field", "operator" and "value" for rule
- Protected mode for "combinators", "field", "operator", "value" in monaco text mode
- Validation of permissibility of "negation" in text mode
- Adapted GUI lock / unlock to account for granular readOnly targets
- Updated documentation and api sections on the website
- Updated README