### PR TITLE
fix: Fixed inability to type in text mode when editor state is valid

### DIFF
--- a/src/builder/builder.test.tsx
+++ b/src/builder/builder.test.tsx
@@ -1052,21 +1052,242 @@ describe('#components/Builder', () => {
       />
     );
 
-    const previousTextValue = (
-      getByDataTest(container, 'CustomTextModeEditorInput') as HTMLTextAreaElement
-    ).value;
-
     fireEvent.change(getByDataTest(container, 'CustomTextModeEditorInput'), {
       target: { value: '(MOCK_NUMBER != 8)' },
     });
 
     expect(onChange).not.toHaveBeenCalled();
     expect(getByDataTest(container, 'CustomTextModeEditorInput')).toHaveValue(
-      previousTextValue
+      '(MOCK_NUMBER != 8)'
     );
     expect(getByDataTest(container, 'CustomTextModeEditorError')).toHaveTextContent(
       'One or more read-only clauses cannot be changed or removed in text mode.'
     );
+  });
+
+  it('allows adding another rule with the same locked field and operator in text mode', async () => {
+    const onChange = jest.fn();
+    const { container } = render(
+      <Builder
+        fields={fields}
+        data={[
+          {
+            type: 'GROUP',
+            value: 'AND',
+            isNegated: false,
+            children: [
+              {
+                field: 'MOCK_FIELD',
+                value: 'alpha',
+                operator: 'EQUAL',
+                readOnly: {
+                  enabled: true,
+                  targets: ['field', 'operator'],
+                },
+              },
+              {
+                field: 'MOCK_NUMBER',
+                value: 5,
+                operator: 'NOT_EQUAL',
+              },
+            ],
+          },
+        ]}
+        textMode
+        defaultMode="text"
+        components={{
+          ...defaultComponents,
+          TextModeEditor: CustomTextModeEditor,
+        }}
+        onChange={onChange}
+      />
+    );
+
+    fireEvent.change(getByDataTest(container, 'CustomTextModeEditorInput'), {
+      target: {
+        value:
+          "(MOCK_FIELD = 'alpha' AND MOCK_FIELD = 'beta' AND MOCK_NUMBER != 5)",
+      },
+    });
+
+    await waitFor(() =>
+      expect(onChange).toHaveBeenLastCalledWith([
+        {
+          type: 'GROUP',
+          value: 'AND',
+          isNegated: false,
+          children: [
+            {
+              field: 'MOCK_FIELD',
+              value: 'alpha',
+              operator: 'EQUAL',
+              readOnly: {
+                enabled: true,
+                targets: ['field', 'operator'],
+              },
+            },
+            {
+              field: 'MOCK_FIELD',
+              value: 'beta',
+              operator: 'EQUAL',
+            },
+            {
+              field: 'MOCK_NUMBER',
+              value: 5,
+              operator: 'NOT_EQUAL',
+            },
+          ],
+        },
+      ])
+    );
+
+    expect(queryByDataTest(container, 'CustomTextModeEditorError')).toBeNull();
+  });
+
+  it('allows adding another rule next to a targeted lock when another identical read-only rule exists elsewhere', async () => {
+    const onChange = jest.fn();
+    const { container } = render(
+      <Builder
+        fields={fields}
+        data={[
+          {
+            type: 'GROUP',
+            value: 'AND',
+            isNegated: false,
+            children: [
+              {
+                field: 'MOCK_FIELD',
+                value: 'alpha',
+                operator: 'EQUAL',
+                readOnly: {
+                  enabled: true,
+                  targets: ['field', 'operator'],
+                },
+              },
+              {
+                type: 'GROUP',
+                value: 'OR',
+                isNegated: false,
+                children: [
+                  {
+                    field: 'MOCK_FIELD',
+                    value: 'gamma',
+                    operator: 'EQUAL',
+                  },
+                  {
+                    field: 'MOCK_NUMBER',
+                    value: 5,
+                    operator: 'NOT_EQUAL',
+                  },
+                ],
+              },
+              {
+                type: 'GROUP',
+                value: 'AND',
+                isNegated: false,
+                children: [
+                  {
+                    field: 'MOCK_FIELD',
+                    value: 'gamma',
+                    operator: 'EQUAL',
+                    readOnly: true,
+                  },
+                  {
+                    field: 'MOCK_NUMBER',
+                    value: 8,
+                    operator: 'NOT_EQUAL',
+                  },
+                ],
+              },
+            ],
+          },
+        ]}
+        textMode
+        defaultMode="text"
+        components={{
+          ...defaultComponents,
+          TextModeEditor: CustomTextModeEditor,
+        }}
+        onChange={onChange}
+      />
+    );
+
+    fireEvent.change(getByDataTest(container, 'CustomTextModeEditorInput'), {
+      target: {
+        value:
+          "((MOCK_FIELD = 'alpha' AND MOCK_FIELD = 'beta') AND (MOCK_FIELD = 'gamma' OR MOCK_NUMBER != 5) AND (MOCK_FIELD = 'gamma' AND MOCK_NUMBER != 8))",
+      },
+    });
+
+    await waitFor(() =>
+      expect(onChange).toHaveBeenLastCalledWith([
+        {
+          type: 'GROUP',
+          value: 'AND',
+          isNegated: false,
+          children: [
+            {
+              type: 'GROUP',
+              value: 'AND',
+              isNegated: false,
+              children: [
+                {
+                  field: 'MOCK_FIELD',
+                  value: 'alpha',
+                  operator: 'EQUAL',
+                  readOnly: {
+                    enabled: true,
+                    targets: ['field', 'operator'],
+                  },
+                },
+                {
+                  field: 'MOCK_FIELD',
+                  value: 'beta',
+                  operator: 'EQUAL',
+                },
+              ],
+            },
+            {
+              type: 'GROUP',
+              value: 'OR',
+              isNegated: false,
+              children: [
+                {
+                  field: 'MOCK_FIELD',
+                  value: 'gamma',
+                  operator: 'EQUAL',
+                },
+                {
+                  field: 'MOCK_NUMBER',
+                  value: 5,
+                  operator: 'NOT_EQUAL',
+                },
+              ],
+            },
+            {
+              type: 'GROUP',
+              value: 'AND',
+              isNegated: false,
+              children: [
+                {
+                  field: 'MOCK_FIELD',
+                  value: 'gamma',
+                  operator: 'EQUAL',
+                  readOnly: true,
+                },
+                {
+                  field: 'MOCK_NUMBER',
+                  value: 8,
+                  operator: 'NOT_EQUAL',
+                },
+              ],
+            },
+          ],
+        },
+      ])
+    );
+
+    expect(queryByDataTest(container, 'CustomTextModeEditorError')).toBeNull();
   });
 
   it('allows deleting a group with a read-only descendant in text mode when readOnlyProtectsDelete is false', async () => {
@@ -1753,6 +1974,55 @@ describe('#components/Builder', () => {
         canRedo: true,
       });
     });
+  });
+
+  it('Keeps exact local spacing for valid text-mode edits after a combinator', async () => {
+    const onChange = jest.fn();
+    const { container } = render(
+      <Builder
+        fields={fields}
+        data={[
+          {
+            type: 'GROUP',
+            value: 'AND',
+            isNegated: false,
+            children: [
+              { field: 'MOCK_FIELD', value: 'alpha', operator: 'EQUAL' },
+              { field: 'MOCK_NUMBER', value: 2, operator: 'EQUAL' },
+            ],
+          },
+        ]}
+        textMode
+        defaultMode="text"
+        components={{
+          ...defaultComponents,
+          TextModeEditor: CustomTextModeEditor,
+        }}
+        onChange={onChange}
+      />
+    );
+
+    fireEvent.change(getByDataTest(container, 'CustomTextModeEditorInput'), {
+      target: { value: "(MOCK_FIELD = 'alpha' AND  MOCK_NUMBER = 3)" },
+    });
+
+    await waitFor(() =>
+      expect(onChange).toHaveBeenLastCalledWith([
+        {
+          type: 'GROUP',
+          value: 'AND',
+          isNegated: false,
+          children: [
+            { field: 'MOCK_FIELD', value: 'alpha', operator: 'EQUAL' },
+            { field: 'MOCK_NUMBER', value: 3, operator: 'EQUAL' },
+          ],
+        },
+      ])
+    );
+
+    expect(getByDataTest(container, 'CustomTextModeEditorInput')).toHaveValue(
+      "(MOCK_FIELD = 'alpha' AND  MOCK_NUMBER = 3)"
+    );
   });
 
   it('Clones a rule directly below the original rule', () => {

--- a/src/builder/builder.tsx
+++ b/src/builder/builder.tsx
@@ -135,6 +135,7 @@ export const Builder = forwardRef<IBuilderRef, IBuilderProps>(({
   const [textDiagnostics, setTextDiagnostics] = useState<
     ReturnType<typeof parseBuilderSqlText>['diagnostics']
   >([]);
+  const pendingLocalTextValue = useRef<string | null>(null);
   const lastEmittedData = useRef<DenormalizedQuery | null>(null);
   const pendingChangeData = useRef<NormalizedQuery | null>(null);
   const fieldOptionsStoreRef = useRef<ReturnType<typeof createBuilderFieldOptionsStore>>();
@@ -584,6 +585,15 @@ export const Builder = forwardRef<IBuilderRef, IBuilderProps>(({
 
   useEffect(() => {
     if (!textModeEnabled) {
+      pendingLocalTextValue.current = null;
+      return;
+    }
+
+    if (mode === 'text' && pendingLocalTextValue.current !== null) {
+      setTextValue(pendingLocalTextValue.current);
+      setTextDiagnostics([]);
+      setTextErrorMessage(null);
+      pendingLocalTextValue.current = null;
       return;
     }
 
@@ -599,7 +609,7 @@ export const Builder = forwardRef<IBuilderRef, IBuilderProps>(({
     setTextProtectedRanges(nextTextState.protectedRanges);
     setTextDiagnostics([]);
     setTextErrorMessage(null);
-  }, [data, fields, textModeEnabled]);
+  }, [data, fields, mode, textModeEnabled]);
 
   const handleAddRootGroup = useCallback(() => {
     dispatchAction(
@@ -696,14 +706,7 @@ export const Builder = forwardRef<IBuilderRef, IBuilderProps>(({
             : null
         );
 
-        if (readOnlyTargetDiagnostic) {
-          setTextValue(textValue);
-          setTextProtectedRanges((currentProtectedRanges) => [
-            ...currentProtectedRanges,
-          ]);
-        }
-
-        if (readOnlyNegationDiagnostic) {
+        if (readOnlyTargetDiagnostic || readOnlyNegationDiagnostic) {
           setTextProtectedRanges((currentProtectedRanges) => [
             ...currentProtectedRanges,
           ]);
@@ -728,6 +731,7 @@ export const Builder = forwardRef<IBuilderRef, IBuilderProps>(({
         rootGroupType,
         singleRootGroup
       );
+      pendingLocalTextValue.current = nextText;
       commitData(createReplaceQueryAction(nextData));
     },
     [
@@ -737,7 +741,6 @@ export const Builder = forwardRef<IBuilderRef, IBuilderProps>(({
       rootGroupType,
       singleRootGroup,
       strings.textMode,
-      textValue,
     ]
   );
 

--- a/src/builder/text-mode/utils/find-read-only-target-diagnostic.util.test.ts
+++ b/src/builder/text-mode/utils/find-read-only-target-diagnostic.util.test.ts
@@ -1,0 +1,212 @@
+import { DenormalizedQuery } from '../../../utils/query-tree';
+import { findReadOnlyTargetDiagnostic } from './find-read-only-target-diagnostic.util';
+
+describe('findReadOnlyTargetDiagnostic', () => {
+  it('allows adding another rule with the same locked field and operator in a demo-like query', () => {
+    const previousQuery: DenormalizedQuery = [
+      {
+        type: 'GROUP',
+        value: 'AND',
+        isNegated: false,
+        children: [
+          {
+            field: 'CUSTOMER_COUNTRY',
+            operator: 'EQUAL',
+            value: 'CZ',
+            readOnly: {
+              enabled: true,
+              targets: ['operator', 'field'],
+            },
+          },
+          {
+            type: 'GROUP',
+            value: 'OR',
+            isNegated: false,
+            children: [
+              {
+                field: 'CUSTOMER_CITY',
+                operator: 'EQUAL',
+                value: 'Prague',
+              },
+              {
+                field: 'ORDER_TOTAL',
+                operator: 'BETWEEN',
+                value: [2500, 12000],
+              },
+            ],
+          },
+          {
+            type: 'GROUP',
+            value: 'AND',
+            isNegated: false,
+            children: [
+              {
+                field: 'CUSTOMER_CITY',
+                operator: 'EQUAL',
+                value: 'Prague',
+                readOnly: true,
+              },
+              {
+                field: 'ORDER_TOTAL',
+                operator: 'BETWEEN',
+                value: [2500, 12000],
+              },
+            ],
+          },
+          {
+            type: 'GROUP',
+            value: 'AND',
+            isNegated: false,
+            readOnly: {
+              enabled: true,
+              inheritToChildren: true,
+            },
+            children: [
+              {
+                field: 'IS_VAT_PAYER',
+                operator: 'EQUAL',
+                value: true,
+              },
+              {
+                field: 'CUSTOMER_SEGMENTS',
+                operator: 'ALL_IN',
+                value: ['B2B', 'Priority'],
+              },
+            ],
+          },
+        ],
+      },
+    ];
+
+    const nextQuery: DenormalizedQuery = [
+      {
+        type: 'GROUP',
+        value: 'AND',
+        isNegated: false,
+        children: [
+          {
+            field: 'CUSTOMER_COUNTRY',
+            operator: 'EQUAL',
+            value: 'CZ',
+          },
+          {
+            field: 'CUSTOMER_CITY',
+            operator: 'EQUAL',
+            value: 'Brno',
+          },
+          {
+            field: 'CUSTOMER_COUNTRY',
+            operator: 'EQUAL',
+            value: 'SK',
+          },
+          {
+            type: 'GROUP',
+            value: 'OR',
+            isNegated: false,
+            children: [
+              {
+                field: 'CUSTOMER_CITY',
+                operator: 'EQUAL',
+                value: 'Prague',
+              },
+              {
+                field: 'ORDER_TOTAL',
+                operator: 'BETWEEN',
+                value: [2500, 12000],
+              },
+            ],
+          },
+          {
+            type: 'GROUP',
+            value: 'AND',
+            isNegated: false,
+            children: [
+              {
+                field: 'CUSTOMER_CITY',
+                operator: 'EQUAL',
+                value: 'Prague',
+              },
+              {
+                field: 'ORDER_TOTAL',
+                operator: 'BETWEEN',
+                value: [2500, 12000],
+              },
+            ],
+          },
+          {
+            type: 'GROUP',
+            value: 'AND',
+            isNegated: false,
+            children: [
+              {
+                field: 'IS_VAT_PAYER',
+                operator: 'EQUAL',
+                value: true,
+              },
+              {
+                field: 'CUSTOMER_SEGMENTS',
+                operator: 'ALL_IN',
+                value: ['B2B', 'Priority'],
+              },
+            ],
+          },
+        ],
+      },
+    ];
+
+    expect(findReadOnlyTargetDiagnostic(previousQuery, nextQuery)).toBeNull();
+  });
+
+  it('keeps a targeted lock attached to the original exact duplicate when the duplicate is inserted before it', () => {
+    const previousQuery: DenormalizedQuery = [
+      {
+        type: 'GROUP',
+        value: 'AND',
+        isNegated: false,
+        children: [
+          {
+            field: 'CUSTOMER_COUNTRY',
+            operator: 'EQUAL',
+            value: 'CZ',
+            readOnly: {
+              enabled: true,
+              targets: ['operator', 'field'],
+            },
+          },
+          {
+            field: 'ORDER_TOTAL',
+            operator: 'EQUAL',
+            value: 5,
+          },
+        ],
+      },
+    ];
+
+    const nextQuery: DenormalizedQuery = [
+      {
+        type: 'GROUP',
+        value: 'AND',
+        isNegated: false,
+        children: [
+          {
+            field: 'CUSTOMER_COUNTRY',
+            operator: 'EQUAL',
+            value: 'SK',
+          },
+          {
+            field: 'CUSTOMER_COUNTRY',
+            operator: 'EQUAL',
+            value: 'CZ',
+          },
+          {
+            field: 'ORDER_TOTAL',
+            operator: 'EQUAL',
+            value: 5,
+          },
+        ],
+      },
+    ];
+
+    expect(findReadOnlyTargetDiagnostic(previousQuery, nextQuery)).toBeNull();
+  });
+});

--- a/src/builder/text-mode/utils/match-read-only-nodes.util.ts
+++ b/src/builder/text-mode/utils/match-read-only-nodes.util.ts
@@ -20,6 +20,7 @@ export interface IReadOnlyNodeDescriptor {
   readOnly: DenormalizedNode['readOnly'];
   path: number[];
   parentPath: number[];
+  parentGroupFingerprint?: string;
 }
 
 export interface INodeCandidate {
@@ -28,6 +29,7 @@ export interface INodeCandidate {
   node: DenormalizedNode;
   path: number[];
   parentPath: number[];
+  parentGroupFingerprint?: string;
 }
 
 const normalizeLockFingerprintOperator = (
@@ -175,10 +177,36 @@ const findUniqueGlobalCandidate = (
   return matchingCandidates.length === 1 ? matchingCandidates[0] : undefined;
 };
 
+const findCandidateByParentGroupFingerprint = (
+  descriptor: IReadOnlyNodeDescriptor,
+  candidates: INodeCandidate[],
+  usedCandidates: WeakSet<DenormalizedNode>,
+  matcher: (candidate: INodeCandidate) => boolean
+): INodeCandidate | undefined => {
+  if (!descriptor.parentGroupFingerprint) {
+    return undefined;
+  }
+
+  const matchingCandidates = candidates
+    .filter(
+      candidate =>
+        !usedCandidates.has(candidate.node) &&
+        candidate.parentGroupFingerprint === descriptor.parentGroupFingerprint &&
+        matcher(candidate)
+    )
+    .sort(
+      (left, right) =>
+        getSiblingDistance(descriptor, left) - getSiblingDistance(descriptor, right)
+    );
+
+  return matchingCandidates[0];
+};
+
 export const collectReadOnlyNodeDescriptors = (
   query: DenormalizedQuery,
   target: IReadOnlyNodeDescriptor[] = [],
-  parentPath: number[] = []
+  parentPath: number[] = [],
+  parentGroup?: DenormalizedGroupNode
 ): IReadOnlyNodeDescriptor[] => {
   query.forEach((node, index) => {
     const path = [...parentPath, index];
@@ -202,10 +230,13 @@ export const collectReadOnlyNodeDescriptors = (
           readOnly: node.readOnly,
           path,
           parentPath,
+          parentGroupFingerprint: parentGroup
+            ? createExactFingerprint(parentGroup)
+            : undefined,
         });
       }
 
-      collectReadOnlyNodeDescriptors(node.children, target, path);
+      collectReadOnlyNodeDescriptors(node.children, target, path, node);
       return;
     }
 
@@ -223,6 +254,9 @@ export const collectReadOnlyNodeDescriptors = (
         readOnly: ruleNode.readOnly,
         path,
         parentPath,
+        parentGroupFingerprint: parentGroup
+          ? createExactFingerprint(parentGroup)
+          : undefined,
       });
     }
   });
@@ -237,7 +271,8 @@ export const collectReadOnlyNodeCandidates = (
     'group-all': [],
     'group-self': [],
   },
-  parentPath: number[] = []
+  parentPath: number[] = [],
+  parentGroup?: DenormalizedGroupNode
 ): Record<IReadOnlyNodeDescriptor['kind'], INodeCandidate[]> => {
   query.forEach((node, index) => {
     const path = [...parentPath, index];
@@ -249,6 +284,9 @@ export const collectReadOnlyNodeCandidates = (
         node,
         path,
         parentPath,
+        parentGroupFingerprint: parentGroup
+          ? createExactFingerprint(parentGroup)
+          : undefined,
       });
       candidates['group-self'].push({
         kind: 'group-self',
@@ -256,8 +294,11 @@ export const collectReadOnlyNodeCandidates = (
         node,
         path,
         parentPath,
+        parentGroupFingerprint: parentGroup
+          ? createExactFingerprint(parentGroup)
+          : undefined,
       });
-      collectReadOnlyNodeCandidates(node.children, candidates, path);
+      collectReadOnlyNodeCandidates(node.children, candidates, path, node);
       return;
     }
 
@@ -267,6 +308,9 @@ export const collectReadOnlyNodeCandidates = (
       node,
       path,
       parentPath,
+      parentGroupFingerprint: parentGroup
+        ? createExactFingerprint(parentGroup)
+        : undefined,
     });
   });
 
@@ -284,6 +328,12 @@ export const matchReadOnlyDescriptorToCandidate = (
     usedCandidates,
     candidate => candidate.fingerprint === descriptor.fingerprint
   ) ||
+  findCandidateByParentGroupFingerprint(
+    descriptor,
+    candidatePool,
+    usedCandidates,
+    candidate => candidate.fingerprint === descriptor.fingerprint
+  ) ||
   findUniqueGlobalCandidate(
     candidatePool,
     usedCandidates,
@@ -291,6 +341,22 @@ export const matchReadOnlyDescriptorToCandidate = (
   ) ||
   (descriptor.relaxedFingerprint
     ? findCandidate(
+        descriptor,
+        candidatePool,
+        usedCandidates,
+        candidate => {
+          const relaxedFingerprint =
+            descriptor.kind === 'rule'
+              ? getRuleCandidateRelaxedFingerprint(candidate.node, descriptor.readOnly)
+              : getGroupCandidateRelaxedFingerprint(
+                  candidate.node as DenormalizedGroupNode,
+                  descriptor.readOnly
+                );
+
+          return relaxedFingerprint === descriptor.relaxedFingerprint;
+        }
+      )
+    || findCandidateByParentGroupFingerprint(
         descriptor,
         candidatePool,
         usedCandidates,

--- a/src/monaco/components/monaco-text-mode-editor.test.tsx
+++ b/src/monaco/components/monaco-text-mode-editor.test.tsx
@@ -15,18 +15,30 @@ type IMonacoDecoration = {
   };
 };
 
+type ISelectionPosition = {
+  lineNumber: number;
+  column: number;
+};
+
 jest.mock('monaco-editor', () => {
   let currentValue = '';
   let changeListener:
     | ((event: { changes: IMonacoChange[] }) => void)
     | null = null;
   let lastDecorations: IMonacoDecoration[] = [];
+  let currentSelections = [
+    {
+      getStartPosition: () => ({ lineNumber: 1, column: 1 }),
+      getEndPosition: () => ({ lineNumber: 1, column: 1 }),
+    },
+  ];
 
   const model = {
     getPositionAt: (offset: number) => ({
       lineNumber: 1,
       column: offset + 1,
     }),
+    getOffsetAt: (position: ISelectionPosition) => position.column - 1,
     getValue: () => currentValue,
   };
 
@@ -36,6 +48,10 @@ jest.mock('monaco-editor', () => {
       currentValue = nextValue;
     },
     getModel: () => model,
+    getSelections: () => currentSelections,
+    setSelections: jest.fn((nextSelections: typeof currentSelections) => {
+      currentSelections = nextSelections;
+    }),
     onDidChangeModelContent: (
       listener: (event: { changes: IMonacoChange[] }) => void
     ) => {
@@ -67,6 +83,38 @@ jest.mock('monaco-editor', () => {
     editor: {
       create,
     },
+    Selection: class {
+      startLineNumber: number;
+      startColumn: number;
+      endLineNumber: number;
+      endColumn: number;
+
+      constructor(
+        startLineNumber: number,
+        startColumn: number,
+        endLineNumber: number,
+        endColumn: number
+      ) {
+        this.startLineNumber = startLineNumber;
+        this.startColumn = startColumn;
+        this.endLineNumber = endLineNumber;
+        this.endColumn = endColumn;
+      }
+
+      getStartPosition() {
+        return {
+          lineNumber: this.startLineNumber,
+          column: this.startColumn,
+        };
+      }
+
+      getEndPosition() {
+        return {
+          lineNumber: this.endLineNumber,
+          column: this.endColumn,
+        };
+      }
+    },
     Range: class {
       startLineNumber: number;
       startColumn: number;
@@ -88,17 +136,42 @@ jest.mock('monaco-editor', () => {
     __mock: {
       getCurrentValue: () => currentValue,
       getLastDecorations: () => lastDecorations,
+      getSelections: () => currentSelections,
       emitChange: (nextValue: string, changes: IMonacoChange[]) => {
         currentValue = nextValue;
+        const lastChange = changes[changes.length - 1];
+
+        if (lastChange) {
+          const nextColumn =
+            lastChange.rangeOffset + lastChange.text.length + 1;
+
+          currentSelections = [
+            {
+              getStartPosition: () => ({ lineNumber: 1, column: nextColumn }),
+              getEndPosition: () => ({ lineNumber: 1, column: nextColumn }),
+            },
+          ];
+        }
+
         changeListener?.({ changes });
+      },
+      setSelections: (nextSelections: typeof currentSelections) => {
+        currentSelections = nextSelections;
       },
       reset: () => {
         currentValue = '';
         changeListener = null;
         lastDecorations = [];
+        currentSelections = [
+          {
+            getStartPosition: () => ({ lineNumber: 1, column: 1 }),
+            getEndPosition: () => ({ lineNumber: 1, column: 1 }),
+          },
+        ];
         create.mockClear();
         editorInstance.updateOptions.mockClear();
         editorInstance.deltaDecorations.mockClear();
+        editorInstance.setSelections.mockClear();
         editorInstance.dispose.mockClear();
       },
     },
@@ -110,7 +183,17 @@ const getMonacoMock = () =>
     __mock: {
       getCurrentValue: () => string;
       getLastDecorations: () => IMonacoDecoration[];
+      getSelections: () => Array<{
+        getStartPosition: () => ISelectionPosition;
+        getEndPosition: () => ISelectionPosition;
+      }>;
       emitChange: (nextValue: string, changes: IMonacoChange[]) => void;
+      setSelections: (
+        nextSelections: Array<{
+          getStartPosition: () => ISelectionPosition;
+          getEndPosition: () => ISelectionPosition;
+        }>
+      ) => void;
       reset: () => void;
     };
     editor: {
@@ -121,6 +204,10 @@ const getMonacoMock = () =>
 describe('MonacoTextModeEditor', () => {
   beforeEach(() => {
     getMonacoMock().reset();
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
   });
 
   it('restores the last accepted value and keeps protected decorations after a blocked delete', async () => {
@@ -179,6 +266,183 @@ describe('MonacoTextModeEditor', () => {
           )
       ).toHaveLength(4);
     });
+  });
+
+  it('restores the pre-change selection after a blocked edit', async () => {
+    const monacoMock = getMonacoMock();
+    const initialValue = "A AND (FIELD = 'alpha')";
+    const onChange = jest.fn();
+
+    render(
+      <MonacoTextModeEditor
+        value={initialValue}
+        diagnostics={[]}
+        errorMessage={null}
+        protectedRanges={[{ start: 6, end: initialValue.length }]}
+        onChange={onChange}
+      />
+    );
+
+    await waitFor(() => {
+      expect(monacoMock.getCurrentValue()).toBe(initialValue);
+    });
+
+    monacoMock.setSelections([
+      {
+        getStartPosition: () => ({ lineNumber: 1, column: 8 }),
+        getEndPosition: () => ({ lineNumber: 1, column: 8 }),
+      },
+    ]);
+
+    act(() => {
+      monacoMock.emitChange("A AND (XFIELD = 'alpha')", [
+        {
+          rangeOffset: 7,
+          rangeLength: 0,
+          text: 'X',
+        },
+      ]);
+    });
+
+    await waitFor(() => {
+      expect(onChange).not.toHaveBeenCalled();
+      expect(monacoMock.getCurrentValue()).toBe(initialValue);
+      expect(monacoMock.getSelections()[0].getStartPosition()).toEqual({
+        lineNumber: 1,
+        column: 8,
+      });
+    });
+  });
+
+  it('restores the pre-change selection after a parent-driven revert', async () => {
+    const monacoMock = getMonacoMock();
+    const initialValue = "A AND (FIELD = 'alpha')";
+
+    const ControlledEditor = () => {
+      const [value, setValue] = React.useState(initialValue);
+
+      return (
+        <MonacoTextModeEditor
+          value={value}
+          diagnostics={[]}
+          errorMessage={null}
+          protectedRanges={[{ start: 6, end: initialValue.length }]}
+          onChange={(nextValue) => {
+            setValue(nextValue);
+
+            setTimeout(() => {
+              setValue(initialValue);
+            }, 0);
+          }}
+        />
+      );
+    };
+
+    render(<ControlledEditor />);
+
+    await waitFor(() => {
+      expect(monacoMock.getCurrentValue()).toBe(initialValue);
+    });
+
+    monacoMock.setSelections([
+      {
+        getStartPosition: () => ({ lineNumber: 1, column: 6 }),
+        getEndPosition: () => ({ lineNumber: 1, column: 6 }),
+      },
+    ]);
+
+    act(() => {
+      monacoMock.emitChange("AX AND (FIELD = 'alpha')", [
+        {
+          rangeOffset: 5,
+          rangeLength: 0,
+          text: 'X',
+        },
+      ]);
+    });
+
+    await waitFor(() => {
+      expect(monacoMock.getCurrentValue()).toBe(initialValue);
+      expect(monacoMock.getSelections()[0].getStartPosition()).toEqual({
+        lineNumber: 1,
+        column: 6,
+      });
+    });
+  });
+
+  it('ignores stale controlled value echoes while newer local typing is present', async () => {
+    const monacoMock = getMonacoMock();
+    const initialValue = "A AND (FIELD = 'alpha')";
+    const firstLocalValue = "A AND  (FIELD = 'alpha')";
+    const secondLocalValue = "A AND X (FIELD = 'alpha')";
+    const onChange = jest.fn();
+
+    const { rerender } = render(
+      <MonacoTextModeEditor
+        value={initialValue}
+        diagnostics={[]}
+        errorMessage={null}
+        onChange={onChange}
+      />
+    );
+
+    await waitFor(() => {
+      expect(monacoMock.getCurrentValue()).toBe(initialValue);
+    });
+
+    act(() => {
+      monacoMock.emitChange(firstLocalValue, [
+        {
+          rangeOffset: 5,
+          rangeLength: 0,
+          text: ' ',
+        },
+      ]);
+      monacoMock.emitChange(secondLocalValue, [
+        {
+          rangeOffset: 6,
+          rangeLength: 0,
+          text: 'X',
+        },
+      ]);
+    });
+
+    expect(monacoMock.getCurrentValue()).toBe(secondLocalValue);
+    expect(onChange).toHaveBeenNthCalledWith(1, firstLocalValue);
+    expect(onChange).toHaveBeenNthCalledWith(2, secondLocalValue);
+
+    rerender(
+      <MonacoTextModeEditor
+        value={initialValue}
+        diagnostics={[]}
+        errorMessage={null}
+        onChange={onChange}
+      />
+    );
+
+    expect(monacoMock.getCurrentValue()).toBe(secondLocalValue);
+
+    rerender(
+      <MonacoTextModeEditor
+        value={firstLocalValue}
+        diagnostics={[]}
+        errorMessage={null}
+        onChange={onChange}
+      />
+    );
+
+    expect(monacoMock.getCurrentValue()).toBe(secondLocalValue);
+
+    rerender(
+      <MonacoTextModeEditor
+        value={secondLocalValue}
+        diagnostics={[]}
+        errorMessage={null}
+        onChange={onChange}
+      />
+    );
+
+    expect(monacoMock.getCurrentValue()).toBe(secondLocalValue);
   });
 
   it('emits valid unlocked edits and updates protected decorations from the shifted ranges', async () => {

--- a/src/monaco/components/monaco-text-mode-editor.tsx
+++ b/src/monaco/components/monaco-text-mode-editor.tsx
@@ -8,6 +8,7 @@ import { IThemeProps } from '../../theme-provider/theme-provider';
 import { createMonacoRangeFromOffsets } from '../utils/create-monaco-range-from-offsets';
 import { createMonacoDiagnosticDecoration } from '../utils/create-monaco-diagnostic-decoration';
 import { doesChangeIntersectProtectedRanges } from '../utils/does-change-intersect-protected-ranges';
+import { restoreSelectionsBeforeChange } from '../utils/restore-selection-before-change';
 import { updateProtectedRangesAfterChange } from '../utils/update-protected-ranges-after-change';
 
 const EditorRoot = styled.div`
@@ -90,10 +91,22 @@ const ErrorMessage = styled.div<{ $theme: Required<IThemeProps> }>`
   font-size: 0.8rem;
 `;
 
+const EMPTY_PROTECTED_RANGES: ITextModeProtectedRange[] = [];
+
+const areProtectedRangesEqual = (
+  left: ITextModeProtectedRange[],
+  right: ITextModeProtectedRange[]
+): boolean =>
+  left.length === right.length &&
+  left.every(
+    (range, index) =>
+      range.start === right[index]?.start && range.end === right[index]?.end
+  );
+
 export const MonacoTextModeEditor: FC<ITextModeEditorProps> = ({
   value,
   diagnostics,
-  protectedRanges = [],
+  protectedRanges = EMPTY_PROTECTED_RANGES,
   protectedRangeHoverMessage = null,
   errorMessage,
   readOnly = false,
@@ -108,6 +121,9 @@ export const MonacoTextModeEditor: FC<ITextModeEditorProps> = ({
   const onChangeRef = useRef(onChange);
   const isSyncingValueRef = useRef(false);
   const isRevertingChangeRef = useRef(false);
+  const pendingSelectionRestoreRef = useRef<Monaco.Selection[] | null>(null);
+  const pendingSelectionRestoreValueRef = useRef<string | null>(null);
+  const pendingEchoValuesRef = useRef<string[]>([]);
   const decorationIdsRef = useRef<string[]>([]);
   const protectedRangesRef = useRef<ITextModeProtectedRange[]>(protectedRanges);
   const acceptedValueRef = useRef(value);
@@ -172,6 +188,18 @@ export const MonacoTextModeEditor: FC<ITextModeEditorProps> = ({
           return;
         }
 
+        const monaco = monacoRef.current;
+        const currentSelections = editor.getSelections();
+        const restoredSelections =
+          monaco && currentSelections && currentSelections.length > 0
+            ? restoreSelectionsBeforeChange(
+                currentSelections,
+                event.changes,
+                model,
+                monaco
+              )
+            : null;
+
         const intersectsProtectedRange = event.changes.some(change =>
           doesChangeIntersectProtectedRanges(change, protectedRangesRef.current, {
             allowPureDeletionOfProtectedRanges: allowProtectedRangeDeletion,
@@ -186,8 +214,14 @@ export const MonacoTextModeEditor: FC<ITextModeEditorProps> = ({
 
           isRevertingChangeRef.current = true;
           editor.setValue(acceptedValueRef.current);
+          if (restoredSelections && restoredSelections.length > 0) {
+            editor.setSelections(restoredSelections);
+          }
           protectedRangesRef.current = restoredProtectedRanges;
           setRenderedProtectedRanges(restoredProtectedRanges);
+          pendingSelectionRestoreRef.current = null;
+          pendingSelectionRestoreValueRef.current = null;
+          pendingEchoValuesRef.current = [];
           isRevertingChangeRef.current = false;
           return;
         }
@@ -197,6 +231,17 @@ export const MonacoTextModeEditor: FC<ITextModeEditorProps> = ({
           protectedRangesRef.current
         );
         setRenderedProtectedRanges(protectedRangesRef.current);
+        pendingSelectionRestoreRef.current = restoredSelections;
+        pendingSelectionRestoreValueRef.current = model.getValue();
+        if (
+          pendingEchoValuesRef.current[pendingEchoValuesRef.current.length - 1] !==
+          model.getValue()
+        ) {
+          pendingEchoValuesRef.current = [
+            ...pendingEchoValuesRef.current,
+            model.getValue(),
+          ];
+        }
 
         onChangeRef.current(model.getValue());
       });
@@ -221,6 +266,10 @@ export const MonacoTextModeEditor: FC<ITextModeEditorProps> = ({
   useEffect(() => {
     const nextProtectedRanges = [...protectedRanges];
 
+    if (areProtectedRangesEqual(acceptedProtectedRangesRef.current, nextProtectedRanges)) {
+      return;
+    }
+
     protectedRangesRef.current = nextProtectedRanges;
     acceptedProtectedRangesRef.current = nextProtectedRanges;
     setRenderedProtectedRanges(nextProtectedRanges);
@@ -240,16 +289,59 @@ export const MonacoTextModeEditor: FC<ITextModeEditorProps> = ({
     }
 
     const currentValue = editorRef.current.getValue();
+    const pendingEchoIndex = pendingEchoValuesRef.current.indexOf(value);
 
     if (currentValue === value) {
       acceptedValueRef.current = value;
+      if (pendingEchoIndex !== -1) {
+        pendingEchoValuesRef.current = pendingEchoValuesRef.current.slice(
+          pendingEchoIndex + 1
+        );
+      }
+
+      if (pendingSelectionRestoreValueRef.current !== value) {
+        pendingSelectionRestoreRef.current = null;
+        pendingSelectionRestoreValueRef.current = null;
+      }
+
       return;
+    }
+
+    if (
+      pendingEchoValuesRef.current.length > 0 &&
+      value === acceptedValueRef.current
+    ) {
+      return;
+    }
+
+    if (pendingEchoIndex !== -1) {
+      const hasNewerPendingEcho =
+        pendingEchoIndex < pendingEchoValuesRef.current.length - 1;
+
+      pendingEchoValuesRef.current = pendingEchoValuesRef.current.slice(
+        pendingEchoIndex + 1
+      );
+
+      if (hasNewerPendingEcho) {
+        return;
+      }
     }
 
     isSyncingValueRef.current = true;
     editorRef.current.setValue(value);
+    protectedRangesRef.current = [...acceptedProtectedRangesRef.current];
+    setRenderedProtectedRanges(protectedRangesRef.current);
+    if (
+      pendingSelectionRestoreRef.current &&
+      pendingSelectionRestoreRef.current.length > 0
+    ) {
+      editorRef.current.setSelections(pendingSelectionRestoreRef.current);
+    }
     isSyncingValueRef.current = false;
     acceptedValueRef.current = value;
+    pendingSelectionRestoreRef.current = null;
+    pendingSelectionRestoreValueRef.current = null;
+    pendingEchoValuesRef.current = [];
   }, [value]);
 
   useEffect(() => {

--- a/src/monaco/utils/restore-selection-before-change.ts
+++ b/src/monaco/utils/restore-selection-before-change.ts
@@ -1,0 +1,75 @@
+import type * as Monaco from 'monaco-editor';
+
+interface ITextModelChangeLike {
+  rangeOffset: number;
+  rangeLength: number;
+  text: string;
+}
+
+interface IResolvedChange extends ITextModelChangeLike {
+  postStart: number;
+  postEnd: number;
+}
+
+const resolveChanges = (
+  changes: ITextModelChangeLike[]
+): IResolvedChange[] => {
+  const sortedChanges = [...changes].sort(
+    (left, right) => left.rangeOffset - right.rangeOffset
+  );
+  let delta = 0;
+
+  return sortedChanges.map((change) => {
+    const postStart = change.rangeOffset + delta;
+    const postEnd = postStart + change.text.length;
+
+    delta += change.text.length - change.rangeLength;
+
+    return {
+      ...change,
+      postStart,
+      postEnd,
+    };
+  });
+};
+
+const restoreOffsetBeforeChange = (
+  offset: number,
+  changes: IResolvedChange[]
+): number =>
+  [...changes].reverse().reduce((restoredOffset, change) => {
+    if (restoredOffset < change.postStart) {
+      return restoredOffset;
+    }
+
+    if (restoredOffset <= change.postEnd) {
+      return change.rangeOffset;
+    }
+
+    return restoredOffset + change.rangeLength - change.text.length;
+  }, offset);
+
+export const restoreSelectionsBeforeChange = (
+  selections: Monaco.Selection[],
+  changes: ITextModelChangeLike[],
+  model: Monaco.editor.ITextModel,
+  monaco: typeof Monaco
+): Monaco.Selection[] => {
+  const resolvedChanges = resolveChanges(changes);
+
+  return selections.map((selection) => {
+    const selectionStart = model.getOffsetAt(selection.getStartPosition());
+    const selectionEnd = model.getOffsetAt(selection.getEndPosition());
+    const restoredStart = restoreOffsetBeforeChange(selectionStart, resolvedChanges);
+    const restoredEnd = restoreOffsetBeforeChange(selectionEnd, resolvedChanges);
+    const restoredStartPosition = model.getPositionAt(restoredStart);
+    const restoredEndPosition = model.getPositionAt(restoredEnd);
+
+    return new monaco.Selection(
+      restoredStartPosition.lineNumber,
+      restoredStartPosition.column,
+      restoredEndPosition.lineNumber,
+      restoredEndPosition.column
+    );
+  });
+};


### PR DESCRIPTION
- Losened strictness of text editor by allowing double spaces in valid editor state and cursor jumps in case state became invalid
- Fixed persistence and matching of protected ranges

#130