### PR TITLE
feat: Added field-to-field comparisons and documented support

### DIFF
--- a/.codex/AGENTS.md
+++ b/.codex/AGENTS.md
@@ -1,7 +1,141 @@
 Long-running tooling (tests, docker compose, migrations, etc.) must always be invoked with sensible timeouts or in non-interactive batch mode. Never leave a shell command waiting indefinitely—prefer explicit timeouts, scripted runs, or log polling after the command exits.
 
-Prefer arrow functions over function statements. Make sure each file contains exactly one function, one react component or set of constants that are related.
+<!--
+# Repository structure
 
-If pattern is react component, function is tied to one or two interfaces or one or two styled components, they can be in one file. Once the file becomes too complex, prefer splitting types into ./types folder relative to the component or move styled components to ./components folder relative to the component.
+Over time, repository structure should turn into following. Follow this only when specifically instructed to do wider refactoring, otherwise stick to the structure that currently exists
 
-Utility functions should be always suffixed with .util.(ts|tsx).
+```
+src/
+  __mocks__/
+  constants/
+  hooks/
+  utils/
+  adapters/
+    antd/
+      shared/
+        ...
+    mui/
+    mantine/
+    radix/
+    fluentui/
+    bootstrap/
+  formatters/
+    query-formats/
+    parse-query/
+    format-query/
+  text-editor/
+    monaco/
+  builder/
+    utils/
+      history/ // moved from the root level
+    components/
+      field-control/ // originally root level widgets
+      rule/
+      group/
+      alert.tsx // root level components should be moved under a builder if that is where they logically belong
+      button.tsx
+      ...
+    utils/
+    hooks/
+    types/
+    text-mode/
+    constants/
+  index.ts
+```
+-->
+
+## Editing tools
+
+- Do not use `apply_patch` in this repository. It is consistently blocked in the current environment.
+- Use a working alternative for file edits instead, preferably PowerShell-based edits via `shell_command` such as `Set-Content` or other safe scripted file updates.
+- Before overwriting a file, read the current contents first and keep the change scoped to the task at hand.
+
+# File names and placement
+
+
+- Utility files should be always suffixed with `*.util.(ts|tsx)`
+- Interfaces should be prefixed with `I` in the interface name
+- Enums should be suffixed with `*-enum.ts`
+- Types should have no suffix
+- Types, interfaces, enums, utility functions, components and so on should not be mixed together in one folder as a flat structure
+- File placement into top-level `utils/`, `types/`, `hooks/`, `constants/` is allowed if these are either shared or serve top level files themselves
+- Slice-local `types/`, `utils/`, `hooks`, `components` and `constants/` folders are allowed when they serve one concrete slice and contain actual code owned by that slice. Do not create empty or speculative local folders.
+- Prefer granular and colocated files over catch-all files such as `types.ts`, `constants.ts`, or `helpers.ts`
+- Do not introduce new catch-all files such as `types.ts`, `constants.ts`, or `helpers.ts` unless explicitly instructed
+- Do not refactor existing catch-all files such as `types.ts`, `constants.ts`, or `helpers.ts` just to enforce this rule unless explicitly instructed
+
+## Naming Conventions
+
+Use `kebab-case` for:
+
+- folders
+- files
+
+### Architecture
+
+- Use a structure that is readable and explicit for long-term readability and maintainability
+- Prefer one function / type / interface per file. Where content belongs to the same logical category (like API functions), it can be grouped into one file
+
+  For example component that has one interface / type / enum / constant (that are not shared) and one styled component tied to it can be placed in one file, together with the component
+  Utility function and one interface / type / enum / constant can be placed together in one file if they themselves are not shared
+  Two or more utility functions should never be placed together in one file
+  Two or more components should never be placed together in one file
+  Two or more interfaces / enums / types / constants should never be placed together in one file
+
+- Prefer arrow functions over function statements where `this` context is not needed
+- Keep tasks small and committable
+- Each code addition or refactor should be tested
+
+## Sub-agents
+
+Define and use these two sub-agents from now on.
+
+### Planning agent
+
+Use before implementation begins and again whenever scope changes materially.
+
+Responsibilities:
+
+- Validates the task against AGENTS.md and to any related task list if it exists for that given task
+- Larger tasks should be written into `./codex/{task-name}-tasks.md` for easier task tracking and better observability
+- Identifies the implementation scope and calls out what is in scope vs out of scope
+- Identifies edge cases, affected areas, migration impact, API impact, and test needs
+- Prefers incremental refactoring and the minimum structural change needed for the current task
+- Flags any conflict with service boundaries, placement rules, naming rules, or the current task checklist
+- Does not write code
+
+Expected output:
+
+- A short implementation brief
+- A list of constraints pulled from the repo guidance
+- A concrete test checklist for the task
+- Any open risks or assumptions that should be resolved before coding
+
+### Code review agent
+
+Use after implementation and before considering the task complete.
+
+Responsibilities:
+
+- Reviews the diff, not just the final file contents
+- Checks whether naming, placement, ownership, and service-boundary rules from AGENTS.md are followed
+- Checks for obvious anti-patterns, misplaced abstractions, overly broad refactors, and Encore/business-logic leakage
+- Checks whether tests are sufficient for the behavior and edge cases introduced by the change
+- Checks whether migrations are additive and whether existing migration history was preserved
+- Calls out any mismatch between the implemented change and the agreed implementation scope
+
+Expected output:
+
+- Findings first, ordered by severity
+- Explicit note when no issues are found
+- Residual risks or missing tests, if any
+
+Operating rule:
+
+- Do not skip the planning agent for non-trivial work (trivial task could be fixing typo, small styles fix / addition, unused file / folder deletion, minor or patch dependency update that does not bring any breaking changes)
+- Do not skip the code review agent after implementation
+
+
+
+

--- a/.codex/field-to-field-phase1-tasks.md
+++ b/.codex/field-to-field-phase1-tasks.md
@@ -1,0 +1,56 @@
+# Field-To-Field Phase 1 Tasks
+
+1. Completed: establish the canonical rule model for literal vs field-reference comparisons, including defaults, equality semantics, nearest-field snapshots, and field-change payload plumbing.
+2. Completed: add visual builder support for field-to-field comparisons, including a value-source selector, compatible target-field selection, and validation/rendering updates for field-reference rules.
+3. Completed for the Phase 1 SQL-backed slice: translate directly expressible field-to-field comparisons through the SQL parser, SQL formatter, and SQL text mode flows shared by both the built-in text editor and Monaco-backed text mode.
+4. Completed: clean up the broader `src/builder/builder.test.tsx` TypeScript fallout from the normalized-rule union change introduced in Task 1 so the full builder suite compiles cleanly again.
+5. Completed: extend field-to-field translation beyond the current SQL-backed slice, including non-SQL parsers/formatters and any operator-specific cases that are natively representable without inventing backend-only syntax.
+   - Completed slice: OData scalar field-to-field support for `eq`, `ne`, `gt`, `ge`, `lt`, and `le`, including formatter output, parser round-tripping, and inferred target fields.
+   - Completed slice: AQL scalar field-to-field support for `==`, `!=`, `>`, `>=`, `<`, and `<=`, including formatter output, parser round-tripping, inferred target fields, and collapse guards for range folding.
+   - Completed slice: CEL scalar field-to-field support for `==`, `!=`, `>`, `>=`, `<`, and `<=`, including formatter output, parser round-tripping, inferred target fields, and collapse guards for range folding.
+   - Completed slice: Dynamo scalar field-to-field support for `=`, `<>`, `>`, `>=`, `<`, and `<=`, including formatter output, parser round-tripping, inferred target fields, and collapse guards for not-between folding.
+   - Completed slice: Prisma scalar field-to-field support for `equals`, `not`, `gt`, `gte`, `lt`, and `lte`, using a JSON `$ref` field-reference sentinel, with formatter output, parser round-tripping, inferred target fields, and collapse guards for range folding.
+   - Completed slice: JsonLogic scalar field-to-field support for `==`, `!=`, `>`, `>=`, `<`, and `<=`, using native `var` references on the right-hand side, with formatter output, parser round-tripping, inferred target fields, and range-collapse guards.
+   - Completed slice: SpEL scalar field-to-field support for `==`, `!=`, `>`, `>=`, `<`, and `<=`, using native RHS field identifiers, with formatter output, parser round-tripping, inferred target fields, and range-collapse guards.
+   - Completed slice: JSONata scalar field-to-field support for `=`, `!=`, `>`, `>=`, `<`, and `<=`, using native RHS field identifiers, with formatter output, parser round-tripping, inferred target fields, range-collapse guards, and explicit rejection of computed RHS expressions outside the builder model.
+   - Completed slice: Mongo scalar field-to-field support for `=`, `!=`, `>`, `>=`, `<`, and `<=`, using native `$expr` comparisons with field references on both sides, with formatter output, parser round-tripping, inferred target fields, and explicit rejection of `$expr` shapes outside the builder field-to-field model.
+   - Completed slice: Django scalar field-to-field support for `=`, `!=`, `>`, `>=`, `<`, and `<=`, using native RHS `F()` references, with formatter output, parser round-tripping, inferred target fields, and range-collapse guards.
+   - Completed slice: native field-to-field string-method support for CEL, OData, and Django where the RHS can be passed directly as a field reference without synthesizing computed expressions.
+   - Completed hardening: broader Mongo `$expr` negative-path coverage for invalid shapes such as unsupported operators, wrong operand counts, and multi-operator payloads.
+   - Phase 1 policy: do not invent custom backend-only field-to-field syntax for formats that do not natively support it. For those formats, skip field-to-field formatter support and fail parsing/validation clearly when field-to-field comparisons are encountered or requested. RSQL is explicitly in this category unless native support is identified.
+
+## Phase 2 Checklist
+
+- [x] Slice 1: add Builder-level `allowFieldComparisons?: boolean` with default `false`, thread it through Builder/context/validation/text-mode plumbing, and preserve recovery for preloaded `valueSource: 'field'` rules.
+- [x] Slice 2: extend field configuration with semantic field-comparison metadata via `fieldComparison?: { type?: 'string' | 'number' | 'date' | 'boolean'; comparableFields?: string[] }`.
+- [x] Slice 3: refactor field-comparison compatibility helpers to use semantic comparison types and source-owned allowlists instead of raw builder `type` equality.
+- [x] Slice 4: update Builder UI and widget mutation flows (`rule`, `field-select`, `operator-select`, `value-source-select`, `value-field-select`) to honor the new Builder flag and semantic compatibility rules.
+- [x] Slice 5: update Builder validation, Builder SQL text-mode semantic validation, Monaco diagnostics, and non-Monaco diagnostics to use the shared semantic field-comparison rules and distinct failure codes.
+- [x] Slice 6: expand demo/example coverage with opt-in Builder field comparisons, semantically compatible `LIST <-> TEXT` examples, additional numeric targets, and allowlist-restricted examples.
+- [x] Slice 7: broaden automated coverage for helper logic, widget transition behavior, Builder validation, text-mode diagnostics, and demo/build smoke coverage.
+- [x] Evaluate whether SpEL field-to-field string-method comparisons can be made to round-trip cleanly through the current parser layer without inventing non-native syntax.
+- [x] If SpEL string-method field references become round-trippable, add formatter support, parser support, inferred-field coverage, and builder/text-mode validation coverage for `contains`, `startsWith`, and `endsWith`.
+- [x] Add extra negative-path parser coverage for the new native string field-reference entry points in CEL, OData, and Django so unsupported shapes fail explicitly and stay guarded over time.
+- [x] Harden unsupported field-to-field handling for RSQL and Elasticsearch: formatter-side explicit throws for valueSource: 'field' rules, Elasticsearch parser rejection for unsupported object/non-scalar RHS shapes, and documented RSQL parser ambiguity where native syntax cannot distinguish bare string literals from hypothetical field references.
+- [ ] Re-evaluate any remaining format/operator combinations only if a direct native RHS field-reference shape is identified that fits the builder model without computed-expression synthesis.
+
+## Won't Implement Checklist
+
+- [x] Elasticsearch field-to-field support: requires script-query or runtime-field semantics rather than the native term/range/prefix/wildcard DSL shapes supported in this feature.
+- [x] RSQL field-to-field support via custom backend-only functions or invented syntax.
+- [x] AQL field-to-field string comparisons that would require wildcard or pattern synthesis instead of a direct native field reference on the RHS.
+- [x] Mongo field-to-field regex or pattern matching that would require computed regex-expression semantics beyond the builder model.
+- [x] Prisma field-to-field string filters that would require non-native or synthesized semantics beyond the current direct-reference model.
+- [x] Any other format/operator combination that cannot be represented as a native direct field-to-field comparison without backend-specific extensions or computed-expression synthesis.
+
+
+
+
+
+
+
+
+
+
+
+

--- a/README.md
+++ b/README.md
@@ -29,6 +29,10 @@ It also supports an optional SQL text mode for `Builder`, with built-in syntax
 and semantic validation, plus an optional Monaco-based advanced editor
 integration for protected locked ranges.
 
+Field-to-field comparisons are also supported through
+`allowFieldComparisons`, per-field `fieldComparison` metadata, and
+`valueSource: 'field'` / `valueField` rule data.
+
 Full documentation, API reference, and the interactive demo are available on
 the project website:
 
@@ -418,6 +422,11 @@ The library also provides parser and formatter helpers through subpath exports:
 
 Supported formats are documented on the website:
 
+Field-to-field comparisons are supported in the builder model and in native
+query formats that have a direct right-hand-side field-reference form. See the
+supported-formats documentation for the current list and unsupported cases such
+as `Elasticsearch` and `RSQL`.
+
 - <a href="https://vojtechportes.github.io/react-query-builder/documentation/parsing-and-formatting" target="_blank" rel="noopener noreferrer">Documentation: Parsing and Formatting</a>
 - <a href="https://vojtechportes.github.io/react-query-builder/documentation/parsing-and-formatting/supported-formats" target="_blank" rel="noopener noreferrer">Documentation: Supported Formats</a>
 - <a href="https://vojtechportes.github.io/react-query-builder/api/format-query" target="_blank" rel="noopener noreferrer">API: formatQuery</a>
@@ -436,3 +445,4 @@ Responsive behavior is documented in more detail on the website:
 
 - <a href="https://vojtechportes.github.io/react-query-builder/documentation/components" target="_blank" rel="noopener noreferrer">Documentation: Components</a>
 - <a href="https://vojtechportes.github.io/react-query-builder/api/components" target="_blank" rel="noopener noreferrer">API: Components</a>
+

--- a/example/src/app/app.tsx
+++ b/example/src/app/app.tsx
@@ -55,6 +55,10 @@ export const App: React.FC = () => (
           <Route path="/documentation" element={<DocumentationPage />} />
           <Route path="/documentation/installation" element={<DocumentationPage />} />
           <Route path="/documentation/usage" element={<DocumentationPage />} />
+          <Route
+            path="/documentation/field-comparisons"
+            element={<DocumentationPage />}
+          />
           <Route path="/documentation/builder-ref" element={<DocumentationPage />} />
           <Route
             path="/documentation/dynamic-field-options"
@@ -150,3 +154,4 @@ export const App: React.FC = () => (
     </React.Suspense>
   </BrowserRouter>
 );
+

--- a/example/src/components/demo-playground.tsx
+++ b/example/src/components/demo-playground.tsx
@@ -165,6 +165,11 @@ const Tab = styled.button<{ $active: boolean }>`
   color: ${({ $active }) => ($active ? siteTheme.primaryDark : '#475569')};
   font-weight: 600;
   cursor: pointer;
+
+  &:disabled {
+    opacity: 0.55;
+    cursor: not-allowed;
+  }
 `;
 
 const OutputCard = styled.section`
@@ -252,6 +257,13 @@ export interface IDemoPlaygroundProps {
   initialData?: DenormalizedQuery;
 }
 
+const containsFieldComparisons = (query: DenormalizedQuery): boolean =>
+  query.some(node =>
+    'type' in node ? containsFieldComparisons(node.children) : node.valueSource === 'field'
+  );
+
+const unsupportedFieldComparisonFormats: OutputFormat[] = ['Elasticsearch', 'RSQL'];
+
 export const DemoPlayground: React.FC<IDemoPlaygroundProps> = ({
   initialData = initialQueryTree,
 }) => {
@@ -265,6 +277,7 @@ export const DemoPlayground: React.FC<IDemoPlaygroundProps> = ({
   const [cloneable, setCloneable] = React.useState(false);
   const [draggable, setDraggable] = React.useState(false);
   const [allowGroupNegation, setAllowGroupNegation] = React.useState(true);
+  const [allowFieldComparisons, setAllowFieldComparisons] = React.useState(true);
   const [newNodePlacement, setNewNodePlacement] = React.useState<
     'append' | 'prepend'
   >('append');
@@ -334,6 +347,7 @@ export const DemoPlayground: React.FC<IDemoPlaygroundProps> = ({
     onChange: setData,
     draggable,
     allowGroupNegation,
+    allowFieldComparisons,
     newNodePlacement,
     history,
     textMode,
@@ -343,6 +357,19 @@ export const DemoPlayground: React.FC<IDemoPlaygroundProps> = ({
     showValidation,
     ...(builderComponents ? { components: builderComponents } : {}),
   };
+
+  const hasFieldComparisons = React.useMemo(() => containsFieldComparisons(data), [data]);
+  const isOutputFormatDisabled = React.useCallback(
+    (format: OutputFormat) =>
+      hasFieldComparisons && unsupportedFieldComparisonFormats.includes(format),
+    [hasFieldComparisons]
+  );
+
+  React.useEffect(() => {
+    if (isOutputFormatDisabled(outputFormat)) {
+      setOutputFormat('Native');
+    }
+  }, [isOutputFormatDisabled, outputFormat]);
 
   const outputText = React.useMemo(() => {
     if (outputFormat === 'Native') {
@@ -361,6 +388,7 @@ export const DemoPlayground: React.FC<IDemoPlaygroundProps> = ({
         cloneable,
         draggable,
         allowGroupNegation,
+        allowFieldComparisons,
         newNodePlacement,
         history,
         textMode,
@@ -379,6 +407,7 @@ export const DemoPlayground: React.FC<IDemoPlaygroundProps> = ({
       cloneable,
       draggable,
       allowGroupNegation,
+      allowFieldComparisons,
       newNodePlacement,
       history,
       textMode,
@@ -451,6 +480,15 @@ export const DemoPlayground: React.FC<IDemoPlaygroundProps> = ({
               onChange={event => setAllowGroupNegation(event.target.checked)}
             />
             <span>Allow group negation</span>
+          </ToggleRow>
+
+          <ToggleRow>
+            <Toggle
+              type="checkbox"
+              checked={allowFieldComparisons}
+              onChange={event => setAllowFieldComparisons(event.target.checked)}
+            />
+            <span>Allow field comparisons</span>
           </ToggleRow>
 
           <ToggleRow>
@@ -717,6 +755,12 @@ export const DemoPlayground: React.FC<IDemoPlaygroundProps> = ({
                 <Tab
                   key={format}
                   $active={outputFormat === format}
+                  disabled={isOutputFormatDisabled(format)}
+                  title={
+                    isOutputFormatDisabled(format)
+                      ? 'Disabled because the current query contains field-to-field comparisons.'
+                      : undefined
+                  }
                   onClick={() => setOutputFormat(format)}
                 >
                   {formatLabels[format]}
@@ -735,3 +779,7 @@ export const DemoPlayground: React.FC<IDemoPlaygroundProps> = ({
     </Layout>
   );
 };
+
+
+
+

--- a/example/src/components/parsing-sandbox.tsx
+++ b/example/src/components/parsing-sandbox.tsx
@@ -9,7 +9,11 @@ import { ThemeProvider } from '../../../src/theme-provider/theme-provider';
 import { parseQuery } from '../../../src/parseQuery';
 import { AlertBox } from './alert-box';
 import { CodeBlock } from './code-block';
-import { demoFields, defaultTheme, initialQueryTree } from '../constants/demo-data';
+import {
+  demoFields,
+  defaultTheme,
+  parsingSandboxInitialQueryTree,
+} from '../constants/demo-data';
 import { siteTheme } from '../constants/site-theme';
 import {
   formatQueryText,
@@ -116,11 +120,11 @@ export const ParsingSandbox: React.FC = () => {
   const [outputFormat, setOutputFormat] =
     React.useState<SupportedQueryFormat>('Mongo');
   const [builderData, setBuilderData] =
-    React.useState<DenormalizedQuery>(initialQueryTree);
+    React.useState<DenormalizedQuery>(parsingSandboxInitialQueryTree);
   const [builderFields, setBuilderFields] =
     React.useState<IBuilderFieldProps[]>(demoFields);
   const [inputText, setInputText] = React.useState(() =>
-    formatExample(initialQueryTree, 'SQL')
+    formatExample(parsingSandboxInitialQueryTree, 'SQL')
   );
   const [inputError, setInputError] = React.useState<string | null>(null);
   const [outputError, setOutputError] = React.useState<string | null>(null);
@@ -248,3 +252,4 @@ export const ParsingSandbox: React.FC = () => {
     </Root>
   );
 };
+

--- a/example/src/constants/demo-data.ts
+++ b/example/src/constants/demo-data.ts
@@ -16,6 +16,30 @@ export const demoFields: IBuilderFieldProps[] = [
       { value: 'DE', label: 'Germany' },
       { value: 'AT', label: 'Austria' },
     ],
+    fieldComparison: {
+      type: 'string',
+      comparableFields: ['CUSTOMER_COUNTRY_CODE', 'DELIVERY_COUNTRY_CODE'],
+    },
+  },
+  {
+    field: 'CUSTOMER_COUNTRY_CODE',
+    label: 'Customer country code',
+    type: 'TEXT',
+    operators: ['EQUAL', 'NOT_EQUAL', 'IS_NULL', 'IS_NOT_NULL'],
+    fieldComparison: {
+      type: 'string',
+      comparableFields: ['CUSTOMER_COUNTRY', 'DELIVERY_COUNTRY_CODE'],
+    },
+  },
+  {
+    field: 'DELIVERY_COUNTRY_CODE',
+    label: 'Delivery country code',
+    type: 'TEXT',
+    operators: ['EQUAL', 'NOT_EQUAL', 'IS_NULL', 'IS_NOT_NULL'],
+    fieldComparison: {
+      type: 'string',
+      comparableFields: ['CUSTOMER_COUNTRY', 'CUSTOMER_COUNTRY_CODE'],
+    },
   },
   {
     field: 'CUSTOMER_SEGMENTS',
@@ -34,12 +58,18 @@ export const demoFields: IBuilderFieldProps[] = [
     label: 'Customer is in EU',
     type: 'BOOLEAN',
     operators: ['EQUAL', 'NOT_EQUAL'],
+    fieldComparison: {
+      type: 'boolean',
+    },
   },
   {
     field: 'IS_VAT_PAYER',
     label: 'Customer is VAT payer',
     type: 'BOOLEAN',
     operators: ['EQUAL', 'NOT_EQUAL', 'IS_NULL', 'IS_NOT_NULL'],
+    fieldComparison: {
+      type: 'boolean',
+    },
   },
   {
     field: 'CUSTOMER_CITY',
@@ -57,6 +87,9 @@ export const demoFields: IBuilderFieldProps[] = [
       'IS_NULL',
       'IS_NOT_NULL',
     ],
+    fieldComparison: {
+      type: 'string',
+    },
   },
   {
     field: 'ORDER_TOTAL',
@@ -74,6 +107,69 @@ export const demoFields: IBuilderFieldProps[] = [
       'IS_NULL',
       'IS_NOT_NULL',
     ],
+    fieldComparison: {
+      type: 'number',
+    },
+  },
+  {
+    field: 'ORDER_APPROVAL_LIMIT',
+    label: 'Order approval limit',
+    type: 'NUMBER',
+    operators: [
+      'EQUAL',
+      'NOT_EQUAL',
+      'BETWEEN',
+      'NOT_BETWEEN',
+      'LARGER',
+      'SMALLER',
+      'LARGER_EQUAL',
+      'SMALLER_EQUAL',
+      'IS_NULL',
+      'IS_NOT_NULL',
+    ],
+    fieldComparison: {
+      type: 'number',
+    },
+  },
+  {
+    field: 'ORDER_MANUAL_REVIEW_THRESHOLD',
+    label: 'Order manual review threshold',
+    type: 'NUMBER',
+    operators: [
+      'EQUAL',
+      'NOT_EQUAL',
+      'BETWEEN',
+      'NOT_BETWEEN',
+      'LARGER',
+      'SMALLER',
+      'LARGER_EQUAL',
+      'SMALLER_EQUAL',
+      'IS_NULL',
+      'IS_NOT_NULL',
+    ],
+    fieldComparison: {
+      type: 'number',
+    },
+  },
+  {
+    field: 'ORDER_DISCOUNT_CAP',
+    label: 'Order discount cap',
+    type: 'NUMBER',
+    operators: [
+      'EQUAL',
+      'NOT_EQUAL',
+      'BETWEEN',
+      'NOT_BETWEEN',
+      'LARGER',
+      'SMALLER',
+      'LARGER_EQUAL',
+      'SMALLER_EQUAL',
+      'IS_NULL',
+      'IS_NOT_NULL',
+    ],
+    fieldComparison: {
+      type: 'number',
+    },
   },
   {
     field: 'ORDER_CREATED_AT',
@@ -91,6 +187,9 @@ export const demoFields: IBuilderFieldProps[] = [
       'IS_NULL',
       'IS_NOT_NULL',
     ],
+    fieldComparison: {
+      type: 'date',
+    },
   },
   {
     field: 'COMPANY_NAME',
@@ -108,6 +207,10 @@ export const demoFields: IBuilderFieldProps[] = [
     ],
     validation: {
       required: true,
+    },
+    fieldComparison: {
+      type: 'string',
+      comparableFields: ['CUSTOMER_CITY'],
     },
   },
   {
@@ -139,8 +242,8 @@ export const demoFields: IBuilderFieldProps[] = [
     },
     usageLimit: {
       max: 1,
-      scope: 'global'
-    }
+      scope: 'global',
+    },
   },
 ];
 
@@ -174,6 +277,12 @@ export const initialQueryTree: DenormalizedQuery = [
             operator: 'BETWEEN',
             value: [2500, 12000],
           },
+          {
+            field: 'CUSTOMER_COUNTRY',
+            operator: 'EQUAL',
+            valueSource: 'field',
+            valueField: 'CUSTOMER_COUNTRY_CODE',
+          },
         ],
       },
       {
@@ -191,6 +300,18 @@ export const initialQueryTree: DenormalizedQuery = [
             field: 'ORDER_TOTAL',
             operator: 'BETWEEN',
             value: [2500, 12000],
+          },
+          {
+            field: 'ORDER_TOTAL',
+            operator: 'SMALLER_EQUAL',
+            valueSource: 'field',
+            valueField: 'ORDER_APPROVAL_LIMIT',
+          },
+          {
+            field: 'ORDER_TOTAL',
+            operator: 'LARGER_EQUAL',
+            valueSource: 'field',
+            valueField: 'ORDER_MANUAL_REVIEW_THRESHOLD',
           },
         ],
       },
@@ -220,8 +341,9 @@ export const initialQueryTree: DenormalizedQuery = [
             children: [
               {
                 field: 'COMPANY_NAME',
-                operator: 'CONTAINS',
-                value: 'Prague',
+                operator: 'EQUAL',
+                valueSource: 'field',
+                valueField: 'CUSTOMER_CITY',
               },
               {
                 field: 'ORDER_CREATED_AT',
@@ -236,4 +358,52 @@ export const initialQueryTree: DenormalizedQuery = [
   },
 ];
 
+export const parsingSandboxInitialQueryTree: DenormalizedQuery = [
+  {
+    type: 'GROUP',
+    value: 'AND',
+    isNegated: false,
+    children: [
+      {
+        field: 'CUSTOMER_COUNTRY',
+        operator: 'EQUAL',
+        value: 'CZ',
+      },
+      {
+        type: 'GROUP',
+        value: 'OR',
+        isNegated: false,
+        children: [
+          {
+            field: 'CUSTOMER_CITY',
+            operator: 'EQUAL',
+            value: 'Prague',
+          },
+          {
+            field: 'ORDER_TOTAL',
+            operator: 'BETWEEN',
+            value: [2500, 12000],
+          },
+        ],
+      },
+      {
+        field: 'IS_VAT_PAYER',
+        operator: 'EQUAL',
+        value: true,
+      },
+      {
+        field: 'CUSTOMER_SEGMENTS',
+        operator: 'ALL_IN',
+        value: ['B2B', 'Priority'],
+      },
+      {
+        field: 'ORDER_CREATED_AT',
+        operator: 'LARGER_EQUAL',
+        value: '2025-01-01',
+      },
+    ],
+  },
+];
+
 export const defaultTheme = { colors };
+

--- a/example/src/pages/api-page/pages/api-content.tsx
+++ b/example/src/pages/api-page/pages/api-content.tsx
@@ -22,6 +22,7 @@ const builderSignature = `export interface IBuilderProps {
   cloneable?: boolean;
   draggable?: boolean;
   allowGroupNegation?: boolean;
+  allowFieldComparisons?: boolean;
   singleRootGroup?: boolean;
   groupTypes?: 'with-modifiers' | 'without-modifiers' | 'both';
   newNodePlacement?: 'append' | 'prepend';
@@ -227,6 +228,7 @@ const fieldBaseSignature = `interface IBuilderFieldBase<TType, TValue, TValidati
   operators?: BuilderFieldOperator[];
   usageLimit?: IBuilderFieldUsageLimit;
   validation?: TValidation;
+  fieldComparison?: IBuilderFieldComparisonConfig;
 }`;
 
 const fieldUsageLimitSignature = `export type BuilderFieldUsageLimitScope = 'global' | 'parent';
@@ -236,6 +238,17 @@ export interface IBuilderFieldUsageLimit {
   max: number;
   scope?: BuilderFieldUsageLimitScope;
   message?: BuilderValidationMessage;
+}`;
+
+const fieldComparisonConfigSignature = `export type BuilderFieldComparisonType =
+  | 'string'
+  | 'number'
+  | 'date'
+  | 'boolean';
+
+export interface IBuilderFieldComparisonConfig {
+  type?: BuilderFieldComparisonType;
+  comparableFields?: string[];
 }`;
 
 const fieldOptionTypesSignature = `export type BuilderFieldOption = {
@@ -268,15 +281,21 @@ export type IBuilderFieldDependencyEntry = IBuilderRuleDependencyEntry;
 export interface INearestFieldMatch {
   nodeId: string;
   field: string;
+  valueSource?: QueryRuleValueSource;
   value: QueryRuleValue | undefined;
+  valueField?: string;
   operator?: QueryOperator;
 }
 
 export interface IBuilderFieldChange {
   nodeId: string;
   field: string;
+  previousValueSource?: QueryRuleValueSource;
   previousValue: QueryRuleValue | undefined;
+  previousValueField?: string;
+  valueSource?: QueryRuleValueSource;
   value: QueryRuleValue | undefined;
+  valueField?: string;
   data: DenormalizedQuery;
 };`;
 
@@ -284,6 +303,7 @@ const queryTreeSignature = `export type QueryGroupValue = 'AND' | 'OR';
 export type QueryGroupType = 'with-modifiers' | 'without-modifiers';
 export type GroupReadOnlyTarget = 'negation' | 'combinator';
 export type RuleReadOnlyTarget = 'field' | 'operator' | 'value';
+export type QueryRuleValueSource = 'value' | 'field';
 
 export interface IGroupReadOnlyConfig {
   enabled: boolean;
@@ -303,15 +323,31 @@ export type QueryRuleValue =
   | number[]
   | boolean;
 
-export interface IDenormalizedRuleNode {
+export interface ILiteralRuleNode {
   id?: string;
   parent?: string;
   field: string;
+  valueSource?: 'value';
   value?: QueryRuleValue;
+  valueField?: undefined;
   operator?: QueryOperator;
   operators?: QueryOperator[];
   readOnly?: boolean | IRuleReadOnlyConfig;
 }
+
+export interface IFieldReferenceRuleNode {
+  id?: string;
+  parent?: string;
+  field: string;
+  valueSource: 'field';
+  value?: undefined;
+  valueField: string;
+  operator?: QueryOperator;
+  operators?: QueryOperator[];
+  readOnly?: boolean | IRuleReadOnlyConfig;
+}
+
+export type IDenormalizedRuleNode = ILiteralRuleNode | IFieldReferenceRuleNode;
 
 export interface IDenormalizedGroupNodeBase {
   id?: string;
@@ -792,6 +828,86 @@ const queryFormatSignature = `export type QueryFormat =
   | 'Dynamo'
   | 'Django';`;
 
+const builderFieldComparisonSnippet = `const data: DenormalizedQuery = [
+  {
+    type: 'GROUP',
+    value: 'AND',
+    isNegated: false,
+    children: [
+      {
+        field: 'ORDER_TOTAL',
+        operator: 'LARGER_EQUAL',
+        valueSource: 'field',
+        valueField: 'ORDER_APPROVAL_LIMIT',
+      },
+    ],
+  },
+];
+
+<Builder
+  allowFieldComparisons
+  fields={fields}
+  data={data}
+  onChange={setData}
+/>;`;
+
+const fieldsFieldComparisonSnippet = `const fields: IBuilderFieldProps[] = [
+  {
+    field: 'CUSTOMER_COUNTRY',
+    label: 'Customer country',
+    type: 'LIST',
+    operators: ['EQUAL'],
+    value: [
+      { value: 'CZ', label: 'Czech Republic' },
+      { value: 'SK', label: 'Slovakia' },
+    ],
+    fieldComparison: {
+      type: 'string',
+      comparableFields: ['DELIVERY_COUNTRY_CODE'],
+    },
+  },
+  {
+    field: 'DELIVERY_COUNTRY_CODE',
+    label: 'Delivery country code',
+    type: 'TEXT',
+    operators: ['EQUAL'],
+  },
+];`;
+
+const dataFieldComparisonSnippet = `const rule: IDenormalizedRuleNode = {
+  field: 'ORDER_TOTAL',
+  operator: 'LARGER_EQUAL',
+  valueSource: 'field',
+  valueField: 'ORDER_APPROVAL_LIMIT',
+};`;
+
+const formatQueryFieldComparisonSnippet = `const sql = formatQuery(data, 'SQL', {
+  fields,
+  wrapWhereClause: true,
+});
+
+// WHERE ORDER_TOTAL >= ORDER_APPROVAL_LIMIT`;
+
+const parseQueryFieldComparisonSnippet = `const result = parseQuery(
+  'WHERE ORDER_TOTAL >= ORDER_APPROVAL_LIMIT',
+  'SQL'
+);
+
+console.log(result.data[0]);
+// {
+//   type: 'GROUP',
+//   value: 'AND',
+//   isNegated: false,
+//   children: [
+//     {
+//       field: 'ORDER_TOTAL',
+//       operator: 'LARGER_EQUAL',
+//       valueSource: 'field',
+//       valueField: 'ORDER_APPROVAL_LIMIT',
+//     },
+//   ],
+// }`;
+
 export interface IApiPage {
   path: string;
   title: string;
@@ -846,9 +962,9 @@ export const apiPages: IApiPage[] = [
     sectionTitle: 'Core API',
     summary: '',
     description:
-      'Builder component API reference for IBuilderProps, controlled data flow, validation, and editing options.',
+      'Builder component API reference for IBuilderProps, controlled data flow, validation, editing options, and field-to-field comparisons.',
     searchText:
-      'Builder component IBuilderProps onChange controlled component defaults strings components validator history state change undo redo canUndo canRedo newNodePlacement append prepend',
+      'Builder component IBuilderProps onChange controlled component defaults strings components validator history state change undo redo canUndo canRedo newNodePlacement append prepend allowFieldComparisons field comparison valueSource valueField',
     content: (
       <>
         <CodeBlock code={builderSignature} language="ts" label="IBuilderProps" />
@@ -868,6 +984,7 @@ export const apiPages: IApiPage[] = [
           <li><ItemTitle><InlineCode>cloneable</InlineCode>:</ItemTitle> Defaults to <InlineCode>false</InlineCode>. Renders clone controls for rules and groups and inserts the cloned node directly below the original.</li>
           <li><ItemTitle><InlineCode>draggable</InlineCode>:</ItemTitle> Defaults to <InlineCode>false</InlineCode>. Enables drag-and-drop reordering and movement of query nodes.</li>
           <li><ItemTitle><InlineCode>allowGroupNegation</InlineCode>:</ItemTitle> Defaults to <InlineCode>true</InlineCode>. When set to <InlineCode>false</InlineCode>, group negation is disabled across the builder: the group-level <InlineCode>NOT</InlineCode> control is hidden, emitted groups are normalized to non-negated form, and SQL text mode rejects group-level <InlineCode>NOT (...)</InlineCode> expressions. Operator-level negation such as <InlineCode>NOT IN</InlineCode>, <InlineCode>NOT LIKE</InlineCode>, <InlineCode>IS NOT NULL</InlineCode>, and <InlineCode>NOT BETWEEN</InlineCode> remains supported.</li>
+          <li><ItemTitle><InlineCode>allowFieldComparisons</InlineCode>:</ItemTitle> Defaults to <InlineCode>false</InlineCode>. Enables the built-in value-source toggle so supported rules can compare one field against another through <InlineCode>valueSource: 'field'</InlineCode> and <InlineCode>valueField</InlineCode>.</li>
           <li><ItemTitle><InlineCode>singleRootGroup</InlineCode>:</ItemTitle> Defaults to <InlineCode>true</InlineCode>. Wraps root-level items into a single root group and prevents deleting that root group. Text mode requires this to stay enabled.</li>
           <li><ItemTitle><InlineCode>groupTypes</InlineCode>:</ItemTitle> Defaults to <InlineCode>'with-modifiers'</InlineCode>. Controls whether groups use combinator/negation controls, modifierless groups, or both. When text mode is active, builder-compatible SQL round-tripping uses groups with modifiers.</li>
           <li><ItemTitle><InlineCode>newNodePlacement</InlineCode>:</ItemTitle> Defaults to <InlineCode>'append'</InlineCode>. Controls whether newly added rules and groups are inserted at the end or the beginning of their parent when built-in add actions or imperative add methods omit an explicit index.</li>
@@ -880,6 +997,16 @@ export const apiPages: IApiPage[] = [
           <li><ItemTitle><InlineCode>history</InlineCode>:</ItemTitle> Optional. Set to <InlineCode>true</InlineCode> to enable undo and redo with default settings, or pass <InlineCode>IBuilderHistoryConfig</InlineCode> to customize retention and built-in controls.</li>
           <li><ItemTitle><InlineCode>onChange</InlineCode>:</ItemTitle> Optional callback fired with the denormalized query tree after changes are emitted.</li>
         </List>
+        <SectionTitle>Field comparisons</SectionTitle>
+        <CodeBlock
+          code={builderFieldComparisonSnippet}
+          language="tsx"
+          label="Builder field comparison setup"
+        />
+        <List>
+          <li><ItemTitle>Opt-in:</ItemTitle> The default UI exposes field-to-field comparisons only when <InlineCode>allowFieldComparisons</InlineCode> is enabled.</li>
+          <li><ItemTitle>Persisted data:</ItemTitle> Preloaded field-comparison rules stay representable through <InlineCode>valueSource</InlineCode> and <InlineCode>valueField</InlineCode>, even though validation will block them when the prop is disabled.</li>
+        </List>
         <SectionTitle>Text mode behavior</SectionTitle>
         <CodeBlock code={textModeConfigSignature} language="ts" label="Text mode types" />
         <List>
@@ -887,6 +1014,7 @@ export const apiPages: IApiPage[] = [
           <li><ItemTitle>Config shape:</ItemTitle> <InlineCode>textMode</InlineCode> accepts either <InlineCode>true</InlineCode> or <InlineCode>{`{ format?: 'SQL'; defaultMode?: 'builder' | 'text' }`}</InlineCode>.</li>
           <li><ItemTitle>Default-mode precedence:</ItemTitle> If both <InlineCode>textMode.defaultMode</InlineCode> and the top-level <InlineCode>defaultMode</InlineCode> prop are provided, the top-level prop wins.</li>
           <li><ItemTitle>Syntax and semantic validation:</ItemTitle> The built-in editor highlights invalid SQL syntax plus builder-specific issues such as unknown fields, unsupported operators, and invalid select values.</li>
+          <li><ItemTitle>Field comparisons:</ItemTitle> When <InlineCode>allowFieldComparisons</InlineCode> is enabled, SQL text mode accepts builder-compatible right-hand-side field references such as <InlineCode>ORDER_TOTAL &gt;= ORDER_APPROVAL_LIMIT</InlineCode>. When disabled, the same expression is reported as a semantic validation issue.</li>
           <li><ItemTitle>Invalid text flow:</ItemTitle> Invalid text stays local to text mode, the last valid builder query is preserved, and <InlineCode>onChange</InlineCode> is fired only after a valid parse and semantic validation.</li>
           <li><ItemTitle>History:</ItemTitle> Valid text edits are committed into builder history. Invalid intermediate text is not committed into builder state or history.</li>
           <li><ItemTitle>Built-in editor:</ItemTitle> Included in the main package and suitable for freely editable SQL text mode.</li>
@@ -1016,9 +1144,9 @@ export const apiPages: IApiPage[] = [
     sectionTitle: 'Core API',
     summary: '',
     description:
-      'Field definition API reference for IBuilderFieldProps, field types, operators, usageLimit, and validation metadata.',
+      'Field definition API reference for IBuilderFieldProps, field types, operators, usageLimit, validation metadata, and field-comparison configuration.',
     searchText:
-      'IBuilderFieldProps field label type value operators usageLimit validation BOOLEAN TEXT DATE NUMBER STATEMENT LIST MULTI_LIST GROUP BuilderFieldOption BuilderFieldOptionsStatus IBuilderFieldOptionState INearestFieldMatch IBuilderFieldChange dynamic field options',
+      'IBuilderFieldProps field label type value operators usageLimit validation fieldComparison comparableFields BOOLEAN TEXT DATE NUMBER STATEMENT LIST MULTI_LIST GROUP BuilderFieldOption BuilderFieldOptionsStatus IBuilderFieldOptionState INearestFieldMatch IBuilderFieldChange dynamic field options',
     content: (
       <>
         <CodeBlock code={fieldTypesSignature} language="ts" label="Field unions" />
@@ -1027,6 +1155,11 @@ export const apiPages: IApiPage[] = [
           code={fieldUsageLimitSignature}
           language="ts"
           label="Field usage limits"
+        />
+        <CodeBlock
+          code={fieldComparisonConfigSignature}
+          language="ts"
+          label="Field comparison config"
         />
         <CodeBlock
           code={fieldOptionTypesSignature}
@@ -1042,6 +1175,7 @@ export const apiPages: IApiPage[] = [
           <li><ItemTitle><InlineCode>operators</InlineCode>:</ItemTitle> Optional operator whitelist. When omitted, the builder falls back to the default operators for the field type.</li>
           <li><ItemTitle><InlineCode>usageLimit</InlineCode>:</ItemTitle> Optional structural constraint that limits how many rules may use this field or its shared usage bucket.</li>
           <li><ItemTitle><InlineCode>validation</InlineCode>:</ItemTitle> Optional validation config. The shape depends on field type.</li>
+          <li><ItemTitle><InlineCode>fieldComparison</InlineCode>:</ItemTitle> Optional semantic config for field-to-field comparisons, including a comparison type override and an allowlist of valid target fields.</li>
         </List>
         <SectionTitle>usageLimit</SectionTitle>
         <List>
@@ -1049,6 +1183,17 @@ export const apiPages: IApiPage[] = [
           <li><ItemTitle><InlineCode>scope</InlineCode>:</ItemTitle> Optional. Defaults to <InlineCode>global</InlineCode>. Use <InlineCode>parent</InlineCode> to limit usage only within the same immediate parent group.</li>
           <li><ItemTitle><InlineCode>key</InlineCode>:</ItemTitle> Optional shared bucket identifier. When omitted, the builder uses the field&apos;s own <InlineCode>field</InlineCode> value.</li>
           <li><ItemTitle><InlineCode>message</InlineCode>:</ItemTitle> Optional custom validation message used when persisted or imported data exceeds the allowed limit.</li>
+        </List>
+        <SectionTitle>fieldComparison</SectionTitle>
+        <CodeBlock
+          code={fieldsFieldComparisonSnippet}
+          language="tsx"
+          label="Semantic field comparison metadata"
+        />
+        <List>
+          <li><ItemTitle><InlineCode>type</InlineCode>:</ItemTitle> Optional semantic comparison type. When omitted, <InlineCode>TEXT</InlineCode>, <InlineCode>NUMBER</InlineCode>, <InlineCode>DATE</InlineCode>, and <InlineCode>BOOLEAN</InlineCode> infer automatically, while <InlineCode>LIST</InlineCode> can infer from uniform option values.</li>
+          <li><ItemTitle><InlineCode>comparableFields</InlineCode>:</ItemTitle> Optional source-owned allowlist that restricts which fields may appear on the right-hand side.</li>
+          <li><ItemTitle>Operator support:</ItemTitle> Field comparisons are only offered for operators that have a direct single-value right-hand side. Range and set-style operators continue to use literal values.</li>
         </List>
         <SectionTitle>Type notes</SectionTitle>
         <List>
@@ -1074,17 +1219,24 @@ export const apiPages: IApiPage[] = [
     sectionTitle: 'Core API',
     summary: '',
     description:
-      'Query data API reference for denormalized rule and group shapes, values, and read-only semantics.',
+      'Query data API reference for denormalized rule and group shapes, literal versus field-reference values, and read-only semantics.',
     searchText:
-      'DenormalizedQuery DenormalizedNode IDenormalizedRuleNode IDenormalizedGroupNode QueryRuleValue QueryGroupValue readOnly id parent',
+      'DenormalizedQuery DenormalizedNode IDenormalizedRuleNode IDenormalizedGroupNode QueryRuleValue QueryRuleValueSource valueSource valueField QueryGroupValue readOnly id parent',
     content: (
       <>
         <CodeBlock code={queryTreeSignature} language="ts" label="Query tree types" />
+        <CodeBlock
+          code={dataFieldComparisonSnippet}
+          language="ts"
+          label="Field-reference rule data"
+        />
         <SectionTitle>Rule props</SectionTitle>
         <List>
           <li><ItemTitle><InlineCode>field</InlineCode>:</ItemTitle> Required field identifier matching one of the configured fields.</li>
           <li><ItemTitle><InlineCode>operator</InlineCode>:</ItemTitle> Optional operator for the rule. Some field and operator combinations imply different value shapes.</li>
-          <li><ItemTitle><InlineCode>value</InlineCode>:</ItemTitle> Optional rule value. Supported scalar/array forms are defined by <InlineCode>QueryRuleValue</InlineCode>.</li>
+          <li><ItemTitle><InlineCode>valueSource</InlineCode>:</ItemTitle> Optional discriminant. Omit it or set <InlineCode>'value'</InlineCode> for literal comparisons, or set <InlineCode>'field'</InlineCode> for right-hand-side field references.</li>
+          <li><ItemTitle><InlineCode>value</InlineCode>:</ItemTitle> Optional literal rule value used when <InlineCode>valueSource</InlineCode> is omitted or set to <InlineCode>'value'</InlineCode>. Supported scalar and array forms are defined by <InlineCode>QueryRuleValue</InlineCode>.</li>
+          <li><ItemTitle><InlineCode>valueField</InlineCode>:</ItemTitle> Required when <InlineCode>valueSource</InlineCode> is <InlineCode>'field'</InlineCode>. Stores the compared field identifier instead of a literal value.</li>
           <li><ItemTitle><InlineCode>operators</InlineCode>:</ItemTitle> Optional rule-level operator override list.</li>
           <li><ItemTitle><InlineCode>readOnly</InlineCode>:</ItemTitle> Optional per-rule lock definition. Supported shapes are <InlineCode>false</InlineCode> or omitted, <InlineCode>true</InlineCode>, or <InlineCode>{`{ enabled: boolean; targets?: ('field' | 'operator' | 'value')[] }`}</InlineCode>.</li>
           <li><ItemTitle><InlineCode>readOnly.targets</InlineCode>:</ItemTitle> Part of the <InlineCode>readOnly</InlineCode> object config. Rule targets are <InlineCode>'field'</InlineCode>, <InlineCode>'operator'</InlineCode>, and <InlineCode>'value'</InlineCode>. Targeted controls stay visible but become non-editable.</li>
@@ -1496,9 +1648,9 @@ export const apiPages: IApiPage[] = [
     sectionTitle: 'Query Conversion',
     summary: '',
     description:
-      'API reference for formatQuery, including supported formats and shared or format-specific options.',
+      'API reference for formatQuery, including supported formats, shared or format-specific options, and field-to-field serialization behavior.',
     searchText:
-      'formatQuery signature parameters value format options fields wrapWhereClause wrapFilterClause wrapQueryClause variableName rootlessCombinator modifierlessGroupCombinator',
+      'formatQuery signature parameters value format options fields wrapWhereClause wrapFilterClause wrapQueryClause variableName rootlessCombinator modifierlessGroupCombinator field comparison valueSource valueField',
     content: (
       <>
         <CodeBlock code={formatQuerySignature} language="ts" label="formatQuery signature" />
@@ -1529,6 +1681,17 @@ export const apiPages: IApiPage[] = [
           <li><ItemTitle><InlineCode>variableName</InlineCode>:</ItemTitle> Supported by AQL format options. Sets the document variable prefix used in generated expressions.</li>
           <li><ItemTitle><InlineCode>wrapQueryClause</InlineCode>:</ItemTitle> Supported by Elasticsearch format options. Wraps the generated expression in the outer query clause shape.</li>
         </List>
+        <SectionTitle>Field comparisons</SectionTitle>
+        <CodeBlock
+          code={formatQueryFieldComparisonSnippet}
+          language="ts"
+          label="Formatting a field-reference rule"
+        />
+        <List>
+          <li><ItemTitle>Native support:</ItemTitle> <InlineCode>SQL</InlineCode>, <InlineCode>Mongo</InlineCode>, <InlineCode>AQL</InlineCode>, <InlineCode>JSONata</InlineCode>, <InlineCode>JsonLogic</InlineCode>, <InlineCode>CEL</InlineCode>, <InlineCode>SpEL</InlineCode>, <InlineCode>Prisma</InlineCode>, <InlineCode>OData</InlineCode>, <InlineCode>Dynamo</InlineCode>, and <InlineCode>Django</InlineCode> serialize field comparisons when the operator has a direct right-hand-side field form.</li>
+          <li><ItemTitle><InlineCode>fields</InlineCode> option:</ItemTitle> Treat field metadata as strongly recommended here because formatter behavior depends on field semantics and operator compatibility.</li>
+          <li><ItemTitle>Explicit rejection:</ItemTitle> <InlineCode>Elasticsearch</InlineCode> and <InlineCode>RSQL</InlineCode> intentionally throw for <InlineCode>valueSource: 'field'</InlineCode> rules instead of inventing backend-only syntax.</li>
+        </List>
         <AlertBox title="See also" variant="info">
           For a live sandbox that exercises these formats, use{' '}
           <TextLink to="/documentation/parsing-and-formatting">
@@ -1545,9 +1708,9 @@ export const apiPages: IApiPage[] = [
     sectionTitle: 'Query Conversion',
     summary: '',
     description:
-      'API reference for parseQuery, including supported input formats and the parse result shape.',
+      'API reference for parseQuery, including supported input formats, the parse result shape, and field-to-field inference.',
     searchText:
-      'parseQuery signature parameters value format IParseQueryResult fields data QueryFormat',
+      'parseQuery signature parameters value format IParseQueryResult fields data QueryFormat field comparison valueSource valueField',
     content: (
       <>
         <CodeBlock code={parseQuerySignature} language="ts" label="parseQuery signature" />
@@ -1562,6 +1725,17 @@ export const apiPages: IApiPage[] = [
         <List>
           <li><ItemTitle><InlineCode>fields</InlineCode>:</ItemTitle> <TextLink to="/api/fields">Field metadata</TextLink> inferred by the parser where possible. Some parsers can infer types and operator sets from the source expression.</li>
           <li><ItemTitle><InlineCode>data</InlineCode>:</ItemTitle> The <TextLink to="/api/data">denormalized query tree</TextLink> produced from the input string.</li>
+        </List>
+        <SectionTitle>Field comparisons</SectionTitle>
+        <CodeBlock
+          code={parseQueryFieldComparisonSnippet}
+          language="ts"
+          label="Parsing a field-reference rule"
+        />
+        <List>
+          <li><ItemTitle>Rule shape:</ItemTitle> When the source syntax uses a native right-hand-side field reference, the parsed rule uses <InlineCode>valueSource: 'field'</InlineCode> plus <InlineCode>valueField</InlineCode>.</li>
+          <li><ItemTitle>Supported native parsing:</ItemTitle> <InlineCode>SQL</InlineCode>, <InlineCode>Mongo</InlineCode>, <InlineCode>AQL</InlineCode>, <InlineCode>JSONata</InlineCode>, <InlineCode>JsonLogic</InlineCode>, <InlineCode>CEL</InlineCode>, <InlineCode>SpEL</InlineCode>, <InlineCode>Prisma</InlineCode>, <InlineCode>OData</InlineCode>, <InlineCode>Dynamo</InlineCode>, and <InlineCode>Django</InlineCode> can infer field comparisons from builder-compatible expressions.</li>
+          <li><ItemTitle>Guardrails:</ItemTitle> Unsupported or ambiguous shapes fail explicitly rather than being guessed as field references, including the intentionally unsupported <InlineCode>RSQL</InlineCode> and <InlineCode>Elasticsearch</InlineCode> cases.</li>
         </List>
         <AlertBox title="Documentation" variant="info">
           <TextLink to="/documentation/parsing-and-formatting">Parsing and Formatting</TextLink>.
@@ -1593,3 +1767,4 @@ export const findApiPage = (pathname: string) =>
   apiPages.find(page => page.path === pathname) ?? apiPages[0];
 
 export const apiOverviewPage = apiPages[0];
+

--- a/example/src/pages/documentation-page/pages/documentation-content.tsx
+++ b/example/src/pages/documentation-page/pages/documentation-content.tsx
@@ -102,6 +102,53 @@ const result = parseQuery(
 console.log(result.fields);
 console.log(result.data);`;
 
+const fieldComparisonFormatSnippet = `import { type DenormalizedQuery } from '@vojtechportes/react-query-builder';
+import { formatQuery } from '@vojtechportes/react-query-builder/formatQuery';
+
+const data: DenormalizedQuery = [
+  {
+    type: 'GROUP',
+    value: 'AND',
+    isNegated: false,
+    children: [
+      {
+        field: 'ORDER_TOTAL',
+        operator: 'LARGER_EQUAL',
+        valueSource: 'field',
+        valueField: 'ORDER_APPROVAL_LIMIT',
+      },
+    ],
+  },
+];
+
+const sql = formatQuery(data, 'SQL', {
+  fields,
+  wrapWhereClause: true,
+});
+
+// WHERE ORDER_TOTAL >= ORDER_APPROVAL_LIMIT`;
+
+const fieldComparisonParseSnippet = `import { parseQuery } from '@vojtechportes/react-query-builder/parseQuery';
+
+const result = parseQuery(
+  'WHERE ORDER_TOTAL >= ORDER_APPROVAL_LIMIT',
+  'SQL'
+);
+
+console.log(result.data[0]);
+// {
+//   type: 'GROUP',
+//   value: 'AND',
+//   isNegated: false,
+//   children: [
+//     {
+//       field: 'ORDER_TOTAL',
+//       operator: 'LARGER_EQUAL',
+//       valueSource: 'field',
+//       valueField: 'ORDER_APPROVAL_LIMIT',
+//     },
+//   ],
+// }`;
 const themeSnippet = `import { ThemeProvider } from '@vojtechportes/react-query-builder/theme-provider';
 import { colors } from '@vojtechportes/react-query-builder';
 
@@ -568,6 +615,86 @@ const usageLimitSnippet = `const fields: IBuilderFieldProps[] = [
   onChange={setData}
 />;`;
 
+const fieldComparisonSnippet = `import React, { useState } from 'react';
+import {
+  Builder,
+  type DenormalizedQuery,
+  type IBuilderFieldProps,
+} from '@vojtechportes/react-query-builder';
+
+const fields: IBuilderFieldProps[] = [
+  {
+    field: 'ORDER_TOTAL',
+    label: 'Order total',
+    type: 'NUMBER',
+    operators: ['LARGER_EQUAL'],
+    fieldComparison: {
+      type: 'number',
+      comparableFields: ['ORDER_APPROVAL_LIMIT'],
+    },
+  },
+  {
+    field: 'ORDER_APPROVAL_LIMIT',
+    label: 'Approval limit',
+    type: 'NUMBER',
+    operators: ['LARGER_EQUAL'],
+  },
+  {
+    field: 'CUSTOMER_COUNTRY',
+    label: 'Customer country',
+    type: 'LIST',
+    operators: ['EQUAL'],
+    value: [
+      { value: 'CZ', label: 'Czech Republic' },
+      { value: 'SK', label: 'Slovakia' },
+    ],
+    fieldComparison: {
+      type: 'string',
+      comparableFields: ['DELIVERY_COUNTRY_CODE'],
+    },
+  },
+  {
+    field: 'DELIVERY_COUNTRY_CODE',
+    label: 'Delivery country code',
+    type: 'TEXT',
+    operators: ['EQUAL'],
+  },
+];
+
+const initialData: DenormalizedQuery = [
+  {
+    type: 'GROUP',
+    value: 'AND',
+    isNegated: false,
+    children: [
+      {
+        field: 'ORDER_TOTAL',
+        operator: 'LARGER_EQUAL',
+        valueSource: 'field',
+        valueField: 'ORDER_APPROVAL_LIMIT',
+      },
+      {
+        field: 'CUSTOMER_COUNTRY',
+        operator: 'EQUAL',
+        valueSource: 'field',
+        valueField: 'DELIVERY_COUNTRY_CODE',
+      },
+    ],
+  },
+];
+
+export const FieldComparisonBuilder = () => {
+  const [data, setData] = useState(initialData);
+
+  return (
+    <Builder
+      allowFieldComparisons
+      fields={fields}
+      data={data}
+      onChange={setData}
+    />
+  );
+};`;
 const builderBehaviorSnippet = `<Builder
   fields={fields}
   data={data}
@@ -1445,6 +1572,7 @@ export const documentationPages: IDocumentationPage[] = [
         <List>
           <li>Start with installation and the first controlled builder example.</li>
           <li>Use <TextLink to="/documentation/dynamic-field-options">Dynamic Field Options</TextLink> when list values need to come from async or dependent data sources.</li>
+          <li><TextLink to="/documentation/field-comparisons">Field Comparisons</TextLink> shows how to compare one field against another field.</li>
           <li>Move to parsing and formatting when you need interoperability with external query syntaxes.</li>
           <li>Visit <TextLink to="/documentation/adapters">Adapters</TextLink> if you want ready-made mappings for MUI, ANTD, Bootstrap, Mantine, Fluent UI, or Radix Themes.</li>
           <li>
@@ -1501,25 +1629,149 @@ export const documentationPages: IDocumentationPage[] = [
           to show that locking can live directly in the query data without changing
           the rest of the builder configuration.
         </p>
-        <AlertBox title="API reference" variant="info">
-          <TextLink to="/api/builder">Builder</TextLink>,{' '}
-          <TextLink to="/api/fields">Fields</TextLink>, and{' '}
-          <TextLink to="/api/data">Data</TextLink>.
+        <AlertBox title="Related guide" variant="info">
+          Need a rule to compare against another field instead of a literal value? Visit{' '}
+          <TextLink to="/documentation/field-comparisons">Field Comparisons</TextLink>.
         </AlertBox>
         <AlertBox title="Next step" variant="tip">
           Continue with{' '}
+          <TextLink to="/documentation/builder-ref">Builder Ref</TextLink>{' '}
+          for imperative control,{' '}
+          <TextLink to="/documentation/field-comparisons">Field Comparisons</TextLink>{' '}
+          for cross-field rules,{' '}
           <TextLink to="/documentation/builder-behavior">Builder Behavior</TextLink>{' '}
           or <TextLink to="/documentation/text-mode">Text Mode</TextLink>{' '}
           or <TextLink to="/documentation/history">Undo and Redo</TextLink>{' '}
           for editing workflows, or{' '}
-          <TextLink to="/documentation/builder-ref">Builder Ref</TextLink>{' '}
-          for imperative control, or{' '}
           <TextLink to="/documentation/dynamic-field-options">
             Dynamic Field Options
           </TextLink>{' '}
           for async select data, or{' '}
           <TextLink to="/documentation/locking-and-read-only">Locking and Read-only</TextLink>{' '}
           for partial locking.
+        </AlertBox>
+      </>
+    ),
+  },
+  {
+    path: '/documentation/builder-behavior',
+    title: 'Builder Behavior',
+    sectionKey: 'getting-started',
+    sectionTitle: 'Getting Started',
+    summary: '',
+    description:
+      'Documentation for clone controls, drag-and-drop, insertion placement, root-group behavior, and group mode configuration.',
+    searchText:
+      'builder behavior cloneable clone controls draggable drag and drop allowGroupNegation group negation not groups readOnlyProtectsDelete newNodePlacement append prepend singleRootGroup groupTypes with modifiers without modifiers both root group',
+    content: (
+      <>
+        <p>
+          A few builder props shape the overall editing model more than the
+          field or query data itself. These are worth deciding early because
+          they affect how users add, move, and organize rules.
+        </p>
+        <CodeBlock code={builderBehaviorSnippet} language="tsx" label="Builder behavior" />
+        <SectionTitle>cloneable</SectionTitle>
+        <List>
+          <li>Defaults to <InlineCode>false</InlineCode> and renders built-in clone controls for rules and groups.</li>
+          <li>The clone button appears immediately to the left of the lock button when both controls are enabled.</li>
+          <li>Cloning a rule inserts a duplicate directly below that rule.</li>
+          <li>Cloning a group duplicates the entire subtree and inserts the clone directly below that group.</li>
+          <li>When <InlineCode>singleRootGroup</InlineCode> is enabled, the synthetic root group does not expose a clone control.</li>
+        </List>
+        <SectionTitle>draggable</SectionTitle>
+        <List>
+          <li>Use <InlineCode>lockable</InlineCode> to expose lock controls directly in the UI.</li>
+          <li>Enables drag-and-drop reordering and movement for editable rules and groups.</li>
+          <li>Read-only rules and groups are excluded from dragging.</li>
+          <li>When the entire builder is read-only, drag-and-drop is disabled as well.</li>
+          <li>Empty groups expose a dedicated drop zone so items can be moved into them.</li>
+        </List>
+        <SectionTitle>readOnlyProtectsDelete</SectionTitle>
+        <List>
+          <li>Defaults to <InlineCode>true</InlineCode>.</li>
+          <li>When enabled, deleting a group is blocked if that would indirectly remove read-only protected descendants.</li>
+          <li>Set it to <InlineCode>false</InlineCode> when your product wants only directly protected nodes to be non-deletable, while still allowing parent-group deletes around them.</li>
+        </List>
+        <SectionTitle>singleRootGroup</SectionTitle>
+        <List>
+          <li>
+            Defaults to <InlineCode>true</InlineCode>, which means the builder
+            maintains a single root group around the visible tree.
+          </li>
+          <li>
+            The root group cannot be deleted while <InlineCode>singleRootGroup</InlineCode>{' '}
+            is enabled.
+          </li>
+          <li>
+            Set it to <InlineCode>false</InlineCode> when your application
+            wants multiple top-level nodes instead of one wrapped root group.
+          </li>
+        </List>
+        <SectionTitle>newNodePlacement</SectionTitle>
+        <List>
+          <li>
+            Defaults to <InlineCode>'append'</InlineCode>, which inserts newly
+            added rules and groups at the end of their parent.
+          </li>
+          <li>
+            Set it to <InlineCode>'prepend'</InlineCode> to insert new rules
+            and groups at the beginning of their parent instead.
+          </li>
+          <li>
+            This affects built-in Add Rule and Add Group controls, root-level
+            add controls, and imperative ref methods when no explicit index is
+            provided.
+          </li>
+          <li>
+            It does not change cloning or drag-and-drop behavior, since those
+            actions already use explicit target positions.
+          </li>
+        </List>
+        <SectionTitle>groupTypes</SectionTitle>
+        <List>
+          <li>
+            <InlineCode>with-modifiers</InlineCode> shows group controls such as{' '}
+            <InlineCode>AND</InlineCode>, <InlineCode>OR</InlineCode>, and negation.
+          </li>
+          <li>
+            <InlineCode>without-modifiers</InlineCode> creates structural groups
+            that do not render combinator or negation controls.
+          </li>
+          <li>
+            <InlineCode>both</InlineCode> lets users choose which group kind to
+            insert when adding a new group.
+          </li>
+        </List>
+        <SectionTitle>allowGroupNegation</SectionTitle>
+        <List>
+          <li>
+            Set <InlineCode>allowGroupNegation={false}</InlineCode> when you want
+            groups to keep combinators like <InlineCode>AND</InlineCode> and{' '}
+            <InlineCode>OR</InlineCode> but remove the group-level{' '}
+            <InlineCode>NOT</InlineCode> option.
+          </li>
+          <li>
+            This is narrower than <InlineCode>groupTypes</InlineCode>: it only
+            disables negating whole groups and does not affect whether groups
+            render combinator controls.
+          </li>
+          <li>
+            Operator-level negation still works normally, including{' '}
+            <InlineCode>NOT IN</InlineCode>, <InlineCode>NOT LIKE</InlineCode>,{' '}
+            <InlineCode>IS NOT NULL</InlineCode>, and{' '}
+            <InlineCode>NOT BETWEEN</InlineCode>.
+          </li>
+          <li>
+            When disabled, incoming negated groups are normalized to non-negated
+            form so the builder output stays consistent with the visible UI.
+          </li>
+        </List>
+        <AlertBox title="Related docs" variant="info">
+          <TextLink to="/documentation/history">Undo and Redo</TextLink>,{' '}
+          <TextLink to="/documentation/builder-ref">Builder Ref</TextLink>,{' '}
+          <TextLink to="/documentation/locking-and-read-only">Locking and Read-only</TextLink>{' '}
+          and <TextLink to="/api/builder">Builder</TextLink>.
         </AlertBox>
       </>
     ),
@@ -1597,6 +1849,60 @@ export const documentationPages: IDocumentationPage[] = [
           <TextLink to="/documentation/dynamic-field-options">
             Dynamic Field Options
           </TextLink>.
+        </AlertBox>
+      </>
+    ),
+  },
+  {
+    path: '/documentation/field-comparisons',
+    title: 'Field Comparisons',
+    sectionKey: 'getting-started',
+    sectionTitle: 'Getting Started',
+    summary: '',
+    description:
+      'Enable rules that compare one field against another field, including configuration, data shape, and format support.',
+    searchText:
+      'field comparisons field-to-field allowFieldComparisons valueSource valueField comparableFields fieldComparison formatQuery parseQuery',
+    content: (
+      <>
+        <p>
+          Enable <InlineCode>allowFieldComparisons</InlineCode> on{' '}
+          <TextLink to="/api/builder">Builder</TextLink> when a rule should be
+          able to compare against another field instead of a literal value.
+        </p>
+        <CodeBlock
+          code={fieldComparisonSnippet}
+          language="tsx"
+          label="Enable field comparisons"
+        />
+        <SectionTitle>How It Works</SectionTitle>
+        <List>
+          <li>
+            <InlineCode>valueSource: 'field'</InlineCode> plus{' '}
+            <InlineCode>valueField</InlineCode> stores the selected comparison
+            field in query data.
+          </li>
+          <li>
+            <InlineCode>fieldComparison.type</InlineCode> lets semantically
+            compatible fields compare even when their builder UI types differ,
+            such as <InlineCode>LIST</InlineCode> to <InlineCode>TEXT</InlineCode>.
+          </li>
+          <li>
+            <InlineCode>fieldComparison.comparableFields</InlineCode> narrows
+            the right-hand-side selector to an explicit allowlist owned by the
+            source field.
+          </li>
+        </List>
+        <AlertBox title="API reference" variant="info">
+          <TextLink to="/api/builder">Builder</TextLink>,{' '}
+          <TextLink to="/api/fields">Fields</TextLink>,{' '}
+          <TextLink to="/api/data">Data</TextLink>,{' '}
+          <TextLink to="/api/format-query">formatQuery</TextLink>, and{' '}
+          <TextLink to="/api/parse-query">parseQuery</TextLink>.
+        </AlertBox>
+        <AlertBox title="Parsing and formatting" variant="tip">
+          Native field-to-field formatting and parsing examples are documented in{' '}
+          <TextLink to="/documentation/parsing-and-formatting/supported-formats">Supported Formats</TextLink>.
         </AlertBox>
       </>
     ),
@@ -1825,129 +2131,6 @@ export const documentationPages: IDocumentationPage[] = [
           <TextLink to="/documentation/builder-ref">Builder Ref</TextLink>,{' '}
           <TextLink to="/demo">Demo</TextLink>, and{' '}
           <TextLink to="/api/builder">Builder</TextLink>.
-        </AlertBox>
-      </>
-    ),
-  },
-  {
-    path: '/documentation/builder-behavior',
-    title: 'Builder Behavior',
-    sectionKey: 'getting-started',
-    sectionTitle: 'Getting Started',
-    summary: '',
-    description:
-      'Documentation for clone controls, drag-and-drop, insertion placement, root-group behavior, and group mode configuration.',
-    searchText:
-      'builder behavior cloneable clone controls draggable drag and drop allowGroupNegation group negation not groups readOnlyProtectsDelete newNodePlacement append prepend singleRootGroup groupTypes with modifiers without modifiers both root group',
-    content: (
-      <>
-        <p>
-          A few builder props shape the overall editing model more than the
-          field or query data itself. These are worth deciding early because
-          they affect how users add, move, and organize rules.
-        </p>
-        <CodeBlock code={builderBehaviorSnippet} language="tsx" label="Builder behavior" />
-        <SectionTitle>cloneable</SectionTitle>
-        <List>
-          <li>Defaults to <InlineCode>false</InlineCode> and renders built-in clone controls for rules and groups.</li>
-          <li>The clone button appears immediately to the left of the lock button when both controls are enabled.</li>
-          <li>Cloning a rule inserts a duplicate directly below that rule.</li>
-          <li>Cloning a group duplicates the entire subtree and inserts the clone directly below that group.</li>
-          <li>When <InlineCode>singleRootGroup</InlineCode> is enabled, the synthetic root group does not expose a clone control.</li>
-        </List>
-        <SectionTitle>draggable</SectionTitle>
-        <List>
-          <li>Use <InlineCode>lockable</InlineCode> to expose lock controls directly in the UI.</li>
-          <li>Enables drag-and-drop reordering and movement for editable rules and groups.</li>
-          <li>Read-only rules and groups are excluded from dragging.</li>
-          <li>When the entire builder is read-only, drag-and-drop is disabled as well.</li>
-          <li>Empty groups expose a dedicated drop zone so items can be moved into them.</li>
-        </List>
-        <SectionTitle>readOnlyProtectsDelete</SectionTitle>
-        <List>
-          <li>Defaults to <InlineCode>true</InlineCode>.</li>
-          <li>When enabled, deleting a group is blocked if that would indirectly remove read-only protected descendants.</li>
-          <li>Set it to <InlineCode>false</InlineCode> when your product wants only directly protected nodes to be non-deletable, while still allowing parent-group deletes around them.</li>
-        </List>
-        <SectionTitle>singleRootGroup</SectionTitle>
-        <List>
-          <li>
-            Defaults to <InlineCode>true</InlineCode>, which means the builder
-            maintains a single root group around the visible tree.
-          </li>
-          <li>
-            The root group cannot be deleted while <InlineCode>singleRootGroup</InlineCode>{' '}
-            is enabled.
-          </li>
-          <li>
-            Set it to <InlineCode>false</InlineCode> when your application
-            wants multiple top-level nodes instead of one wrapped root group.
-          </li>
-        </List>
-        <SectionTitle>newNodePlacement</SectionTitle>
-        <List>
-          <li>
-            Defaults to <InlineCode>'append'</InlineCode>, which inserts newly
-            added rules and groups at the end of their parent.
-          </li>
-          <li>
-            Set it to <InlineCode>'prepend'</InlineCode> to insert new rules
-            and groups at the beginning of their parent instead.
-          </li>
-          <li>
-            This affects built-in Add Rule and Add Group controls, root-level
-            add controls, and imperative ref methods when no explicit index is
-            provided.
-          </li>
-          <li>
-            It does not change cloning or drag-and-drop behavior, since those
-            actions already use explicit target positions.
-          </li>
-        </List>
-        <SectionTitle>groupTypes</SectionTitle>
-        <List>
-          <li>
-            <InlineCode>with-modifiers</InlineCode> shows group controls such as{' '}
-            <InlineCode>AND</InlineCode>, <InlineCode>OR</InlineCode>, and negation.
-          </li>
-          <li>
-            <InlineCode>without-modifiers</InlineCode> creates structural groups
-            that do not render combinator or negation controls.
-          </li>
-          <li>
-            <InlineCode>both</InlineCode> lets users choose which group kind to
-            insert when adding a new group.
-          </li>
-        </List>
-        <SectionTitle>allowGroupNegation</SectionTitle>
-        <List>
-          <li>
-            Set <InlineCode>allowGroupNegation={false}</InlineCode> when you want
-            groups to keep combinators like <InlineCode>AND</InlineCode> and{' '}
-            <InlineCode>OR</InlineCode> but remove the group-level{' '}
-            <InlineCode>NOT</InlineCode> option.
-          </li>
-          <li>
-            This is narrower than <InlineCode>groupTypes</InlineCode>: it only
-            disables negating whole groups and does not affect whether groups
-            render combinator controls.
-          </li>
-          <li>
-            Operator-level negation still works normally, including{' '}
-            <InlineCode>NOT IN</InlineCode>, <InlineCode>NOT LIKE</InlineCode>,{' '}
-            <InlineCode>IS NOT NULL</InlineCode>, and{' '}
-            <InlineCode>NOT BETWEEN</InlineCode>.
-          </li>
-          <li>
-            When disabled, incoming negated groups are normalized to non-negated
-            form so the builder output stays consistent with the visible UI.
-          </li>
-        </List>
-        <AlertBox title="Related docs" variant="info">
-          <TextLink to="/documentation/history">Undo and Redo</TextLink>,{' '}
-          <TextLink to="/documentation/builder-ref">Builder Ref</TextLink>,{' '}
-          <TextLink to="/documentation/locking-and-read-only">Locking and Read-only</TextLink>{' '}
-          and <TextLink to="/api/builder">Builder</TextLink>.
         </AlertBox>
       </>
     ),
@@ -2186,6 +2369,50 @@ export const documentationPages: IDocumentationPage[] = [
         <List>
           <li>API and datastore integrations with format-specific output conventions.</li>
         </List>
+        <SectionTitle>Advanced: Field-To-Field Comparisons</SectionTitle>
+        <p>
+          Most formats on this page can be explored with ordinary literal-based
+          rules. If you specifically need one field to compare against another,
+          start with <TextLink to="/documentation/field-comparisons">Field Comparisons</TextLink>{' '}
+          and then use the native field-reference support only in formats that
+          have a direct right-hand-side field form.
+        </p>
+        <List>
+          <li>
+            Supported native field-to-field formats in this feature are{' '}
+            <InlineCode>SQL</InlineCode>, <InlineCode>Mongo</InlineCode>,{' '}
+            <InlineCode>AQL</InlineCode>, <InlineCode>JSONata</InlineCode>,{' '}
+            <InlineCode>JsonLogic</InlineCode>, <InlineCode>CEL</InlineCode>,{' '}
+            <InlineCode>SpEL</InlineCode>, <InlineCode>Prisma</InlineCode>,{' '}
+            <InlineCode>OData</InlineCode>, <InlineCode>Dynamo</InlineCode>,
+            and <InlineCode>Django</InlineCode>.
+          </li>
+          <li>
+            String-style field references are also supported where the target
+            format has a native form for them, such as{' '}
+            <InlineCode>contains</InlineCode>,{' '}
+            <InlineCode>startsWith</InlineCode>, and{' '}
+            <InlineCode>endsWith</InlineCode> in{' '}
+            <InlineCode>CEL</InlineCode>, <InlineCode>OData</InlineCode>,{' '}
+            <InlineCode>Django</InlineCode>, and <InlineCode>SpEL</InlineCode>.
+          </li>
+          <li>
+            <InlineCode>Elasticsearch</InlineCode> and{' '}
+            <InlineCode>RSQL</InlineCode> intentionally reject field
+            comparisons because supporting them would require invented syntax or
+            non-native backend semantics.
+          </li>
+        </List>
+        <CodeBlock
+          code={fieldComparisonFormatSnippet}
+          language="ts"
+          label="Formatting a field comparison"
+        />
+        <CodeBlock
+          code={fieldComparisonParseSnippet}
+          language="ts"
+          label="Parsing a field comparison"
+        />
         <AlertBox title="API reference" variant="info">
           <TextLink to="/api/format-query">formatQuery</TextLink> and{' '}
           <TextLink to="/api/parse-query">parseQuery</TextLink>.

--- a/example/src/utils/builder-source/format-builder-source.ts
+++ b/example/src/utils/builder-source/format-builder-source.ts
@@ -16,6 +16,7 @@ export const formatBuilderSource = ({
   cloneable,
   draggable,
   allowGroupNegation,
+  allowFieldComparisons,
   newNodePlacement,
   history,
   textMode,
@@ -81,7 +82,7 @@ import { components as radixComponents } from '@vojtechportes/react-query-builde
     .filter(Boolean)
     .join('\n');
 
-  const builderProps = [
+  const builderProps: string[] = [
     'data={data}',
     'fields={demoFields}',
     'onChange={setData}',
@@ -93,6 +94,7 @@ import { components as radixComponents } from '@vojtechportes/react-query-builde
     cloneable ? 'cloneable' : null,
     draggable ? 'draggable' : null,
     allowGroupNegation ? null : 'allowGroupNegation={false}',
+    allowFieldComparisons ? 'allowFieldComparisons' : null,
     newNodePlacement === 'prepend'
       ? 'newNodePlacement="prepend"'
       : null,
@@ -108,7 +110,7 @@ import { components as radixComponents } from '@vojtechportes/react-query-builde
     usesFluentUiAdapter ? 'components={fluentUiComponents}' : null,
     usesRadixAdapter ? 'components={radixComponents}' : null,
     usesBootstrapAdapter ? 'components={bootstrapComponents}' : null,
-  ].filter(Boolean);
+  ].filter((prop): prop is string => Boolean(prop));
 
   const componentExpression = useMonacoTextEditor
     ? usesMuiAdapter
@@ -148,7 +150,7 @@ import { components as radixComponents } from '@vojtechportes/react-query-builde
     ? [
         '    <ThemeProvider',
         '      colors={',
-        formatThemeOverrides(themeOverrides)
+        formatThemeOverrides(themeOverrides!)
           .split('\n')
           .map(line => `      ${line}`)
           .join('\n'),
@@ -188,3 +190,6 @@ import { components as radixComponents } from '@vojtechportes/react-query-builde
     .filter(line => line !== null)
     .join('\n');
 };
+
+
+

--- a/example/src/utils/builder-source/types/index.ts
+++ b/example/src/utils/builder-source/types/index.ts
@@ -1,4 +1,4 @@
-import type { IColors } from '../../../../src/constants/colors';
+import type { IColors } from '../../../../../src/constants/colors';
 
 export type CustomizationMode =
   | 'default'
@@ -16,6 +16,7 @@ export interface IBuilderSourceOptions {
   cloneable: boolean;
   draggable: boolean;
   allowGroupNegation: boolean;
+  allowFieldComparisons: boolean;
   newNodePlacement: 'append' | 'prepend';
   history: boolean;
   textMode: boolean;
@@ -27,3 +28,5 @@ export interface IBuilderSourceOptions {
   themeColors: IColors;
   defaultThemeColors: IColors;
 }
+
+

--- a/example/src/utils/builder-source/utils/create-theme-overrides.util.ts
+++ b/example/src/utils/builder-source/utils/create-theme-overrides.util.ts
@@ -1,34 +1,37 @@
-import type { IColors } from '../../../../src/constants/colors';
+import type { IColors } from '../../../../../src/constants/colors';
 
 export const createThemeOverrides = (
   themeColors: IColors,
   defaultThemeColors: IColors
 ): Partial<IColors> | null => {
   const overrides: Partial<IColors> = {};
+  const overrideRecord = overrides as Record<keyof IColors, IColors[keyof IColors] | undefined>;
 
   for (const colorGroupKey of Object.keys(themeColors) as Array<keyof IColors>) {
     const nextValue = themeColors[colorGroupKey];
     const defaultValue = defaultThemeColors[colorGroupKey];
 
-    if (
-      typeof nextValue === 'string' ||
-      typeof defaultValue === 'string'
-    ) {
+    if (typeof nextValue === 'string' || typeof defaultValue === 'string') {
       if (nextValue !== defaultValue) {
-        overrides[colorGroupKey] = nextValue;
+        overrideRecord[colorGroupKey] = nextValue as IColors[keyof IColors];
       }
 
       continue;
     }
 
+    const nextValueRecord = nextValue as unknown as Record<string, string>;
+    const defaultValueRecord = defaultValue as unknown as Record<string, string>;
     const nestedOverrides = Object.fromEntries(
-      Object.entries(nextValue).filter(([key, value]) => value !== defaultValue[key])
+      Object.entries(nextValueRecord).filter(
+        ([key, value]) => value !== defaultValueRecord[key]
+      )
     );
 
     if (Object.keys(nestedOverrides).length > 0) {
-      overrides[colorGroupKey] = nestedOverrides as IColors[keyof IColors];
+      overrideRecord[colorGroupKey] = nestedOverrides as unknown as IColors[keyof IColors];
     }
   }
 
   return Object.keys(overrides).length > 0 ? overrides : null;
 };
+

--- a/example/src/utils/builder-source/utils/format-theme-overrides.util.ts
+++ b/example/src/utils/builder-source/utils/format-theme-overrides.util.ts
@@ -1,4 +1,4 @@
-import type { IColors } from '../../../../src/constants/colors';
+import type { IColors } from '../../../../../src/constants/colors';
 
 export const formatThemeOverrides = (themeOverrides: Partial<IColors>): string => {
   const lines = Object.entries(themeOverrides).flatMap(([key, value]) => {
@@ -20,3 +20,4 @@ export const formatThemeOverrides = (themeOverrides: Partial<IColors>): string =
 
   return ['{', '    ...colors,', ...lines, '  }'].join('\n');
 };
+

--- a/src/builder-context.tsx
+++ b/src/builder-context.tsx
@@ -25,6 +25,7 @@ export interface IBuilderContextProps {
   cloneable?: boolean;
   draggable?: boolean;
   allowGroupNegation?: boolean;
+  allowFieldComparisons?: boolean;
   singleRootGroup?: boolean;
   groupTypes?: BuilderGroupMode;
   newNodePlacement?: BuilderNewNodePlacement;
@@ -63,6 +64,7 @@ export interface IBuilderContextProviderProps {
   cloneable?: boolean;
   draggable?: boolean;
   allowGroupNegation?: boolean;
+  allowFieldComparisons?: boolean;
   singleRootGroup?: boolean;
   groupTypes?: BuilderGroupMode;
   newNodePlacement?: BuilderNewNodePlacement;
@@ -99,6 +101,7 @@ export const BuilderContextProvider: FC<IBuilderContextProviderProps> = ({
   cloneable,
   draggable,
   allowGroupNegation,
+  allowFieldComparisons,
   singleRootGroup,
   groupTypes,
   newNodePlacement,
@@ -167,6 +170,7 @@ export const BuilderContextProvider: FC<IBuilderContextProviderProps> = ({
         cloneable,
         draggable,
         allowGroupNegation,
+        allowFieldComparisons,
         singleRootGroup,
         groupTypes,
         newNodePlacement,
@@ -183,3 +187,4 @@ export const BuilderContextProvider: FC<IBuilderContextProviderProps> = ({
     </BuilderContext.Provider>
   );
 };
+

--- a/src/builder/builder.test.tsx
+++ b/src/builder/builder.test.tsx
@@ -16,7 +16,7 @@ import {
   IBuilderRef,
   useBuilderRef,
 } from './index';
-import { DenormalizedQuery, INormalizedRuleNode } from '../utils/query-tree';
+import { DenormalizedQuery } from '../utils/query-tree';
 
 export const fields: IBuilderFieldProps[] = [
   {
@@ -1878,7 +1878,14 @@ describe('#components/Builder', () => {
         type: 'GROUP',
         value: 'AND',
         isNegated: false,
-        children: [{ field: 'MOCK_FIELD', value: 'beta', operator: 'EQUAL' }],
+        children: [
+          {
+            field: 'MOCK_FIELD',
+            value: 'beta',
+            valueSource: 'value',
+            operator: 'EQUAL',
+          },
+        ],
       },
     ]);
 
@@ -1900,7 +1907,14 @@ describe('#components/Builder', () => {
         type: 'GROUP',
         value: 'AND',
         isNegated: false,
-        children: [{ field: 'MOCK_FIELD', value: 'beta', operator: 'EQUAL' }],
+        children: [
+          {
+            field: 'MOCK_FIELD',
+            value: 'beta',
+            valueSource: 'value',
+            operator: 'EQUAL',
+          },
+        ],
       },
     ]);
   });
@@ -2460,7 +2474,14 @@ describe('#components/Builder', () => {
         type: 'GROUP',
         value: 'AND',
         isNegated: false,
-        children: [{ field: 'MOCK_NUMBER', value: 42.5, operator: 'EQUAL' }],
+        children: [
+          {
+            field: 'MOCK_NUMBER',
+            value: 42.5,
+            valueSource: 'value',
+            operator: 'EQUAL',
+          },
+        ],
       },
     ]);
   });
@@ -3327,7 +3348,12 @@ describe('#components/Builder', () => {
           { field: 'MOCK_FIELD', value: 'alpha', operator: 'EQUAL' },
           { field: 'MOCK_FIELD', value: 'alpha', operator: 'EQUAL' },
           { field: 'MOCK_NUMBER', value: 5, operator: 'NOT_EQUAL' },
-          { field: 'MOCK_FIELD', value: 'beta', operator: 'EQUAL' },
+          {
+            field: 'MOCK_FIELD',
+            value: 'beta',
+            valueSource: 'value',
+            operator: 'EQUAL',
+          },
         ],
       },
     ]);
@@ -3349,7 +3375,12 @@ describe('#components/Builder', () => {
           },
           { field: 'MOCK_FIELD', value: 'alpha', operator: 'EQUAL' },
           { field: 'MOCK_NUMBER', value: 5, operator: 'NOT_EQUAL' },
-          { field: 'MOCK_FIELD', value: 'beta', operator: 'EQUAL' },
+          {
+            field: 'MOCK_FIELD',
+            value: 'beta',
+            valueSource: 'value',
+            operator: 'EQUAL',
+          },
         ],
       },
     ]);
@@ -3367,7 +3398,12 @@ describe('#components/Builder', () => {
           { field: 'MOCK_NUMBER', value: 5, operator: 'NOT_EQUAL' },
           { field: 'MOCK_FIELD', value: 'alpha', operator: 'EQUAL' },
           { field: 'MOCK_FIELD', value: 'alpha', operator: 'EQUAL' },
-          { field: 'MOCK_FIELD', value: 'beta', operator: 'EQUAL' },
+          {
+            field: 'MOCK_FIELD',
+            value: 'beta',
+            valueSource: 'value',
+            operator: 'EQUAL',
+          },
         ],
       },
     ]);
@@ -3375,7 +3411,7 @@ describe('#components/Builder', () => {
     act(() => {
       expect(
         getBuilderRef().updateNode(secondRuleId, (node) =>
-          'field' in node
+          'field' in node && node.valueSource !== 'field'
             ? {
                 ...node,
                 value: 10,
@@ -3393,7 +3429,12 @@ describe('#components/Builder', () => {
           { field: 'MOCK_NUMBER', value: 10, operator: 'NOT_EQUAL' },
           { field: 'MOCK_FIELD', value: 'alpha', operator: 'EQUAL' },
           { field: 'MOCK_FIELD', value: 'alpha', operator: 'EQUAL' },
-          { field: 'MOCK_FIELD', value: 'beta', operator: 'EQUAL' },
+          {
+            field: 'MOCK_FIELD',
+            value: 'beta',
+            valueSource: 'value',
+            operator: 'EQUAL',
+          },
         ],
       },
     ]);
@@ -3413,7 +3454,12 @@ describe('#components/Builder', () => {
           { field: 'MOCK_NUMBER', value: 5, operator: 'NOT_EQUAL' },
           { field: 'MOCK_FIELD', value: 'alpha', operator: 'EQUAL' },
           { field: 'MOCK_FIELD', value: 'alpha', operator: 'EQUAL' },
-          { field: 'MOCK_FIELD', value: 'beta', operator: 'EQUAL' },
+          {
+            field: 'MOCK_FIELD',
+            value: 'beta',
+            valueSource: 'value',
+            operator: 'EQUAL',
+          },
         ],
       },
     ]);
@@ -3430,7 +3476,12 @@ describe('#components/Builder', () => {
           { field: 'MOCK_NUMBER', value: 10, operator: 'NOT_EQUAL' },
           { field: 'MOCK_FIELD', value: 'alpha', operator: 'EQUAL' },
           { field: 'MOCK_FIELD', value: 'alpha', operator: 'EQUAL' },
-          { field: 'MOCK_FIELD', value: 'beta', operator: 'EQUAL' },
+          {
+            field: 'MOCK_FIELD',
+            value: 'beta',
+            valueSource: 'value',
+            operator: 'EQUAL',
+          },
         ],
       },
     ]);
@@ -3451,7 +3502,12 @@ describe('#components/Builder', () => {
         children: [
           { field: 'MOCK_NUMBER', value: 10, operator: 'NOT_EQUAL' },
           { field: 'MOCK_FIELD', value: 'alpha', operator: 'EQUAL' },
-          { field: 'MOCK_FIELD', value: 'beta', operator: 'EQUAL' },
+          {
+            field: 'MOCK_FIELD',
+            value: 'beta',
+            valueSource: 'value',
+            operator: 'EQUAL',
+          },
         ],
       },
     ]);
@@ -3669,10 +3725,14 @@ describe('#components/Builder', () => {
 
     act(() => {
       expect(
-        builderRef?.current?.updateNode(firstRuleId as string, (node) => ({
-          ...(node as INormalizedRuleNode),
-          value: 'beta',
-        }))
+        builderRef?.current?.updateNode(firstRuleId as string, (node) =>
+          'field' in node && node.valueSource !== 'field'
+            ? {
+                ...node,
+                value: 'beta',
+              }
+            : node
+        )
       ).toBe(true);
     });
 
@@ -3902,10 +3962,14 @@ describe('#components/Builder', () => {
 
     act(() => {
       expect(
-        builderRef?.current?.updateNode(firstCountryRuleId as string, (node) => ({
-          ...(node as INormalizedRuleNode),
-          value: 'SK',
-        }))
+        builderRef?.current?.updateNode(firstCountryRuleId as string, (node) =>
+          'field' in node && node.valueSource !== 'field'
+            ? {
+                ...node,
+                value: 'SK',
+              }
+            : node
+        )
       ).toBe(true);
     });
 
@@ -4029,10 +4093,14 @@ describe('#components/Builder', () => {
 
     act(() => {
       expect(
-        builderRef?.current?.updateNode(firstCountryRuleId as string, (node) => ({
-          ...(node as INormalizedRuleNode),
-          value: 'SK',
-        }))
+        builderRef?.current?.updateNode(firstCountryRuleId as string, (node) =>
+          'field' in node && node.valueSource !== 'field'
+            ? {
+                ...node,
+                value: 'SK',
+              }
+            : node
+        )
       ).toBe(true);
     });
 
@@ -4583,7 +4651,12 @@ describe('#components/Builder', () => {
             value: 'AND',
             isNegated: false,
             children: [
-              { field: 'MOCK_FIELD', value: 'beta', operator: 'EQUAL' },
+              {
+                field: 'MOCK_FIELD',
+                value: 'beta',
+                valueSource: 'value',
+                operator: 'EQUAL',
+              },
             ],
           },
         ],
@@ -4647,7 +4720,12 @@ describe('#components/Builder', () => {
         value: 'AND',
         isNegated: false,
         children: [
-          { field: 'MOCK_FIELD', value: 'beta', operator: 'EQUAL' },
+          {
+            field: 'MOCK_FIELD',
+            value: 'beta',
+            valueSource: 'value',
+            operator: 'EQUAL',
+          },
           { field: 'MOCK_FIELD', value: 'alpha', operator: 'EQUAL' },
           { field: 'MOCK_NUMBER', value: 5, operator: 'NOT_EQUAL' },
         ],
@@ -4905,3 +4983,123 @@ describe('#components/Builder', () => {
     expect(queryByDataTest(container, 'Remove')).not.toBeNull();
   });
 });
+
+describe('field-comparison validation surfaces', () => {
+  it('renders field-comparison validation errors for unsupported operators in builder mode', async () => {
+    render(
+      <Builder
+        fields={[
+          {
+            field: 'TEXT_A',
+            label: 'Text A',
+            type: 'TEXT',
+            operators: ['EQUAL', 'BETWEEN'],
+          },
+          {
+            field: 'TEXT_B',
+            label: 'Text B',
+            type: 'TEXT',
+            operators: ['EQUAL', 'BETWEEN'],
+          },
+        ]}
+        data={[
+          {
+            type: 'GROUP',
+            value: 'AND',
+            isNegated: false,
+            children: [
+              {
+                field: 'TEXT_A',
+                operator: 'BETWEEN',
+                valueSource: 'field',
+                valueField: 'TEXT_B',
+              },
+            ],
+          },
+        ]}
+        showValidation
+      />
+    );
+
+    expect(
+      await screen.findByText('Field-to-field comparison is not allowed')
+    ).toBeInTheDocument();
+  });
+
+  it('shows field-comparison semantic errors in the basic text editor', () => {
+    const { container } = render(
+      <Builder
+        fields={[
+          {
+            field: 'LIST_FIELD',
+            label: 'List Field',
+            type: 'LIST',
+            value: [{ value: 'alpha', label: 'Alpha' }],
+            operators: ['EQUAL'],
+          },
+          {
+            field: 'TEXT_FIELD',
+            label: 'Text Field',
+            type: 'TEXT',
+            operators: ['EQUAL'],
+          },
+        ]}
+        data={[]}
+        textMode
+        defaultMode="text"
+        onChange={jest.fn()}
+      />
+    );
+
+    fireEvent.change(getByDataTest(container, 'TextModeEditor'), {
+      target: { value: 'LIST_FIELD = TEXT_FIELD' },
+    });
+
+    expect(getByDataTest(container, 'TextModeError').textContent).toContain(
+      'Field-to-field comparison is not allowed'
+    );
+    expect(queryByDataTest(container, 'TextModeDiagnostic[0]')).not.toBeNull();
+  });
+  it('reports unsupported SQL field-to-field comparisons clearly in text mode', () => {
+    const comparisonFields: IBuilderFieldProps[] = [
+      {
+        field: 'MOCK_FIELD',
+        label: 'Mock Field',
+        type: 'TEXT',
+        operators: ['STARTS_WITH'],
+        fieldComparison: { type: 'string' },
+      },
+      {
+        field: 'PREFIX_FIELD',
+        label: 'Prefix Field',
+        type: 'TEXT',
+        operators: ['EQUAL'],
+        fieldComparison: { type: 'string' },
+      },
+    ];
+
+    const { container } = render(
+      <Builder
+        fields={comparisonFields}
+        data={[
+          {
+            field: 'MOCK_FIELD',
+            operator: 'STARTS_WITH',
+            valueSource: 'field',
+            valueField: 'PREFIX_FIELD',
+          },
+        ]}
+        textMode
+        onChange={jest.fn()}
+      />
+    );
+
+    fireEvent.click(getByDataTest(container, 'TextModeToggle'));
+
+    expect(getByDataTest(container, 'TextModeError').textContent).toContain(
+      'SQL does not support field-to-field comparisons for field "MOCK_FIELD" and operator "STARTS_WITH".'
+    );
+  });
+});
+
+

--- a/src/builder/builder.tsx
+++ b/src/builder/builder.tsx
@@ -71,6 +71,33 @@ import {
 } from '../utils/remove-query-negation.util';
 import { removeNormalizedQueryNegation } from '../utils/remove-normalized-query-negation.util';
 
+const tryFormatBuilderTextState = (
+  data: DenormalizedQuery,
+  fields: IBuilderProps['fields'],
+  options?: Parameters<typeof formatBuilderSqlState>[2]
+): {
+  textState: ReturnType<typeof formatBuilderSqlState>;
+  errorMessage: string | null;
+} => {
+  try {
+    return {
+      textState: formatBuilderSqlState(data, fields, options),
+      errorMessage: null,
+    };
+  } catch (error) {
+    return {
+      textState: {
+        value: '',
+        protectedRanges: [],
+      },
+      errorMessage:
+        error instanceof Error
+          ? error.message
+          : 'Failed to format SQL text mode state.',
+    };
+  }
+};
+
 export const Builder = forwardRef<IBuilderRef, IBuilderProps>(({
   data: originalData = [],
   fields,
@@ -82,6 +109,7 @@ export const Builder = forwardRef<IBuilderRef, IBuilderProps>(({
   cloneable = false,
   draggable = false,
   allowGroupNegation = true,
+  allowFieldComparisons = false,
   singleRootGroup = true,
   groupTypes = 'with-modifiers',
   newNodePlacement = 'append',
@@ -131,29 +159,29 @@ export const Builder = forwardRef<IBuilderRef, IBuilderProps>(({
   const initialData = initialTextModeEnabled
     ? normalizeBuilderTextModeQuery(compatibleOriginalData)
     : compatibleOriginalData;
+  const initialFormattedTextState = initialTextModeEnabled
+    ? tryFormatBuilderTextState(initialData, fields, {
+        protectGroupDeletionBoundaries: readOnlyProtectsDelete,
+      })
+    : {
+        textState: { value: '', protectedRanges: [] },
+        errorMessage: null,
+      };
   const [data, setData] = useState<NormalizedQuery>(() =>
     sanitizeNormalizedQuery(
       ingestQuery(initialData, initialRootGroupType, singleRootGroup)
     )
   );
   const [mode, setMode] = useState<'builder' | 'text'>(resolvedDefaultMode);
-  const [textValue, setTextValue] = useState<string>(() => {
-    if (!initialTextModeEnabled) {
-      return '';
-    }
-
-    return formatBuilderSqlState(initialData, fields).value;
-  });
+  const [textValue, setTextValue] = useState<string>(
+    () => initialFormattedTextState.textState.value
+  );
   const [textProtectedRanges, setTextProtectedRanges] = useState<
     ReturnType<typeof formatBuilderSqlState>['protectedRanges']
-  >(() =>
-    initialTextModeEnabled
-      ? formatBuilderSqlState(initialData, fields, {
-          protectGroupDeletionBoundaries: readOnlyProtectsDelete,
-        }).protectedRanges
-      : []
+  >(() => initialFormattedTextState.textState.protectedRanges);
+  const [textErrorMessage, setTextErrorMessage] = useState<string | null>(
+    () => initialFormattedTextState.errorMessage
   );
-  const [textErrorMessage, setTextErrorMessage] = useState<string | null>(null);
   const [textDiagnostics, setTextDiagnostics] = useState<
     ReturnType<typeof parseBuilderSqlText>['diagnostics']
   >([]);
@@ -222,6 +250,7 @@ export const Builder = forwardRef<IBuilderRef, IBuilderProps>(({
     singleRootGroup,
     groupTypes: effectiveGroupTypes,
     allowGroupNegation,
+    allowFieldComparisons,
     strings,
     validator,
     onStateChange,
@@ -334,8 +363,9 @@ export const Builder = forwardRef<IBuilderRef, IBuilderProps>(({
           field: '',
           id: createId(),
           parent: parentId,
+          valueSource: 'value',
           ...clone(rule),
-        };
+        } as INormalizedRuleNode;
 
         return commitData(
           createInsertSubtreeAction([nextRule], resolvedIndex, parentId)
@@ -523,7 +553,9 @@ export const Builder = forwardRef<IBuilderRef, IBuilderProps>(({
         return commitData(
           createReplaceNodeAction(ruleId, {
             ...ruleNode,
+            valueSource: 'value',
             value: nextValue,
+            valueField: undefined,
           })
         );
       },
@@ -645,7 +677,7 @@ export const Builder = forwardRef<IBuilderRef, IBuilderProps>(({
       return;
     }
 
-    const nextTextState = formatBuilderSqlState(
+    const nextFormattedTextState = tryFormatBuilderTextState(
       normalizeBuilderTextModeQuery(sanitizeDenormalizedQuery(emitQuery(data))),
       fields,
       {
@@ -653,10 +685,10 @@ export const Builder = forwardRef<IBuilderRef, IBuilderProps>(({
       }
     );
 
-    setTextValue(nextTextState.value);
-    setTextProtectedRanges(nextTextState.protectedRanges);
+    setTextValue(nextFormattedTextState.textState.value);
+    setTextProtectedRanges(nextFormattedTextState.textState.protectedRanges);
     setTextDiagnostics([]);
-    setTextErrorMessage(null);
+    setTextErrorMessage(nextFormattedTextState.errorMessage);
   }, [data, fields, mode, readOnlyProtectsDelete, sanitizeDenormalizedQuery, textModeEnabled]);
 
   const handleAddRootGroup = useCallback(() => {
@@ -696,7 +728,7 @@ export const Builder = forwardRef<IBuilderRef, IBuilderProps>(({
   }, []);
 
   const handleSwitchToTextMode = useCallback(() => {
-    const nextTextState = formatBuilderSqlState(
+    const nextFormattedTextState = tryFormatBuilderTextState(
       normalizeBuilderTextModeQuery(sanitizeDenormalizedQuery(emitQuery(data))),
       fields,
       {
@@ -704,10 +736,10 @@ export const Builder = forwardRef<IBuilderRef, IBuilderProps>(({
       }
     );
 
-    setTextValue(nextTextState.value);
-    setTextProtectedRanges(nextTextState.protectedRanges);
+    setTextValue(nextFormattedTextState.textState.value);
+    setTextProtectedRanges(nextFormattedTextState.textState.protectedRanges);
     setTextDiagnostics([]);
-    setTextErrorMessage(null);
+    setTextErrorMessage(nextFormattedTextState.errorMessage);
     setMode('text');
   }, [data, fields, readOnlyProtectsDelete, sanitizeDenormalizedQuery]);
 
@@ -717,6 +749,7 @@ export const Builder = forwardRef<IBuilderRef, IBuilderProps>(({
 
       const parseResult = parseBuilderSqlText(nextText, fields, strings, {
         allowGroupNegation,
+        allowFieldComparisons,
       });
       const currentQuery = sanitizeDenormalizedQuery(emitQuery(data));
       const readOnlyTargetDiagnostic =
@@ -786,6 +819,7 @@ export const Builder = forwardRef<IBuilderRef, IBuilderProps>(({
     },
     [
       allowGroupNegation,
+      allowFieldComparisons,
       commitData,
       data,
       readOnlyProtectsDelete,
@@ -860,6 +894,7 @@ export const Builder = forwardRef<IBuilderRef, IBuilderProps>(({
       cloneable={cloneable}
       draggable={draggable}
       allowGroupNegation={allowGroupNegation}
+      allowFieldComparisons={allowFieldComparisons}
       singleRootGroup={singleRootGroup}
       groupTypes={effectiveGroupTypes}
       newNodePlacement={newNodePlacement}
@@ -931,3 +966,6 @@ export const Builder = forwardRef<IBuilderRef, IBuilderProps>(({
 });
 
 Builder.displayName = 'Builder';
+
+
+

--- a/src/builder/hooks/use-builder-validation.ts
+++ b/src/builder/hooks/use-builder-validation.ts
@@ -20,6 +20,7 @@ export interface IUseBuilderValidationArgs {
   singleRootGroup: boolean;
   groupTypes: BuilderGroupMode;
   allowGroupNegation: boolean;
+  allowFieldComparisons: boolean;
   strings: IStrings;
   validator?: IBuilderValidator;
   onStateChange?: (state: IBuilderStateChange) => void;
@@ -34,6 +35,7 @@ export const useBuilderValidation = ({
   singleRootGroup,
   groupTypes,
   allowGroupNegation,
+  allowFieldComparisons,
   strings,
   validator,
   onStateChange,
@@ -104,6 +106,7 @@ export const useBuilderValidation = ({
       singleRootGroup,
       groupTypes,
       allowGroupNegation,
+      allowFieldComparisons,
       strings,
     };
     const validationResult = validator
@@ -128,6 +131,7 @@ export const useBuilderValidation = ({
     fields,
     groupTypes,
     allowGroupNegation,
+    allowFieldComparisons,
     onStateChange,
     originalData,
     singleRootGroup,
@@ -137,3 +141,4 @@ export const useBuilderValidation = ({
 
   return validation;
 };
+

--- a/src/builder/index.ts
+++ b/src/builder/index.ts
@@ -24,6 +24,7 @@ export type {
   BuilderValidationMessage,
   BuilderValidationSeverity,
   IBuilderTextModeConfig,
+  BuilderFieldComparisonType,
   BuilderFieldOperator,
   BuilderFieldOption,
   BuilderFieldOptionsStatus,
@@ -42,6 +43,7 @@ export type {
   IBooleanFieldValidation,
   IBuilderComponentsProps,
   IBuilderFieldChange,
+  IBuilderFieldComparisonConfig,
   IBuilderRuleDependencyEntry,
   IBuilderFieldDependencyEntry,
   IBuilderFieldProps,
@@ -95,3 +97,4 @@ export type {
   IBooleanValueValidationRule,
   IBuilderHistoryState,
 } from './types';
+

--- a/src/builder/text-mode/utils/create-field-comparison-not-allowed-diagnostic.util.ts
+++ b/src/builder/text-mode/utils/create-field-comparison-not-allowed-diagnostic.util.ts
@@ -1,0 +1,21 @@
+import { IStrings } from '../../../constants/strings';
+import { getValidationString } from '../../../utils/validation/get-validation-string.util';
+import { ITextModeDiagnostic } from '../types/text-mode-diagnostic';
+
+export const createFieldComparisonNotAllowedDiagnostic = (
+  fieldName: string,
+  operator: string,
+  start: number,
+  end: number,
+  strings: IStrings
+): ITextModeDiagnostic => ({
+  code: 'field_comparison_not_allowed',
+  message: getValidationString(
+    strings.validation,
+    'fieldComparisonNotAllowed',
+    `Field-to-field comparison is not allowed for field "${fieldName}" and operator "${operator}"`,
+    { field: fieldName, operator }
+  ),
+  start,
+  end,
+});

--- a/src/builder/text-mode/utils/create-value-field-not-found-diagnostic.util.ts
+++ b/src/builder/text-mode/utils/create-value-field-not-found-diagnostic.util.ts
@@ -1,0 +1,20 @@
+import { IStrings } from '../../../constants/strings';
+import { getValidationString } from '../../../utils/validation/get-validation-string.util';
+import { ITextModeDiagnostic } from '../types/text-mode-diagnostic';
+
+export const createValueFieldNotFoundDiagnostic = (
+  fieldName: string,
+  start: number,
+  end: number,
+  strings: IStrings
+): ITextModeDiagnostic => ({
+  code: 'value_field_not_found',
+  message: getValidationString(
+    strings.validation,
+    'valueFieldNotFound',
+    `Comparison field "${fieldName}" was not found`,
+    { field: fieldName }
+  ),
+  start,
+  end,
+});

--- a/src/builder/text-mode/utils/parse-builder-sql-text.ts
+++ b/src/builder/text-mode/utils/parse-builder-sql-text.ts
@@ -6,6 +6,7 @@ import { validateBuilderSqlTextSemantics } from './validate-builder-sql-text-sem
 
 interface IParseBuilderSqlTextOptions {
   allowGroupNegation?: boolean;
+  allowFieldComparisons?: boolean;
 }
 
 export const parseBuilderSqlText = (
@@ -32,3 +33,4 @@ export const parseBuilderSqlText = (
     diagnostics: [...result.diagnostics, ...semanticDiagnostics],
   };
 };
+

--- a/src/builder/text-mode/utils/validate-builder-sql-text-semantics.test.ts
+++ b/src/builder/text-mode/utils/validate-builder-sql-text-semantics.test.ts
@@ -8,7 +8,36 @@ const fields: IBuilderFieldProps[] = [
     field: 'MOCK_FIELD',
     label: 'Mock Field',
     type: 'TEXT',
-    operators: ['EQUAL', 'IS_NOT_NULL', 'NOT_IN'],
+    operators: ['EQUAL', 'IS_NOT_NULL', 'LIKE', 'NOT_IN'],
+    fieldComparison: { type: 'string', comparableFields: ['OTHER_TEXT_FIELD', 'LIST_FIELD'] },
+  },
+  {
+    field: 'OTHER_TEXT_FIELD',
+    label: 'Other Text Field',
+    type: 'TEXT',
+    operators: ['EQUAL'],
+    fieldComparison: { type: 'string' },
+  },
+  {
+    field: 'THIRD_TEXT_FIELD',
+    label: 'Third Text Field',
+    type: 'TEXT',
+    operators: ['EQUAL'],
+    fieldComparison: { type: 'string' },
+  },
+  {
+    field: 'NUMBER_FIELD',
+    label: 'Number Field',
+    type: 'NUMBER',
+    operators: ['EQUAL'],
+  },
+  {
+    field: 'LIST_FIELD',
+    label: 'List Field',
+    type: 'LIST',
+    operators: ['EQUAL'],
+    value: [{ value: 'alpha', label: 'Alpha' }],
+    fieldComparison: { type: 'string' },
   },
 ];
 
@@ -81,4 +110,88 @@ describe('validateBuilderSqlTextSemantics', () => {
     expect(isNotNullDiagnostics).toEqual([]);
     expect(notInDiagnostics).toEqual([]);
   });
+
+  it('allows supported field-to-field comparisons when enabled', () => {
+    const diagnostics = validateBuilderSqlTextSemantics(
+      parseNodes('MOCK_FIELD = OTHER_TEXT_FIELD'),
+      fields,
+      strings,
+      { allowFieldComparisons: true }
+    );
+
+    expect(diagnostics).toEqual([]);
+  });
+
+  it('rejects field comparisons when the Builder flag is disabled', () => {
+    const diagnostics = validateBuilderSqlTextSemantics(
+      parseNodes('MOCK_FIELD = OTHER_TEXT_FIELD'),
+      fields,
+      strings,
+      { allowFieldComparisons: false }
+    );
+
+    expect(diagnostics).toContainEqual(
+      expect.objectContaining({
+        code: 'field_comparison_disabled',
+      })
+    );
+  });
+
+  it('reports missing comparison fields', () => {
+    const diagnostics = validateBuilderSqlTextSemantics(
+      parseNodes('MOCK_FIELD = UNKNOWN_FIELD'),
+      fields,
+      strings,
+      { allowFieldComparisons: true }
+    );
+
+    expect(diagnostics).toContainEqual(
+      expect.objectContaining({
+        code: 'value_field_not_found',
+      })
+    );
+  });
+
+  it('reports incompatible comparison fields', () => {
+    const typeMismatchDiagnostics = validateBuilderSqlTextSemantics(
+      parseNodes('MOCK_FIELD = NUMBER_FIELD'),
+      fields,
+      strings,
+      { allowFieldComparisons: true }
+    );
+    const selfComparisonDiagnostics = validateBuilderSqlTextSemantics(
+      parseNodes('MOCK_FIELD = MOCK_FIELD'),
+      fields,
+      strings,
+      { allowFieldComparisons: true }
+    );
+
+    expect(typeMismatchDiagnostics).toContainEqual(
+      expect.objectContaining({
+        code: 'field_comparison_incompatible',
+      })
+    );
+    expect(selfComparisonDiagnostics).toContainEqual(
+      expect.objectContaining({
+        code: 'field_comparison_incompatible',
+      })
+    );
+  });
+
+  it('reports allowlist-incompatible comparison fields', () => {
+    const diagnostics = validateBuilderSqlTextSemantics(
+      parseNodes('MOCK_FIELD = THIRD_TEXT_FIELD'),
+      fields,
+      strings,
+      { allowFieldComparisons: true }
+    );
+
+    expect(diagnostics).toContainEqual(
+      expect.objectContaining({
+        code: 'field_comparison_incompatible',
+      })
+    );
+  });
 });
+
+

--- a/src/builder/text-mode/utils/validate-builder-sql-text-semantics.ts
+++ b/src/builder/text-mode/utils/validate-builder-sql-text-semantics.ts
@@ -1,5 +1,7 @@
 import { IStrings } from '../../../constants/strings';
 import { ParsedNode } from '../../../query-formats/sql/sql-token.types';
+import { getValidationString } from '../../../utils/validation/get-validation-string.util';
+import { validateFieldComparison } from '../../../utils/validation/validate-field-comparison.util';
 import { IBuilderFieldProps } from '../../types';
 import {
   resolveBuilderFieldUsageLimitKey,
@@ -17,7 +19,84 @@ import { resolveFieldAllowedValues } from './resolve-field-allowed-values';
 
 interface IValidateBuilderSqlTextSemanticsOptions {
   allowGroupNegation?: boolean;
+  allowFieldComparisons?: boolean;
 }
+
+const createFieldComparisonDiagnostic = (
+  result: ReturnType<typeof validateFieldComparison>,
+  start: number,
+  end: number,
+  strings: IStrings
+): ITextModeDiagnostic | null => {
+  if (!result) {
+    return null;
+  }
+
+  const { code, params } = result;
+
+  switch (code) {
+    case 'field_comparison_disabled':
+      return {
+        code,
+        message: getValidationString(
+          strings.validation,
+          'fieldComparisonDisabled',
+          'Field-to-field comparison is not allowed'
+        ),
+        start,
+        end,
+      };
+    case 'field_comparison_operator_not_allowed':
+      return {
+        code,
+        message: getValidationString(
+          strings.validation,
+          'fieldComparisonOperatorNotAllowed',
+          'Operator "{operator}" does not support field-to-field comparison for field "{field}"',
+          params
+        ),
+        start,
+        end,
+      };
+    case 'field_comparison_incompatible':
+      return {
+        code,
+        message: getValidationString(
+          strings.validation,
+          'fieldComparisonIncompatible',
+          'Comparison field "{valueField}" is not compatible with field "{field}" for operator "{operator}"',
+          params
+        ),
+        start,
+        end,
+      };
+    case 'value_field_required':
+      return {
+        code,
+        message: getValidationString(
+          strings.validation,
+          'valueFieldRequired',
+          'A comparison field is required'
+        ),
+        start,
+        end,
+      };
+    case 'value_field_not_found':
+      return {
+        code,
+        message: getValidationString(
+          strings.validation,
+          'valueFieldNotFound',
+          'Comparison field "{field}" was not found',
+          params
+        ),
+        start,
+        end,
+      };
+    default:
+      return null;
+  }
+};
 
 export const validateBuilderSqlTextSemantics = (
   nodes: ParsedNode[],
@@ -100,6 +179,33 @@ export const validateBuilderSqlTextSemantics = (
       return;
     }
 
+    if (rule.valueSource === 'field') {
+      const valueFieldRange = rule.source.valueField || rule.source.value;
+
+      if (!valueFieldRange) {
+        return;
+      }
+
+      const diagnostic = createFieldComparisonDiagnostic(
+        validateFieldComparison({
+          allowFieldComparisons: options.allowFieldComparisons !== false,
+          field,
+          fields,
+          operator,
+          valueField: rule.valueField,
+        }),
+        valueFieldRange.start,
+        valueFieldRange.end,
+        strings
+      );
+
+      if (diagnostic) {
+        diagnostics.push(diagnostic);
+      }
+
+      return;
+    }
+
     if (field.type !== 'LIST' && field.type !== 'MULTI_LIST') {
       return;
     }
@@ -146,3 +252,4 @@ export const validateBuilderSqlTextSemantics = (
 
   return diagnostics;
 };
+

--- a/src/builder/types/field-option.ts
+++ b/src/builder/types/field-option.ts
@@ -1,4 +1,9 @@
-import { DenormalizedQuery, QueryOperator, QueryRuleValue } from '../../utils/query-tree';
+import {
+  DenormalizedQuery,
+  QueryOperator,
+  QueryRuleValue,
+  QueryRuleValueSource,
+} from '../../utils/query-tree';
 
 export type BuilderFieldOption = {
   value: string | number;
@@ -25,7 +30,9 @@ export interface IBuilderRuleValueReconciliationConfig {
 export interface INearestFieldMatch {
   nodeId: string;
   field: string;
+  valueSource?: QueryRuleValueSource;
   value: QueryRuleValue | undefined;
+  valueField?: string;
   operator?: QueryOperator;
 }
 
@@ -39,7 +46,11 @@ export type IBuilderFieldDependencyEntry = IBuilderRuleDependencyEntry;
 export interface IBuilderFieldChange {
   nodeId: string;
   field: string;
+  previousValueSource?: QueryRuleValueSource;
   previousValue: QueryRuleValue | undefined;
+  previousValueField?: string;
+  valueSource?: QueryRuleValueSource;
   value: QueryRuleValue | undefined;
+  valueField?: string;
   data: DenormalizedQuery;
 }

--- a/src/builder/types/index.ts
+++ b/src/builder/types/index.ts
@@ -82,12 +82,18 @@ export type BuilderFieldValue =
   | Array<{ value: string | number; label: string }>;
 
 export type BuilderFieldUsageLimitScope = 'global' | 'parent';
+export type BuilderFieldComparisonType = 'string' | 'number' | 'date' | 'boolean';
 
 export interface IBuilderFieldUsageLimit {
   key?: string;
   max: number;
   scope?: BuilderFieldUsageLimitScope;
   message?: BuilderValidationMessage;
+}
+
+export interface IBuilderFieldComparisonConfig {
+  type?: BuilderFieldComparisonType;
+  comparableFields?: string[];
 }
 
 export interface IBuilderValidationMessageContext {
@@ -234,6 +240,7 @@ interface IBuilderFieldBase<
   operators?: BuilderFieldOperator[];
   validation?: TValidation;
   usageLimit?: IBuilderFieldUsageLimit;
+  fieldComparison?: IBuilderFieldComparisonConfig;
 }
 
 export type IBooleanFieldProps = IBuilderFieldBase<
@@ -311,6 +318,7 @@ export interface IBuilderValidationContext {
   singleRootGroup: boolean;
   groupTypes: BuilderGroupMode;
   allowGroupNegation: boolean;
+  allowFieldComparisons: boolean;
   strings: IStrings;
 }
 
@@ -406,6 +414,7 @@ export interface IBuilderProps {
   cloneable?: boolean;
   draggable?: boolean;
   allowGroupNegation?: boolean;
+  allowFieldComparisons?: boolean;
   singleRootGroup?: boolean;
   groupTypes?: BuilderGroupMode;
   newNodePlacement?: BuilderNewNodePlacement;
@@ -431,3 +440,5 @@ export type {
   BuilderRefListener,
   IBuilderRef,
 } from '../../hooks/use-builder-ref/types';
+
+

--- a/src/builder/utils/get-nearest-field-match.util.ts
+++ b/src/builder/utils/get-nearest-field-match.util.ts
@@ -1,5 +1,6 @@
 import { NormalizedQuery } from '../../utils/query-tree';
 import { INearestFieldMatch } from '../types/field-option';
+import { getRuleValueSource } from '../../utils/rule-value-source';
 
 export const getNearestFieldMatch = (
   data: NormalizedQuery,
@@ -42,7 +43,9 @@ export const getNearestFieldMatch = (
             return {
               nodeId: previousChildNode.id,
               field: previousChildNode.field,
+              valueSource: getRuleValueSource(previousChildNode),
               value: previousChildNode.value,
+              valueField: previousChildNode.valueField,
               operator: previousChildNode.operator,
             };
           }
@@ -61,7 +64,9 @@ export const getNearestFieldMatch = (
             return {
               nodeId: nextChildNode.id,
               field: nextChildNode.field,
+              valueSource: getRuleValueSource(nextChildNode),
               value: nextChildNode.value,
+              valueField: nextChildNode.valueField,
               operator: nextChildNode.operator,
             };
           }

--- a/src/constants/strings.ts
+++ b/src/constants/strings.ts
@@ -65,6 +65,9 @@ export interface IStrings {
   };
   form?: {
     selectYourValue?: string;
+    compareToValue?: string;
+    compareToField?: string;
+    selectField?: string;
   };
   operators?: {
     LARGER?: string;
@@ -123,6 +126,12 @@ export interface IStrings {
     negationNotAllowed?: string;
     usageLimitExceeded?: string;
     invalidTree?: string;
+    valueFieldRequired?: string;
+    valueFieldNotFound?: string;
+    fieldComparisonNotAllowed?: string;
+    fieldComparisonDisabled?: string;
+    fieldComparisonOperatorNotAllowed?: string;
+    fieldComparisonIncompatible?: string;
   };
 }
 
@@ -197,6 +206,9 @@ export const strings: IStrings = {
   },
   form: {
     selectYourValue: 'Select your value',
+    compareToValue: 'Value',
+    compareToField: 'Field',
+    selectField: 'Select field',
   },
   operators: {
     LARGER: 'Larger',
@@ -246,5 +258,17 @@ export const strings: IStrings = {
     negationNotAllowed: 'Negation is not allowed in this builder',
     usageLimitExceeded: 'Field "{field}" can appear at most {max} times in this scope',
     invalidTree: 'Input data tree is in invalid format',
+    valueFieldRequired: 'A comparison field is required',
+    valueFieldNotFound: 'Comparison field "{field}" was not found',
+    fieldComparisonNotAllowed:
+      'Field-to-field comparison is not allowed for field "{field}" and operator "{operator}"',
+    fieldComparisonDisabled:
+      'Field-to-field comparison is not allowed',
+    fieldComparisonOperatorNotAllowed:
+      'Operator "{operator}" does not support field-to-field comparison for field "{field}"',
+    fieldComparisonIncompatible:
+      'Comparison field "{valueField}" is not compatible with field "{field}" for operator "{operator}"',
   },
 };
+
+

--- a/src/example/format-builder-source.test.ts
+++ b/src/example/format-builder-source.test.ts
@@ -1,0 +1,34 @@
+import { formatBuilderSource } from '../../example/src/utils/builder-source/format-builder-source';
+
+describe('example builder source formatting', () => {
+  const baseOptions: any = {
+    readOnly: false,
+    readOnlyProtectsDelete: true,
+    lockable: false,
+    cloneable: false,
+    draggable: false,
+    allowGroupNegation: true,
+    allowFieldComparisons: false,
+    newNodePlacement: 'append',
+    history: false,
+    textMode: false,
+    defaultMode: 'builder',
+    useMonacoTextEditor: false,
+    singleRootGroup: true,
+    showValidation: true,
+    customizationMode: 'bootstrap',
+    themeColors: {},
+    defaultThemeColors: {},
+  };
+
+  it('includes allowFieldComparisons only when enabled', () => {
+    const disabledOutput = formatBuilderSource(baseOptions);
+    const enabledOutput = formatBuilderSource({
+      ...baseOptions,
+      allowFieldComparisons: true,
+    });
+
+    expect(disabledOutput).not.toContain('allowFieldComparisons');
+    expect(enabledOutput).toContain('allowFieldComparisons');
+  });
+});

--- a/src/formatQuery/formatQuery.aql.test.ts
+++ b/src/formatQuery/formatQuery.aql.test.ts
@@ -34,5 +34,47 @@ describe('formatQuery AQL', () => {
       })
     ).toEqual('(doc.first_name == "Alice" OR doc.last_name == "Smith")');
   });
-});
 
+  it('formats supported field-to-field comparisons', () => {
+    const query: DenormalizedQuery = [
+      {
+        type: 'GROUP',
+        value: 'AND',
+        isNegated: false,
+        children: [
+          {
+            field: 'price',
+            operator: 'LARGER_EQUAL',
+            valueSource: 'field',
+            valueField: 'cost',
+          },
+          {
+            field: 'discount',
+            operator: 'SMALLER',
+            valueSource: 'field',
+            valueField: 'max_discount',
+          },
+          {
+            field: 'name',
+            operator: 'EQUAL',
+            valueSource: 'field',
+            valueField: 'fallback_name',
+          },
+          {
+            field: 'status',
+            operator: 'NOT_EQUAL',
+            valueSource: 'field',
+            valueField: 'archived_status',
+          },
+        ],
+      },
+    ];
+
+    expect(
+      formatQuery(query, 'AQL', {
+        wrapFilterClause: false,
+        variableName: 'item',
+      })
+    ).toEqual('(item.price >= item.cost AND item.discount < item.max_discount AND item.name == item.fallback_name AND item.status != item.archived_status)');
+  });
+});

--- a/src/formatQuery/formatQuery.cel.test.ts
+++ b/src/formatQuery/formatQuery.cel.test.ts
@@ -31,4 +31,64 @@ describe('formatQuery CEL', () => {
       '(name.startsWith("Stev") && (age >= 18 && age <= 30) && ["b2b", "priority"].all(item, item in segments))'
     );
   });
+
+  it('formats supported field-to-field scalar comparisons', () => {
+    const query: DenormalizedQuery = [
+      {
+        type: 'GROUP',
+        value: 'AND',
+        isNegated: false,
+        children: [
+          {
+            field: 'price',
+            operator: 'LARGER_EQUAL',
+            valueSource: 'field',
+            valueField: 'cost',
+          },
+          {
+            field: 'discount',
+            operator: 'SMALLER',
+            valueSource: 'field',
+            valueField: 'max_discount',
+          },
+          {
+            field: 'name',
+            operator: 'EQUAL',
+            valueSource: 'field',
+            valueField: 'fallback_name',
+          },
+          {
+            field: 'status',
+            operator: 'NOT_EQUAL',
+            valueSource: 'field',
+            valueField: 'archived_status',
+          },
+        ],
+      },
+    ];
+
+    expect(formatQuery(query, 'CEL')).toEqual(
+      '(price >= cost && discount < max_discount && name == fallback_name && status != archived_status)'
+    );
+  });
+
+  it('formats native field-to-field string method comparisons', () => {
+    const query: DenormalizedQuery = [
+      {
+        type: 'GROUP',
+        value: 'AND',
+        isNegated: false,
+        children: [
+          { field: 'name', operator: 'CONTAINS', valueSource: 'field', valueField: 'needle' },
+          { field: 'name', operator: 'STARTS_WITH', valueSource: 'field', valueField: 'prefix' },
+          { field: 'name', operator: 'ENDS_WITH', valueSource: 'field', valueField: 'suffix' },
+          { field: 'name', operator: 'LIKE', valueSource: 'field', valueField: 'pattern' },
+        ],
+      },
+    ];
+
+    expect(formatQuery(query, 'CEL')).toEqual(
+      '(name.contains(needle) && name.startsWith(prefix) && name.endsWith(suffix) && name.matches(pattern))'
+    );
+  });
 });

--- a/src/formatQuery/formatQuery.django.test.ts
+++ b/src/formatQuery/formatQuery.django.test.ts
@@ -31,4 +31,64 @@ describe('formatQuery Django', () => {
       "(Q(name__startswith='Stev') & Q(status__in=['active', 'trial']) & Q(age__gte=18, age__lte=30))"
     );
   });
+
+  it('formats supported field-to-field scalar comparisons through F() expressions', () => {
+    const query: DenormalizedQuery = [
+      {
+        type: 'GROUP',
+        value: 'AND',
+        isNegated: false,
+        children: [
+          {
+            field: 'price',
+            operator: 'LARGER_EQUAL',
+            valueSource: 'field',
+            valueField: 'cost',
+          },
+          {
+            field: 'discount',
+            operator: 'SMALLER',
+            valueSource: 'field',
+            valueField: 'max_discount',
+          },
+          {
+            field: 'name',
+            operator: 'EQUAL',
+            valueSource: 'field',
+            valueField: 'fallback_name',
+          },
+          {
+            field: 'status',
+            operator: 'NOT_EQUAL',
+            valueSource: 'field',
+            valueField: 'archived_status',
+          },
+        ],
+      },
+    ];
+
+    expect(formatQuery(query, 'Django')).toEqual(
+      "(Q(price__gte=F('cost')) & Q(discount__lt=F('max_discount')) & Q(name=F('fallback_name')) & ~Q(status=F('archived_status')))"
+    );
+  });
+
+  it('formats native field-to-field string lookups through F() expressions', () => {
+    const query: DenormalizedQuery = [
+      {
+        type: 'GROUP',
+        value: 'AND',
+        isNegated: false,
+        children: [
+          { field: 'name', operator: 'CONTAINS', valueSource: 'field', valueField: 'needle' },
+          { field: 'name', operator: 'STARTS_WITH', valueSource: 'field', valueField: 'prefix' },
+          { field: 'name', operator: 'ENDS_WITH', valueSource: 'field', valueField: 'suffix' },
+          { field: 'status', operator: 'NOT_CONTAINS', valueSource: 'field', valueField: 'archived_status' },
+        ],
+      },
+    ];
+
+    expect(formatQuery(query, 'Django')).toEqual(
+      "(Q(name__contains=F('needle')) & Q(name__startswith=F('prefix')) & Q(name__endswith=F('suffix')) & ~Q(status__contains=F('archived_status')))"
+    );
+  });
 });

--- a/src/formatQuery/formatQuery.dynamo.test.ts
+++ b/src/formatQuery/formatQuery.dynamo.test.ts
@@ -31,4 +31,44 @@ describe('formatQuery Dynamo', () => {
       "(begins_with(name, 'Stev') AND status IN ('active', 'trial') AND age BETWEEN 18 AND 30)"
     );
   });
+
+  it('formats supported field-to-field scalar comparisons', () => {
+    const query: DenormalizedQuery = [
+      {
+        type: 'GROUP',
+        value: 'AND',
+        isNegated: false,
+        children: [
+          {
+            field: 'price',
+            operator: 'LARGER_EQUAL',
+            valueSource: 'field',
+            valueField: 'cost',
+          },
+          {
+            field: 'discount',
+            operator: 'SMALLER',
+            valueSource: 'field',
+            valueField: 'max_discount',
+          },
+          {
+            field: 'name',
+            operator: 'EQUAL',
+            valueSource: 'field',
+            valueField: 'fallback_name',
+          },
+          {
+            field: 'status',
+            operator: 'NOT_EQUAL',
+            valueSource: 'field',
+            valueField: 'archived_status',
+          },
+        ],
+      },
+    ];
+
+    expect(formatQuery(query, 'Dynamo')).toEqual(
+      '(price >= cost AND discount < max_discount AND name = fallback_name AND status <> archived_status)'
+    );
+  });
 });

--- a/src/formatQuery/formatQuery.elasticsearch.test.ts
+++ b/src/formatQuery/formatQuery.elasticsearch.test.ts
@@ -59,4 +59,19 @@ describe('formatQuery Elasticsearch', () => {
       )
     );
   });
+
+  it('throws explicitly for unsupported field-to-field comparisons', () => {
+    const query: DenormalizedQuery = [
+      {
+        field: 'price',
+        operator: 'LARGER_EQUAL',
+        valueSource: 'field',
+        valueField: 'cost',
+      },
+    ];
+
+    expect(() => formatQuery(query, 'Elasticsearch')).toThrow(
+      'Elasticsearch does not support field-to-field comparisons for field "price" and operator "LARGER_EQUAL".'
+    );
+  });
 });

--- a/src/formatQuery/formatQuery.jsonata.test.ts
+++ b/src/formatQuery/formatQuery.jsonata.test.ts
@@ -22,5 +22,44 @@ describe('formatQuery JSONata', () => {
       '$contains(name, /^Stev/)'
     );
   });
-});
 
+  it('formats supported field-to-field scalar comparisons', () => {
+    const query: DenormalizedQuery = [
+      {
+        type: 'GROUP',
+        value: 'AND',
+        isNegated: false,
+        children: [
+          {
+            field: 'price',
+            operator: 'LARGER_EQUAL',
+            valueSource: 'field',
+            valueField: 'cost',
+          },
+          {
+            field: 'discount',
+            operator: 'SMALLER',
+            valueSource: 'field',
+            valueField: 'max_discount',
+          },
+          {
+            field: 'name',
+            operator: 'EQUAL',
+            valueSource: 'field',
+            valueField: 'fallback_name',
+          },
+          {
+            field: 'status',
+            operator: 'NOT_EQUAL',
+            valueSource: 'field',
+            valueField: 'archived_status',
+          },
+        ],
+      },
+    ];
+
+    expect(formatQuery(query, 'JSONata')).toEqual(
+      '(price >= cost and discount < max_discount and name = fallback_name and status != archived_status)'
+    );
+  });
+});

--- a/src/formatQuery/formatQuery.jsonlogic.test.ts
+++ b/src/formatQuery/formatQuery.jsonlogic.test.ts
@@ -48,5 +48,55 @@ describe('formatQuery JsonLogic', () => {
       )
     );
   });
-});
 
+  it('formats supported field-to-field scalar comparisons', () => {
+    const query: DenormalizedQuery = [
+      {
+        type: 'GROUP',
+        value: 'AND',
+        isNegated: false,
+        children: [
+          {
+            field: 'price',
+            operator: 'LARGER_EQUAL',
+            valueSource: 'field',
+            valueField: 'cost',
+          },
+          {
+            field: 'discount',
+            operator: 'SMALLER',
+            valueSource: 'field',
+            valueField: 'max_discount',
+          },
+          {
+            field: 'name',
+            operator: 'EQUAL',
+            valueSource: 'field',
+            valueField: 'fallback_name',
+          },
+          {
+            field: 'status',
+            operator: 'NOT_EQUAL',
+            valueSource: 'field',
+            valueField: 'archived_status',
+          },
+        ],
+      },
+    ];
+
+    expect(formatQuery(query, 'JsonLogic')).toEqual(
+      JSON.stringify(
+        {
+          and: [
+            { '>=': [{ var: 'price' }, { var: 'cost' }] },
+            { '<': [{ var: 'discount' }, { var: 'max_discount' }] },
+            { '==': [{ var: 'name' }, { var: 'fallback_name' }] },
+            { '!=': [{ var: 'status' }, { var: 'archived_status' }] },
+          ],
+        },
+        null,
+        2
+      )
+    );
+  });
+});

--- a/src/formatQuery/formatQuery.mongo.test.ts
+++ b/src/formatQuery/formatQuery.mongo.test.ts
@@ -42,5 +42,55 @@ describe('formatQuery Mongo', () => {
       )
     );
   });
-});
 
+  it('formats supported field-to-field scalar comparisons through $expr', () => {
+    const query: DenormalizedQuery = [
+      {
+        type: 'GROUP',
+        value: 'AND',
+        isNegated: false,
+        children: [
+          {
+            field: 'price',
+            operator: 'LARGER_EQUAL',
+            valueSource: 'field',
+            valueField: 'cost',
+          },
+          {
+            field: 'discount',
+            operator: 'SMALLER',
+            valueSource: 'field',
+            valueField: 'max_discount',
+          },
+          {
+            field: 'name',
+            operator: 'EQUAL',
+            valueSource: 'field',
+            valueField: 'fallback_name',
+          },
+          {
+            field: 'status',
+            operator: 'NOT_EQUAL',
+            valueSource: 'field',
+            valueField: 'archived_status',
+          },
+        ],
+      },
+    ];
+
+    expect(formatQuery(query, 'Mongo')).toEqual(
+      JSON.stringify(
+        {
+          $and: [
+            { $expr: { $gte: ['$price', '$cost'] } },
+            { $expr: { $lt: ['$discount', '$max_discount'] } },
+            { $expr: { $eq: ['$name', '$fallback_name'] } },
+            { $expr: { $ne: ['$status', '$archived_status'] } },
+          ],
+        },
+        null,
+        2
+      )
+    );
+  });
+});

--- a/src/formatQuery/formatQuery.odata.test.ts
+++ b/src/formatQuery/formatQuery.odata.test.ts
@@ -30,4 +30,51 @@ describe('formatQuery OData', () => {
       formatQuery(query, 'OData', { wrapFilterClause: true })
     ).toEqual("$filter=(startswith(name,'Stev') and (age ge 18 and age le 30))");
   });
+
+  it('formats supported field-to-field comparisons', () => {
+    const query: DenormalizedQuery = [
+      {
+        type: 'GROUP',
+        value: 'AND',
+        isNegated: false,
+        children: [
+          {
+            field: 'price',
+            operator: 'LARGER_EQUAL',
+            valueSource: 'field',
+            valueField: 'cost',
+          },
+          {
+            field: 'name',
+            operator: 'NOT_EQUAL',
+            valueSource: 'field',
+            valueField: 'fallback_name',
+          },
+        ],
+      },
+    ];
+
+    expect(formatQuery(query, 'OData')).toEqual(
+      '(price ge cost and name ne fallback_name)'
+    );
+  });
+
+  it('formats native field-to-field string functions', () => {
+    const query: DenormalizedQuery = [
+      {
+        type: 'GROUP',
+        value: 'AND',
+        isNegated: false,
+        children: [
+          { field: 'name', operator: 'CONTAINS', valueSource: 'field', valueField: 'needle' },
+          { field: 'name', operator: 'STARTS_WITH', valueSource: 'field', valueField: 'prefix' },
+          { field: 'name', operator: 'ENDS_WITH', valueSource: 'field', valueField: 'suffix' },
+        ],
+      },
+    ];
+
+    expect(formatQuery(query, 'OData')).toEqual(
+      '(contains(name,needle) and startswith(name,prefix) and endswith(name,suffix))'
+    );
+  });
 });

--- a/src/formatQuery/formatQuery.prisma.test.ts
+++ b/src/formatQuery/formatQuery.prisma.test.ts
@@ -49,4 +49,55 @@ describe('formatQuery Prisma', () => {
       )
     );
   });
+
+  it('formats supported field-to-field scalar comparisons', () => {
+    const query: DenormalizedQuery = [
+      {
+        type: 'GROUP',
+        value: 'AND',
+        isNegated: false,
+        children: [
+          {
+            field: 'price',
+            operator: 'LARGER_EQUAL',
+            valueSource: 'field',
+            valueField: 'cost',
+          },
+          {
+            field: 'discount',
+            operator: 'SMALLER',
+            valueSource: 'field',
+            valueField: 'max_discount',
+          },
+          {
+            field: 'name',
+            operator: 'EQUAL',
+            valueSource: 'field',
+            valueField: 'fallback_name',
+          },
+          {
+            field: 'status',
+            operator: 'NOT_EQUAL',
+            valueSource: 'field',
+            valueField: 'archived_status',
+          },
+        ],
+      },
+    ];
+
+    expect(formatQuery(query, 'Prisma')).toEqual(
+      JSON.stringify(
+        {
+          AND: [
+            { price: { gte: { $ref: 'cost' } } },
+            { discount: { lt: { $ref: 'max_discount' } } },
+            { name: { equals: { $ref: 'fallback_name' } } },
+            { status: { not: { $ref: 'archived_status' } } },
+          ],
+        },
+        null,
+        2
+      )
+    );
+  });
 });

--- a/src/formatQuery/formatQuery.rsql.test.ts
+++ b/src/formatQuery/formatQuery.rsql.test.ts
@@ -31,4 +31,19 @@ describe('formatQuery RSQL', () => {
       "(name==Stev*;status=in=(active,trial);(age=ge=18;age=le=30))"
     );
   });
+
+  it('throws explicitly for unsupported field-to-field comparisons', () => {
+    const query: DenormalizedQuery = [
+      {
+        field: 'price',
+        operator: 'EQUAL',
+        valueSource: 'field',
+        valueField: 'cost',
+      },
+    ];
+
+    expect(() => formatQuery(query, 'RSQL')).toThrow(
+      'RSQL does not support field-to-field comparisons for field "price" and operator "EQUAL".'
+    );
+  });
 });

--- a/src/formatQuery/formatQuery.spel.test.ts
+++ b/src/formatQuery/formatQuery.spel.test.ts
@@ -31,4 +31,64 @@ describe('formatQuery SpEL', () => {
       "(name.startsWith('Stev') and (age >= 18 and age <= 30) and ({'b2b', 'priority'}.?[segments.contains(#this)].size() == 2))"
     );
   });
+
+  it('formats supported field-to-field scalar comparisons', () => {
+    const query: DenormalizedQuery = [
+      {
+        type: 'GROUP',
+        value: 'AND',
+        isNegated: false,
+        children: [
+          {
+            field: 'price',
+            operator: 'LARGER_EQUAL',
+            valueSource: 'field',
+            valueField: 'cost',
+          },
+          {
+            field: 'discount',
+            operator: 'SMALLER',
+            valueSource: 'field',
+            valueField: 'max_discount',
+          },
+          {
+            field: 'name',
+            operator: 'EQUAL',
+            valueSource: 'field',
+            valueField: 'fallback_name',
+          },
+          {
+            field: 'status',
+            operator: 'NOT_EQUAL',
+            valueSource: 'field',
+            valueField: 'archived_status',
+          },
+        ],
+      },
+    ];
+
+    expect(formatQuery(query, 'SpEL')).toEqual(
+      '(price >= cost and discount < max_discount and name == fallback_name and status != archived_status)'
+    );
+  });
+
+  it('formats native field-to-field string methods', () => {
+    const query: DenormalizedQuery = [
+      {
+        type: 'GROUP',
+        value: 'AND',
+        isNegated: false,
+        children: [
+          { field: 'name', operator: 'CONTAINS', valueSource: 'field', valueField: 'needle' },
+          { field: 'name', operator: 'STARTS_WITH', valueSource: 'field', valueField: 'prefix' },
+          { field: 'name', operator: 'ENDS_WITH', valueSource: 'field', valueField: 'suffix' },
+          { field: 'status', operator: 'NOT_CONTAINS', valueSource: 'field', valueField: 'archived_status' },
+        ],
+      },
+    ];
+
+    expect(formatQuery(query, 'SpEL')).toEqual(
+      '(name.contains(needle) and name.startsWith(prefix) and name.endsWith(suffix) and !(status.contains(archived_status)))'
+    );
+  });
 });

--- a/src/formatQuery/formatQuery.test.ts
+++ b/src/formatQuery/formatQuery.test.ts
@@ -48,5 +48,57 @@ describe('formatQuery', () => {
       "WHERE NOT (status = 'archived')"
     );
   });
+
+  it('formats supported field-to-field SQL comparisons', () => {
+    const fields: IBuilderFieldProps[] = [
+      { field: 'price', label: 'Price', type: 'NUMBER' },
+      { field: 'cost', label: 'Cost', type: 'NUMBER' },
+      { field: 'name', label: 'Name', type: 'TEXT' },
+      { field: 'name_pattern', label: 'Pattern', type: 'TEXT' },
+    ];
+    const query: DenormalizedQuery = [
+      {
+        type: 'GROUP',
+        value: 'AND',
+        isNegated: false,
+        children: [
+          {
+            field: 'price',
+            operator: 'LARGER_EQUAL',
+            valueSource: 'field',
+            valueField: 'cost',
+          },
+          {
+            field: 'name',
+            operator: 'LIKE',
+            valueSource: 'field',
+            valueField: 'name_pattern',
+          },
+        ],
+      },
+    ];
+
+    expect(formatQuery(query, 'SQL', { fields })).toEqual(
+      '(price >= cost AND name LIKE name_pattern)'
+    );
+  });
+  it('throws explicitly for unsupported SQL field-to-field string operators', () => {
+    const fields: IBuilderFieldProps[] = [
+      { field: 'name', label: 'Name', type: 'TEXT' },
+      { field: 'prefix', label: 'Prefix', type: 'TEXT' },
+    ];
+    const query: DenormalizedQuery = [
+      {
+        field: 'name',
+        operator: 'STARTS_WITH',
+        valueSource: 'field',
+        valueField: 'prefix',
+      },
+    ];
+
+    expect(() => formatQuery(query, 'SQL', { fields })).toThrow(
+      'SQL does not support field-to-field comparisons for field "name" and operator "STARTS_WITH".'
+    );
+  });
 });
 

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -15,6 +15,7 @@ export type {
   BuilderValidationSeverity,
   BuilderDefaultMode,
   IBuilderTextModeConfig,
+  BuilderFieldComparisonType,
   BuilderFieldOperator,
   BuilderFieldOption,
   BuilderFieldOptionsStatus,
@@ -31,6 +32,7 @@ export type {
   IBooleanFieldValidation,
   IBuilderComponentsProps,
   IBuilderFieldChange,
+  IBuilderFieldComparisonConfig,
   IBuilderRuleDependencyEntry,
   IBuilderFieldDependencyEntry,
   IBuilderFieldProps,
@@ -139,20 +141,29 @@ export type {
 export { strings } from './constants/strings';
 export type { IStrings } from './constants/strings';
 export { queryOperators } from './utils/query-operators';
+export {
+  getRuleValueSource,
+  isFieldComparisonRule,
+  isLiteralComparisonRule,
+} from './utils/rule-value-source';
 export type {
   DenormalizedNode,
   DenormalizedQuery,
   GroupReadOnly,
   GroupReadOnlyTarget,
+  IFieldReferenceRuleNode,
   IGroupReadOnlyConfig,
   IRuleReadOnlyConfig,
   IDenormalizedGroupNodeBase,
   IDenormalizedGroupNodeWithModifiers,
   IDenormalizedGroupNodeWithoutModifiers,
   IDenormalizedRuleNode,
+  ILiteralRuleNode,
+  INormalizedFieldReferenceRuleNode,
   INormalizedGroupNodeBase,
   INormalizedGroupNodeWithModifiers,
   INormalizedGroupNodeWithoutModifiers,
+  INormalizedLiteralRuleNode,
   INormalizedRuleNode,
   NormalizedGroupNode,
   NormalizedNode,
@@ -161,6 +172,8 @@ export type {
   QueryGroupValue,
   QueryOperator,
   QueryRuleValue,
+  QueryRuleValueSource,
   RuleReadOnly,
   RuleReadOnlyTarget,
 } from './utils/query-tree';
+

--- a/src/iterator.tsx
+++ b/src/iterator.tsx
@@ -146,7 +146,7 @@ export const Iterator: FC<IIteratorProps> = ({
       ];
     }
 
-    const { field, value, id, operator } = item as IRuleProps;
+    const { field, value, valueSource, valueField, id, operator } = item as IRuleProps;
     const ruleReadOnly = resolveEffectiveRuleReadOnly(
       item.readOnly,
       inheritedReadOnly
@@ -158,6 +158,8 @@ export const Iterator: FC<IIteratorProps> = ({
         key={id}
         field={field}
         value={value}
+        valueSource={valueSource}
+        valueField={valueField}
         operator={operator}
         id={id}
         readOnly={isRuleReadOnly}

--- a/src/monaco/components/monaco-text-mode-editor.test.tsx
+++ b/src/monaco/components/monaco-text-mode-editor.test.tsx
@@ -496,3 +496,40 @@ describe('MonacoTextModeEditor', () => {
     });
   });
 });
+
+describe('MonacoTextModeEditor diagnostics', () => {
+  it('renders field-comparison diagnostics as Monaco decorations', async () => {
+    const monacoMock = getMonacoMock();
+
+    render(
+      <MonacoTextModeEditor
+        value="LIST_FIELD = TEXT_FIELD"
+        diagnostics={[
+          {
+            code: 'field_comparison_not_allowed',
+            message:
+              'Field-to-field comparison is not allowed for field "LIST_FIELD" and operator "EQUAL"',
+            start: 13,
+            end: 23,
+          },
+        ]}
+        errorMessage={
+          'Field-to-field comparison is not allowed for field "LIST_FIELD" and operator "EQUAL"'
+        }
+        onChange={jest.fn()}
+      />
+    );
+
+    await waitFor(() => {
+      expect(
+        monacoMock
+          .getLastDecorations()
+          .filter(
+            decoration =>
+              decoration.options?.inlineClassName ===
+              'rqb-monaco-text-mode-diagnostic'
+          )
+      ).toHaveLength(1);
+    });
+  });
+});

--- a/src/parseQuery/parseQuery.aql.test.ts
+++ b/src/parseQuery/parseQuery.aql.test.ts
@@ -43,5 +43,116 @@ describe('parseQuery AQL', () => {
       },
     ]);
   });
-});
 
+  it('parses field-to-field scalar comparisons and infers both fields', () => {
+    const result = parseQuery(
+      'FILTER doc.price >= doc.cost AND doc.discount < doc.max_discount AND doc.name == doc.fallback_name AND doc.status != doc.archived_status',
+      'AQL'
+    );
+
+    expect(result.data).toEqual([
+      {
+        type: 'GROUP',
+        value: 'AND',
+        isNegated: false,
+        children: [
+          {
+            field: 'price',
+            operator: 'LARGER_EQUAL',
+            valueSource: 'field',
+            valueField: 'cost',
+          },
+          {
+            field: 'discount',
+            operator: 'SMALLER',
+            valueSource: 'field',
+            valueField: 'max_discount',
+          },
+          {
+            field: 'name',
+            operator: 'EQUAL',
+            valueSource: 'field',
+            valueField: 'fallback_name',
+          },
+          {
+            field: 'status',
+            operator: 'NOT_EQUAL',
+            valueSource: 'field',
+            valueField: 'archived_status',
+          },
+        ],
+      },
+    ]);
+
+    expect(result.fields).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ field: 'price' }),
+        expect.objectContaining({ field: 'cost' }),
+        expect.objectContaining({ field: 'discount' }),
+        expect.objectContaining({ field: 'max_discount' }),
+        expect.objectContaining({ field: 'name' }),
+        expect.objectContaining({ field: 'fallback_name' }),
+        expect.objectContaining({ field: 'status' }),
+        expect.objectContaining({ field: 'archived_status' }),
+      ])
+    );
+  });
+
+  it('does not collapse same-field field references into literal range operators', () => {
+    const result = parseQuery(
+      'FILTER doc.price >= doc.min_price AND doc.price <= doc.max_price',
+      'AQL'
+    );
+
+    expect(result.data).toEqual([
+      {
+        type: 'GROUP',
+        value: 'AND',
+        isNegated: false,
+        children: [
+          {
+            field: 'price',
+            operator: 'LARGER_EQUAL',
+            valueSource: 'field',
+            valueField: 'min_price',
+          },
+          {
+            field: 'price',
+            operator: 'SMALLER_EQUAL',
+            valueSource: 'field',
+            valueField: 'max_price',
+          },
+        ],
+      },
+    ]);
+  });
+
+  it('does not collapse same-field field references into literal not-between operators', () => {
+    const result = parseQuery(
+      'FILTER doc.price < doc.min_price OR doc.price > doc.max_price',
+      'AQL'
+    );
+
+    expect(result.data).toEqual([
+      {
+        type: 'GROUP',
+        value: 'OR',
+        isNegated: false,
+        children: [
+          {
+            field: 'price',
+            operator: 'SMALLER',
+            valueSource: 'field',
+            valueField: 'min_price',
+          },
+          {
+            field: 'price',
+            operator: 'LARGER',
+            valueSource: 'field',
+            valueField: 'max_price',
+          },
+        ],
+      },
+    ]);
+  });
+});

--- a/src/parseQuery/parseQuery.cel.test.ts
+++ b/src/parseQuery/parseQuery.cel.test.ts
@@ -47,4 +47,157 @@ describe('parseQuery CEL', () => {
       },
     ]);
   });
+
+  it('parses field-to-field scalar comparisons and infers both fields', () => {
+    const result = parseQuery(
+      '(price >= cost && discount < max_discount && name == fallback_name && status != archived_status)',
+      'CEL'
+    );
+
+    expect(result.data).toEqual([
+      {
+        type: 'GROUP',
+        value: 'AND',
+        isNegated: false,
+        children: [
+          {
+            field: 'price',
+            operator: 'LARGER_EQUAL',
+            valueSource: 'field',
+            valueField: 'cost',
+          },
+          {
+            field: 'discount',
+            operator: 'SMALLER',
+            valueSource: 'field',
+            valueField: 'max_discount',
+          },
+          {
+            field: 'name',
+            operator: 'EQUAL',
+            valueSource: 'field',
+            valueField: 'fallback_name',
+          },
+          {
+            field: 'status',
+            operator: 'NOT_EQUAL',
+            valueSource: 'field',
+            valueField: 'archived_status',
+          },
+        ],
+      },
+    ]);
+
+    expect(result.fields).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ field: 'price' }),
+        expect.objectContaining({ field: 'cost' }),
+        expect.objectContaining({ field: 'discount' }),
+        expect.objectContaining({ field: 'max_discount' }),
+        expect.objectContaining({ field: 'name' }),
+        expect.objectContaining({ field: 'fallback_name' }),
+        expect.objectContaining({ field: 'status' }),
+        expect.objectContaining({ field: 'archived_status' }),
+      ])
+    );
+  });
+
+  it('does not collapse same-field field references into literal range operators', () => {
+    const result = parseQuery(
+      '(price >= min_price && price <= max_price)',
+      'CEL'
+    );
+
+    expect(result.data).toEqual([
+      {
+        type: 'GROUP',
+        value: 'AND',
+        isNegated: false,
+        children: [
+          {
+            field: 'price',
+            operator: 'LARGER_EQUAL',
+            valueSource: 'field',
+            valueField: 'min_price',
+          },
+          {
+            field: 'price',
+            operator: 'SMALLER_EQUAL',
+            valueSource: 'field',
+            valueField: 'max_price',
+          },
+        ],
+      },
+    ]);
+  });
+
+  it('does not collapse same-field field references into literal not-between operators', () => {
+    const result = parseQuery(
+      '(price < min_price || price > max_price)',
+      'CEL'
+    );
+
+    expect(result.data).toEqual([
+      {
+        type: 'GROUP',
+        value: 'OR',
+        isNegated: false,
+        children: [
+          {
+            field: 'price',
+            operator: 'SMALLER',
+            valueSource: 'field',
+            valueField: 'min_price',
+          },
+          {
+            field: 'price',
+            operator: 'LARGER',
+            valueSource: 'field',
+            valueField: 'max_price',
+          },
+        ],
+      },
+    ]);
+  });
+
+  it('still collapses literal ranges normally', () => {
+    const result = parseQuery(
+      '(price >= 10 && price <= 20)',
+      'CEL'
+    );
+
+    expect(result.data).toEqual([
+      { field: 'price', operator: 'BETWEEN', value: [10, 20] },
+    ]);
+  });
+
+  it('parses native field-to-field string method comparisons', () => {
+    const result = parseQuery(
+      '(profile.name.contains(profile.needle) && profile.name.startsWith(profile.prefix) && profile.name.endsWith(profile.suffix) && profile.name.matches(profile.pattern))',
+      'CEL'
+    );
+
+    expect(result.data).toEqual([
+      {
+        type: 'GROUP',
+        value: 'AND',
+        isNegated: false,
+        children: [
+          { field: 'profile.name', operator: 'CONTAINS', valueSource: 'field', valueField: 'profile.needle' },
+          { field: 'profile.name', operator: 'STARTS_WITH', valueSource: 'field', valueField: 'profile.prefix' },
+          { field: 'profile.name', operator: 'ENDS_WITH', valueSource: 'field', valueField: 'profile.suffix' },
+          { field: 'profile.name', operator: 'LIKE', valueSource: 'field', valueField: 'profile.pattern' },
+        ],
+      },
+    ]);
+  });
+
+  it('rejects computed rhs expressions for native field-to-field string methods', () => {
+    expect(() =>
+      parseQuery(
+        '(profile.name.contains(profile.prefix.startsWith("A")))',
+        'CEL'
+      )
+    ).toThrow('Expected token "RPAREN" but found ".".');
+  });
 });

--- a/src/parseQuery/parseQuery.django.test.ts
+++ b/src/parseQuery/parseQuery.django.test.ts
@@ -39,4 +39,157 @@ describe('parseQuery Django', () => {
       },
     ]);
   });
+
+  it('parses field-to-field scalar comparisons from F() expressions and infers both fields', () => {
+    const result = parseQuery(
+      "(Q(price__gte=F('cost')) & Q(discount__lt=F('max_discount')) & Q(name=F('fallback_name')) & ~Q(status=F('archived_status')))",
+      'Django'
+    );
+
+    expect(result.data).toEqual([
+      {
+        type: 'GROUP',
+        value: 'AND',
+        isNegated: false,
+        children: [
+          {
+            field: 'price',
+            operator: 'LARGER_EQUAL',
+            valueSource: 'field',
+            valueField: 'cost',
+          },
+          {
+            field: 'discount',
+            operator: 'SMALLER',
+            valueSource: 'field',
+            valueField: 'max_discount',
+          },
+          {
+            field: 'name',
+            operator: 'EQUAL',
+            valueSource: 'field',
+            valueField: 'fallback_name',
+          },
+          {
+            field: 'status',
+            operator: 'NOT_EQUAL',
+            valueSource: 'field',
+            valueField: 'archived_status',
+          },
+        ],
+      },
+    ]);
+
+    expect(result.fields).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ field: 'price' }),
+        expect.objectContaining({ field: 'cost' }),
+        expect.objectContaining({ field: 'discount' }),
+        expect.objectContaining({ field: 'max_discount' }),
+        expect.objectContaining({ field: 'name' }),
+        expect.objectContaining({ field: 'fallback_name' }),
+        expect.objectContaining({ field: 'status' }),
+        expect.objectContaining({ field: 'archived_status' }),
+      ])
+    );
+  });
+
+  it('does not collapse same-field field references into literal ranges', () => {
+    const result = parseQuery(
+      "Q(price__gte=F('min_price'), price__lte=F('max_price'))",
+      'Django'
+    );
+
+    expect(result.data).toEqual([
+      {
+        type: 'GROUP',
+        value: 'AND',
+        isNegated: false,
+        children: [
+          {
+            field: 'price',
+            operator: 'LARGER_EQUAL',
+            valueSource: 'field',
+            valueField: 'min_price',
+          },
+          {
+            field: 'price',
+            operator: 'SMALLER_EQUAL',
+            valueSource: 'field',
+            valueField: 'max_price',
+          },
+        ],
+      },
+    ]);
+  });
+
+  it('does not collapse same-field field references into literal not-between ranges', () => {
+    const result = parseQuery(
+      "(Q(price__lt=F('min_price')) | Q(price__gt=F('max_price')))",
+      'Django'
+    );
+
+    expect(result.data).toEqual([
+      {
+        type: 'GROUP',
+        value: 'OR',
+        isNegated: false,
+        children: [
+          {
+            field: 'price',
+            operator: 'SMALLER',
+            valueSource: 'field',
+            valueField: 'min_price',
+          },
+          {
+            field: 'price',
+            operator: 'LARGER',
+            valueSource: 'field',
+            valueField: 'max_price',
+          },
+        ],
+      },
+    ]);
+  });
+
+  it('rejects F() expressions outside the builder field-to-field model', () => {
+    expect(() =>
+      parseQuery(
+        "Q(price__gt=F(cost))",
+        'Django'
+      )
+    ).toThrow('Django F() references must contain a quoted field name.');
+  });
+
+  it('parses native field-to-field string lookups from F() expressions', () => {
+    const result = parseQuery(
+      "(Q(name__contains=F('needle')) & Q(name__startswith=F('prefix')) & Q(name__endswith=F('suffix')) & ~Q(status__contains=F('archived_status')))",
+      'Django'
+    );
+
+    expect(result.data).toEqual([
+      {
+        type: 'GROUP',
+        value: 'AND',
+        isNegated: false,
+        children: [
+          { field: 'name', operator: 'CONTAINS', valueSource: 'field', valueField: 'needle' },
+          { field: 'name', operator: 'STARTS_WITH', valueSource: 'field', valueField: 'prefix' },
+          { field: 'name', operator: 'ENDS_WITH', valueSource: 'field', valueField: 'suffix' },
+          { field: 'status', operator: 'NOT_CONTAINS', valueSource: 'field', valueField: 'archived_status' },
+        ],
+      },
+    ]);
+  });
+
+  it('rejects unsupported transformed string lookups with F() field references', () => {
+    expect(() =>
+      parseQuery(
+        "Q(name__icontains=F('needle'))",
+        'Django'
+      )
+    ).toThrow(
+      'Django F() field references are supported only for native direct-reference lookups, found "icontains".'
+    );
+  });
 });

--- a/src/parseQuery/parseQuery.dynamo.test.ts
+++ b/src/parseQuery/parseQuery.dynamo.test.ts
@@ -39,4 +39,122 @@ describe('parseQuery Dynamo', () => {
       },
     ]);
   });
+
+  it('parses field-to-field scalar comparisons and infers both fields', () => {
+    const result = parseQuery(
+      '(price >= cost AND discount < max_discount AND name = fallback_name AND status <> archived_status)',
+      'Dynamo'
+    );
+
+    expect(result.data).toEqual([
+      {
+        type: 'GROUP',
+        value: 'AND',
+        isNegated: false,
+        children: [
+          {
+            field: 'price',
+            operator: 'LARGER_EQUAL',
+            valueSource: 'field',
+            valueField: 'cost',
+          },
+          {
+            field: 'discount',
+            operator: 'SMALLER',
+            valueSource: 'field',
+            valueField: 'max_discount',
+          },
+          {
+            field: 'name',
+            operator: 'EQUAL',
+            valueSource: 'field',
+            valueField: 'fallback_name',
+          },
+          {
+            field: 'status',
+            operator: 'NOT_EQUAL',
+            valueSource: 'field',
+            valueField: 'archived_status',
+          },
+        ],
+      },
+    ]);
+
+    expect(result.fields).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ field: 'price' }),
+        expect.objectContaining({ field: 'cost' }),
+        expect.objectContaining({ field: 'discount' }),
+        expect.objectContaining({ field: 'max_discount' }),
+        expect.objectContaining({ field: 'name' }),
+        expect.objectContaining({ field: 'fallback_name' }),
+        expect.objectContaining({ field: 'status' }),
+        expect.objectContaining({ field: 'archived_status' }),
+      ])
+    );
+  });
+
+  it('does not collapse same-field field references into literal not-between operators', () => {
+    const result = parseQuery(
+      '(price < min_price OR price > max_price)',
+      'Dynamo'
+    );
+
+    expect(result.data).toEqual([
+      {
+        type: 'GROUP',
+        value: 'OR',
+        isNegated: false,
+        children: [
+          {
+            field: 'price',
+            operator: 'SMALLER',
+            valueSource: 'field',
+            valueField: 'min_price',
+          },
+          {
+            field: 'price',
+            operator: 'LARGER',
+            valueSource: 'field',
+            valueField: 'max_price',
+          },
+        ],
+      },
+    ]);
+  });
+
+  it('still collapses literal not-between ranges normally', () => {
+    const result = parseQuery(
+      '(price < 10 OR price > 20)',
+      'Dynamo'
+    );
+
+    expect(result.data).toEqual([
+      { field: 'price', operator: 'NOT_BETWEEN', value: [10, 20] },
+    ]);
+  });
+
+  it('keeps function parsing scoped to literal arguments', () => {
+    const result = parseQuery(
+      "(begins_with(profile_name, 'Al') AND profile_name = display_name)",
+      'Dynamo'
+    );
+
+    expect(result.data).toEqual([
+      {
+        type: 'GROUP',
+        value: 'AND',
+        isNegated: false,
+        children: [
+          { field: 'profile_name', operator: 'STARTS_WITH', value: 'Al' },
+          {
+            field: 'profile_name',
+            operator: 'EQUAL',
+            valueSource: 'field',
+            valueField: 'display_name',
+          },
+        ],
+      },
+    ]);
+  });
 });

--- a/src/parseQuery/parseQuery.elasticsearch.test.ts
+++ b/src/parseQuery/parseQuery.elasticsearch.test.ts
@@ -57,4 +57,34 @@ describe('parseQuery Elasticsearch', () => {
       },
     ]);
   });
+
+  it('rejects non-native object rhs shapes instead of treating them as field-to-field comparisons', () => {
+    expect(() =>
+      parseQuery(
+        JSON.stringify({
+          term: {
+            price: {
+              value: { field: 'cost' },
+            },
+          },
+        }),
+        'Elasticsearch'
+      )
+    ).toThrow('Elasticsearch term query for field "price" must use a scalar value.');
+
+    expect(() =>
+      parseQuery(
+        JSON.stringify({
+          range: {
+            price: {
+              gte: { field: 'min_price' },
+            },
+          },
+        }),
+        'Elasticsearch'
+      )
+    ).toThrow(
+      'Elasticsearch range query for field "price" must use scalar boundary values.'
+    );
+  });
 });

--- a/src/parseQuery/parseQuery.jsonata.test.ts
+++ b/src/parseQuery/parseQuery.jsonata.test.ts
@@ -38,5 +38,191 @@ describe('parseQuery JSONata', () => {
       },
     ]);
   });
-});
 
+  it('keeps boolean rhs values as literals', () => {
+    const result = parseQuery(
+      'active = true and archived != false',
+      'JSONata'
+    );
+
+    expect(result.data).toEqual([
+      {
+        type: 'GROUP',
+        value: 'AND',
+        isNegated: false,
+        children: [
+          { field: 'active', operator: 'EQUAL', value: true },
+          { field: 'archived', operator: 'NOT_EQUAL', value: false },
+        ],
+      },
+    ]);
+  });
+
+  it('parses field-to-field scalar comparisons and infers both fields', () => {
+    const result = parseQuery(
+      'price >= cost and discount < max_discount and name = fallback_name and status != archived_status',
+      'JSONata'
+    );
+
+    expect(result.data).toEqual([
+      {
+        type: 'GROUP',
+        value: 'AND',
+        isNegated: false,
+        children: [
+          {
+            field: 'price',
+            operator: 'LARGER_EQUAL',
+            valueSource: 'field',
+            valueField: 'cost',
+          },
+          {
+            field: 'discount',
+            operator: 'SMALLER',
+            valueSource: 'field',
+            valueField: 'max_discount',
+          },
+          {
+            field: 'name',
+            operator: 'EQUAL',
+            valueSource: 'field',
+            valueField: 'fallback_name',
+          },
+          {
+            field: 'status',
+            operator: 'NOT_EQUAL',
+            valueSource: 'field',
+            valueField: 'archived_status',
+          },
+        ],
+      },
+    ]);
+
+    expect(result.fields).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ field: 'price' }),
+        expect.objectContaining({ field: 'cost' }),
+        expect.objectContaining({ field: 'discount' }),
+        expect.objectContaining({ field: 'max_discount' }),
+        expect.objectContaining({ field: 'name' }),
+        expect.objectContaining({ field: 'fallback_name' }),
+        expect.objectContaining({ field: 'status' }),
+        expect.objectContaining({ field: 'archived_status' }),
+      ])
+    );
+  });
+
+  it('does not collapse same-field field references into literal ranges', () => {
+    const result = parseQuery(
+      'price >= min_price and price <= max_price',
+      'JSONata'
+    );
+
+    expect(result.data).toEqual([
+      {
+        type: 'GROUP',
+        value: 'AND',
+        isNegated: false,
+        children: [
+          {
+            field: 'price',
+            operator: 'LARGER_EQUAL',
+            valueSource: 'field',
+            valueField: 'min_price',
+          },
+          {
+            field: 'price',
+            operator: 'SMALLER_EQUAL',
+            valueSource: 'field',
+            valueField: 'max_price',
+          },
+        ],
+      },
+    ]);
+  });
+
+  it('does not collapse same-field field references into literal not-between ranges', () => {
+    const result = parseQuery(
+      'price < min_price or price > max_price',
+      'JSONata'
+    );
+
+    expect(result.data).toEqual([
+      {
+        type: 'GROUP',
+        value: 'OR',
+        isNegated: false,
+        children: [
+          {
+            field: 'price',
+            operator: 'SMALLER',
+            valueSource: 'field',
+            valueField: 'min_price',
+          },
+          {
+            field: 'price',
+            operator: 'LARGER',
+            valueSource: 'field',
+            valueField: 'max_price',
+          },
+        ],
+      },
+    ]);
+  });
+
+  it('still collapses literal not-between ranges normally', () => {
+    const result = parseQuery(
+      'price < 10 or price > 20',
+      'JSONata'
+    );
+
+    expect(result.data).toEqual([
+      { field: 'price', operator: 'NOT_BETWEEN', value: [10, 20] },
+    ]);
+  });
+
+  it('still collapses literal ranges normally', () => {
+    const result = parseQuery(
+      'price >= 10 and price <= 20',
+      'JSONata'
+    );
+
+    expect(result.data).toEqual([
+      { field: 'price', operator: 'BETWEEN', value: [10, 20] },
+    ]);
+  });
+
+  it('keeps string-helper parsing scoped to literal arguments', () => {
+    const result = parseQuery(
+      '$contains(profile.name, /^Al/) and profile.name = profile.display_name',
+      'JSONata'
+    );
+
+    expect(result.data).toEqual([
+      {
+        type: 'GROUP',
+        value: 'AND',
+        isNegated: false,
+        children: [
+          { field: 'profile.name', operator: 'STARTS_WITH', value: 'Al' },
+          {
+            field: 'profile.name',
+            operator: 'EQUAL',
+            valueSource: 'field',
+            valueField: 'profile.display_name',
+          },
+        ],
+      },
+    ]);
+  });
+
+
+  it('rejects computed rhs expressions that are outside the builder model', () => {
+    expect(() =>
+      parseQuery(
+        'price > (cost * 1.2)',
+        'JSONata'
+      )
+    ).toThrow(/Unexpected token/);
+  });
+});

--- a/src/parseQuery/parseQuery.jsonlogic.test.ts
+++ b/src/parseQuery/parseQuery.jsonlogic.test.ts
@@ -54,5 +54,125 @@ describe('parseQuery JsonLogic', () => {
       },
     ]);
   });
-});
 
+  it('parses field-to-field scalar comparisons and infers both fields', () => {
+    const result = parseQuery(
+      JSON.stringify({
+        and: [
+          { '>=': [{ var: 'price' }, { var: 'cost' }] },
+          { '<': [{ var: 'discount' }, { var: 'max_discount' }] },
+          { '==': [{ var: 'name' }, { var: 'fallback_name' }] },
+          { '!=': [{ var: 'status' }, { var: 'archived_status' }] },
+        ],
+      }),
+      'JsonLogic'
+    );
+
+    expect(result.data).toEqual([
+      {
+        type: 'GROUP',
+        value: 'AND',
+        isNegated: false,
+        children: [
+          {
+            field: 'price',
+            operator: 'LARGER_EQUAL',
+            valueSource: 'field',
+            valueField: 'cost',
+          },
+          {
+            field: 'discount',
+            operator: 'SMALLER',
+            valueSource: 'field',
+            valueField: 'max_discount',
+          },
+          {
+            field: 'name',
+            operator: 'EQUAL',
+            valueSource: 'field',
+            valueField: 'fallback_name',
+          },
+          {
+            field: 'status',
+            operator: 'NOT_EQUAL',
+            valueSource: 'field',
+            valueField: 'archived_status',
+          },
+        ],
+      },
+    ]);
+
+    expect(result.fields).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ field: 'price' }),
+        expect.objectContaining({ field: 'cost' }),
+        expect.objectContaining({ field: 'discount' }),
+        expect.objectContaining({ field: 'max_discount' }),
+        expect.objectContaining({ field: 'name' }),
+        expect.objectContaining({ field: 'fallback_name' }),
+        expect.objectContaining({ field: 'status' }),
+        expect.objectContaining({ field: 'archived_status' }),
+      ])
+    );
+  });
+
+  it('does not collapse same-field field references into literal ranges', () => {
+    const result = parseQuery(
+      JSON.stringify({
+        and: [
+          { '>=': [{ var: 'price' }, { var: 'min_price' }] },
+          { '<=': [{ var: 'price' }, { var: 'max_price' }] },
+        ],
+      }),
+      'JsonLogic'
+    );
+
+    expect(result.data).toEqual([
+      {
+        type: 'GROUP',
+        value: 'AND',
+        isNegated: false,
+        children: [
+          {
+            field: 'price',
+            operator: 'LARGER_EQUAL',
+            valueSource: 'field',
+            valueField: 'min_price',
+          },
+          {
+            field: 'price',
+            operator: 'SMALLER_EQUAL',
+            valueSource: 'field',
+            valueField: 'max_price',
+          },
+        ],
+      },
+    ]);
+  });
+
+  it('still collapses literal not-between ranges normally', () => {
+    const result = parseQuery(
+      JSON.stringify({
+        '!': { '<=': [10, { var: 'price' }, 20] },
+      }),
+      'JsonLogic'
+    );
+
+    expect(result.data).toEqual([
+      { field: 'price', operator: 'NOT_BETWEEN', value: [10, 20] },
+    ]);
+  });
+
+  it('still collapses literal ranges normally', () => {
+    const result = parseQuery(
+      JSON.stringify({
+        '<=': [10, { var: 'price' }, 20],
+      }),
+      'JsonLogic'
+    );
+
+    expect(result.data).toEqual([
+      { field: 'price', operator: 'BETWEEN', value: [10, 20] },
+    ]);
+  });
+});

--- a/src/parseQuery/parseQuery.mongo.test.ts
+++ b/src/parseQuery/parseQuery.mongo.test.ts
@@ -55,5 +55,109 @@ describe('parseQuery Mongo', () => {
       },
     ]);
   });
+
+  it('parses field-to-field scalar comparisons from $expr and infers both fields', () => {
+    const result = parseQuery(
+      JSON.stringify({
+        $and: [
+          { $expr: { $gte: ['$price', '$cost'] } },
+          { $expr: { $lt: ['$discount', '$max_discount'] } },
+          { $expr: { $eq: ['$name', '$fallback_name'] } },
+          { $expr: { $ne: ['$status', '$archived_status'] } },
+        ],
+      }),
+      'Mongo'
+    );
+
+    expect(result.data).toEqual([
+      {
+        type: 'GROUP',
+        value: 'AND',
+        isNegated: false,
+        children: [
+          {
+            field: 'price',
+            operator: 'LARGER_EQUAL',
+            valueSource: 'field',
+            valueField: 'cost',
+          },
+          {
+            field: 'discount',
+            operator: 'SMALLER',
+            valueSource: 'field',
+            valueField: 'max_discount',
+          },
+          {
+            field: 'name',
+            operator: 'EQUAL',
+            valueSource: 'field',
+            valueField: 'fallback_name',
+          },
+          {
+            field: 'status',
+            operator: 'NOT_EQUAL',
+            valueSource: 'field',
+            valueField: 'archived_status',
+          },
+        ],
+      },
+    ]);
+
+    expect(result.fields).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ field: 'price' }),
+        expect.objectContaining({ field: 'cost' }),
+        expect.objectContaining({ field: 'discount' }),
+        expect.objectContaining({ field: 'max_discount' }),
+        expect.objectContaining({ field: 'name' }),
+        expect.objectContaining({ field: 'fallback_name' }),
+        expect.objectContaining({ field: 'status' }),
+        expect.objectContaining({ field: 'archived_status' }),
+      ])
+    );
+  });
+
+  it('rejects $expr expressions outside the builder field-to-field model', () => {
+    expect(() =>
+      parseQuery(
+        JSON.stringify({
+          $expr: { $gt: ['$price', 10] },
+        }),
+        'Mongo'
+      )
+    ).toThrow('Mongo $expr field-to-field comparisons must use field references on both sides.');
+  });
+  it('rejects $expr expressions with unsupported operators', () => {
+    expect(() =>
+      parseQuery(
+        JSON.stringify({
+          $expr: { $regexMatch: ['$name', '$pattern'] },
+        }),
+        'Mongo'
+      )
+    ).toThrow('Unsupported Mongo $expr operator "$regexMatch".');
+  });
+
+  it('rejects $expr expressions with the wrong operand count', () => {
+    expect(() =>
+      parseQuery(
+        JSON.stringify({
+          $expr: { $eq: ['$price', '$cost', '$extra'] },
+        }),
+        'Mongo'
+      )
+    ).toThrow('Mongo $expr operator "$eq" must contain two operands.');
+  });
+
+  it('rejects $expr expressions with multiple operators', () => {
+    expect(() =>
+      parseQuery(
+        JSON.stringify({
+          $expr: { $eq: ['$price', '$cost'], $gt: ['$price', '$min_price'] },
+        }),
+        'Mongo'
+      )
+    ).toThrow('Mongo $expr must contain exactly one comparison operator.');
+  });
 });
 

--- a/src/parseQuery/parseQuery.odata.test.ts
+++ b/src/parseQuery/parseQuery.odata.test.ts
@@ -43,4 +43,34 @@ describe('parseQuery OData', () => {
       },
     ]);
   });
+
+  it('parses native field-to-field string functions', () => {
+    const result = parseQuery(
+      '(contains(name,needle) and startswith(name,prefix) and endswith(name,suffix) and not contains(status,archived_status))',
+      'OData'
+    );
+
+    expect(result.data).toEqual([
+      {
+        type: 'GROUP',
+        value: 'AND',
+        isNegated: false,
+        children: [
+          { field: 'name', operator: 'CONTAINS', valueSource: 'field', valueField: 'needle' },
+          { field: 'name', operator: 'STARTS_WITH', valueSource: 'field', valueField: 'prefix' },
+          { field: 'name', operator: 'ENDS_WITH', valueSource: 'field', valueField: 'suffix' },
+          { field: 'status', operator: 'NOT_CONTAINS', valueSource: 'field', valueField: 'archived_status' },
+        ],
+      },
+    ]);
+  });
+
+  it('rejects computed rhs expressions for native field-to-field string functions', () => {
+    expect(() =>
+      parseQuery(
+        '(contains(name,startswith(prefix,\'A\')))',
+        'OData'
+      )
+    ).toThrow('Expected token "RPAREN" but found "(".');
+  });
 });

--- a/src/parseQuery/parseQuery.prisma.test.ts
+++ b/src/parseQuery/parseQuery.prisma.test.ts
@@ -50,4 +50,144 @@ describe('parseQuery Prisma', () => {
       },
     ]);
   });
+
+  it('parses field-to-field scalar comparisons and infers both fields', () => {
+    const result = parseQuery(
+      JSON.stringify({
+        AND: [
+          { price: { gte: { $ref: 'cost' } } },
+          { discount: { lt: { $ref: 'max_discount' } } },
+          { name: { equals: { $ref: 'fallback_name' } } },
+          { status: { not: { $ref: 'archived_status' } } },
+        ],
+      }),
+      'Prisma'
+    );
+
+    expect(result.data).toEqual([
+      {
+        type: 'GROUP',
+        value: 'AND',
+        isNegated: false,
+        children: [
+          {
+            field: 'price',
+            operator: 'LARGER_EQUAL',
+            valueSource: 'field',
+            valueField: 'cost',
+          },
+          {
+            field: 'discount',
+            operator: 'SMALLER',
+            valueSource: 'field',
+            valueField: 'max_discount',
+          },
+          {
+            field: 'name',
+            operator: 'EQUAL',
+            valueSource: 'field',
+            valueField: 'fallback_name',
+          },
+          {
+            field: 'status',
+            operator: 'NOT_EQUAL',
+            valueSource: 'field',
+            valueField: 'archived_status',
+          },
+        ],
+      },
+    ]);
+
+    expect(result.fields).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ field: 'price' }),
+        expect.objectContaining({ field: 'cost' }),
+        expect.objectContaining({ field: 'discount' }),
+        expect.objectContaining({ field: 'max_discount' }),
+        expect.objectContaining({ field: 'name' }),
+        expect.objectContaining({ field: 'fallback_name' }),
+        expect.objectContaining({ field: 'status' }),
+        expect.objectContaining({ field: 'archived_status' }),
+      ])
+    );
+  });
+
+  it('still collapses literal not-between ranges normally', () => {
+    const result = parseQuery(
+      JSON.stringify({
+        OR: [{ price: { lt: 10 } }, { price: { gt: 20 } }],
+      }),
+      'Prisma'
+    );
+
+    expect(result.data).toEqual([
+      { field: 'price', operator: 'NOT_BETWEEN', value: [10, 20] },
+    ]);
+  });
+
+  it('does not collapse field references into literal range operators', () => {
+    const betweenResult = parseQuery(
+      JSON.stringify({
+        price: {
+          gte: { $ref: 'min_price' },
+          lte: { $ref: 'max_price' },
+        },
+      }),
+      'Prisma'
+    );
+
+    expect(betweenResult.data).toEqual([
+      {
+        type: 'GROUP',
+        value: 'AND',
+        isNegated: false,
+        children: [
+          {
+            field: 'price',
+            operator: 'LARGER_EQUAL',
+            valueSource: 'field',
+            valueField: 'min_price',
+          },
+          {
+            field: 'price',
+            operator: 'SMALLER_EQUAL',
+            valueSource: 'field',
+            valueField: 'max_price',
+          },
+        ],
+      },
+    ]);
+
+    const notBetweenResult = parseQuery(
+      JSON.stringify({
+        OR: [
+          { price: { lt: { $ref: 'min_price' } } },
+          { price: { gt: { $ref: 'max_price' } } },
+        ],
+      }),
+      'Prisma'
+    );
+
+    expect(notBetweenResult.data).toEqual([
+      {
+        type: 'GROUP',
+        value: 'OR',
+        isNegated: false,
+        children: [
+          {
+            field: 'price',
+            operator: 'SMALLER',
+            valueSource: 'field',
+            valueField: 'min_price',
+          },
+          {
+            field: 'price',
+            operator: 'LARGER',
+            valueSource: 'field',
+            valueField: 'max_price',
+          },
+        ],
+      },
+    ]);
+  });
 });

--- a/src/parseQuery/parseQuery.spel.test.ts
+++ b/src/parseQuery/parseQuery.spel.test.ts
@@ -47,4 +47,189 @@ describe('parseQuery SpEL', () => {
       },
     ]);
   });
+
+  it('keeps boolean rhs values as literals', () => {
+    const result = parseQuery(
+      '(active == true and archived != false)',
+      'SpEL'
+    );
+
+    expect(result.data).toEqual([
+      {
+        type: 'GROUP',
+        value: 'AND',
+        isNegated: false,
+        children: [
+          { field: 'active', operator: 'EQUAL', value: true },
+          { field: 'archived', operator: 'NOT_EQUAL', value: false },
+        ],
+      },
+    ]);
+  });
+
+  it('parses field-to-field scalar comparisons and infers both fields', () => {
+    const result = parseQuery(
+      '(price >= cost and discount < max_discount and name == fallback_name and status != archived_status)',
+      'SpEL'
+    );
+
+    expect(result.data).toEqual([
+      {
+        type: 'GROUP',
+        value: 'AND',
+        isNegated: false,
+        children: [
+          {
+            field: 'price',
+            operator: 'LARGER_EQUAL',
+            valueSource: 'field',
+            valueField: 'cost',
+          },
+          {
+            field: 'discount',
+            operator: 'SMALLER',
+            valueSource: 'field',
+            valueField: 'max_discount',
+          },
+          {
+            field: 'name',
+            operator: 'EQUAL',
+            valueSource: 'field',
+            valueField: 'fallback_name',
+          },
+          {
+            field: 'status',
+            operator: 'NOT_EQUAL',
+            valueSource: 'field',
+            valueField: 'archived_status',
+          },
+        ],
+      },
+    ]);
+
+    expect(result.fields).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ field: 'price' }),
+        expect.objectContaining({ field: 'cost' }),
+        expect.objectContaining({ field: 'discount' }),
+        expect.objectContaining({ field: 'max_discount' }),
+        expect.objectContaining({ field: 'name' }),
+        expect.objectContaining({ field: 'fallback_name' }),
+        expect.objectContaining({ field: 'status' }),
+        expect.objectContaining({ field: 'archived_status' }),
+      ])
+    );
+  });
+
+  it('parses native field-to-field string method comparisons', () => {
+    const result = parseQuery(
+      '(name.contains(needle) and name.startsWith(prefix) and name.endsWith(suffix) and !(status.contains(archived_status)))',
+      'SpEL'
+    );
+
+    expect(result.data).toEqual([
+      {
+        type: 'GROUP',
+        value: 'AND',
+        isNegated: false,
+        children: [
+          { field: 'name', operator: 'CONTAINS', valueSource: 'field', valueField: 'needle' },
+          { field: 'name', operator: 'STARTS_WITH', valueSource: 'field', valueField: 'prefix' },
+          { field: 'name', operator: 'ENDS_WITH', valueSource: 'field', valueField: 'suffix' },
+          { field: 'status', operator: 'NOT_CONTAINS', valueSource: 'field', valueField: 'archived_status' },
+        ],
+      },
+    ]);
+
+    expect(result.fields).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ field: 'name' }),
+        expect.objectContaining({ field: 'needle' }),
+        expect.objectContaining({ field: 'prefix' }),
+        expect.objectContaining({ field: 'suffix' }),
+        expect.objectContaining({ field: 'status' }),
+        expect.objectContaining({ field: 'archived_status' }),
+      ])
+    );
+  });
+
+  it('does not collapse same-field field references into literal ranges', () => {
+    const result = parseQuery(
+      '(price >= min_price and price <= max_price)',
+      'SpEL'
+    );
+
+    expect(result.data).toEqual([
+      {
+        type: 'GROUP',
+        value: 'AND',
+        isNegated: false,
+        children: [
+          {
+            field: 'price',
+            operator: 'LARGER_EQUAL',
+            valueSource: 'field',
+            valueField: 'min_price',
+          },
+          {
+            field: 'price',
+            operator: 'SMALLER_EQUAL',
+            valueSource: 'field',
+            valueField: 'max_price',
+          },
+        ],
+      },
+    ]);
+  });
+
+  it('does not collapse same-field field references into literal not-between ranges', () => {
+    const result = parseQuery(
+      '(price < min_price or price > max_price)',
+      'SpEL'
+    );
+
+    expect(result.data).toEqual([
+      {
+        type: 'GROUP',
+        value: 'OR',
+        isNegated: false,
+        children: [
+          {
+            field: 'price',
+            operator: 'SMALLER',
+            valueSource: 'field',
+            valueField: 'min_price',
+          },
+          {
+            field: 'price',
+            operator: 'LARGER',
+            valueSource: 'field',
+            valueField: 'max_price',
+          },
+        ],
+      },
+    ]);
+  });
+
+  it('still collapses literal not-between ranges normally', () => {
+    const result = parseQuery(
+      '(price < 10 or price > 20)',
+      'SpEL'
+    );
+
+    expect(result.data).toEqual([
+      { field: 'price', operator: 'NOT_BETWEEN', value: [10, 20] },
+    ]);
+  });
+
+  it('still collapses literal ranges normally', () => {
+    const result = parseQuery(
+      '(price >= 10 and price <= 20)',
+      'SpEL'
+    );
+
+    expect(result.data).toEqual([
+      { field: 'price', operator: 'BETWEEN', value: [10, 20] },
+    ]);
+  });
 });

--- a/src/parseQuery/parseQuery.test.ts
+++ b/src/parseQuery/parseQuery.test.ts
@@ -66,6 +66,61 @@ describe('parseQuery', () => {
     ]);
   });
 
+  it('parses field-to-field SQL comparisons and infers both fields', () => {
+    const result = parseQuery(
+      'price >= cost AND name LIKE name_pattern',
+      'SQL'
+    );
+
+    expect(result.data).toEqual([
+      {
+        type: 'GROUP',
+        value: 'AND',
+        isNegated: false,
+        children: [
+          {
+            field: 'price',
+            operator: 'LARGER_EQUAL',
+            valueSource: 'field',
+            valueField: 'cost',
+          },
+          {
+            field: 'name',
+            operator: 'LIKE',
+            valueSource: 'field',
+            valueField: 'name_pattern',
+          },
+        ],
+      },
+    ]);
+    expect(result.fields).toEqual([
+      {
+        field: 'price',
+        label: 'price',
+        type: 'TEXT',
+        operators: ['LARGER_EQUAL'],
+      },
+      {
+        field: 'cost',
+        label: 'cost',
+        type: 'TEXT',
+        operators: ['LARGER_EQUAL'],
+      },
+      {
+        field: 'name',
+        label: 'name',
+        type: 'TEXT',
+        operators: ['LIKE'],
+      },
+      {
+        field: 'name_pattern',
+        label: 'name_pattern',
+        type: 'TEXT',
+        operators: ['LIKE'],
+      },
+    ]);
+  });
+
   it('throws on invalid SQL', () => {
     expect(() => parseQuery('status =', 'SQL')).toThrow(
       'Expected a scalar value'

--- a/src/query-formats/aql/aql-parser.ts
+++ b/src/query-formats/aql/aql-parser.ts
@@ -3,6 +3,7 @@ import type {
   QueryGroupValue,
   QueryOperator,
 } from '../../utils/query-tree';
+import { isFieldComparisonRule } from '../../utils/rule-value-source';
 import type {
   IAqlToken,
   AqlTokenType,
@@ -15,6 +16,8 @@ import {
   AQL_DEFAULT_VARIABLE_NAME,
   extractAqlLikeOperator,
 } from './shared';
+
+type AqlFieldReference = { kind: 'field'; field: string };
 
 export class AqlParser {
   private readonly tokens: IAqlToken[];
@@ -127,7 +130,7 @@ export class AqlParser {
     }
 
     const operatorToken = this.expect('OPERATOR');
-    const value = this.parseScalarValue();
+    const value = this.parseComparisonValue();
 
     return this.mapComparison(left, operatorToken.value, value);
   }
@@ -170,6 +173,19 @@ export class AqlParser {
     }
 
     throw new Error(`Expected a scalar value but found "${token.value}".`);
+  }
+
+  private parseComparisonValue():
+    | string
+    | number
+    | boolean
+    | null
+    | AqlFieldReference {
+    if (this.peek().type === 'IDENTIFIER') {
+      return { kind: 'field', field: this.parseIdentifier() };
+    }
+
+    return this.parseScalarValue();
   }
 
   private parseStringValue(): string {
@@ -218,7 +234,7 @@ export class AqlParser {
   private mapComparison(
     field: string,
     operator: string,
-    value: string | number | boolean | null
+    value: string | number | boolean | null | AqlFieldReference
   ): IDenormalizedRuleNode {
     if (operator === '==' && value === null) {
       return { field, operator: 'IS_NULL' };
@@ -226,6 +242,15 @@ export class AqlParser {
 
     if (operator === '!=' && value === null) {
       return { field, operator: 'IS_NOT_NULL' };
+    }
+
+    if (this.isFieldReference(value)) {
+      return {
+        field,
+        operator: this.mapOperator(operator),
+        valueSource: 'field',
+        valueField: value.field,
+      };
     }
 
     return {
@@ -308,6 +333,10 @@ export class AqlParser {
       return null;
     }
 
+    if (isFieldComparisonRule(left) || isFieldComparisonRule(right)) {
+      return null;
+    }
+
     if (
       combinator === 'AND' &&
       left.operator === 'LARGER_EQUAL' &&
@@ -333,6 +362,15 @@ export class AqlParser {
     }
 
     return null;
+  }
+
+  private isFieldReference(value: unknown): value is AqlFieldReference {
+    return (
+      typeof value === 'object' &&
+      value !== null &&
+      'kind' in value &&
+      value.kind === 'field'
+    );
   }
 
   private isKeyword(value: string): boolean {

--- a/src/query-formats/aql/aql-roundtrip.test.ts
+++ b/src/query-formats/aql/aql-roundtrip.test.ts
@@ -24,5 +24,73 @@ describe('AQL roundtrip', () => {
 
     expect(parsed.data).toEqual(query);
   });
-});
 
+  it('round-trips field-to-field scalar comparisons', () => {
+    const query: DenormalizedQuery = [
+      {
+        type: 'GROUP',
+        value: 'AND',
+        isNegated: false,
+        children: [
+          {
+            field: 'price',
+            operator: 'LARGER_EQUAL',
+            valueSource: 'field',
+            valueField: 'cost',
+          },
+          {
+            field: 'discount',
+            operator: 'SMALLER',
+            valueSource: 'field',
+            valueField: 'max_discount',
+          },
+        ],
+      },
+    ];
+
+    const aql = formatQuery(query, 'AQL', {
+      wrapFilterClause: false,
+      variableName: 'doc',
+    });
+    const parsed = parseQuery(aql, 'AQL');
+
+    expect(parsed.data).toEqual(query);
+    expect(parsed.fields).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ field: 'price' }),
+        expect.objectContaining({ field: 'cost' }),
+        expect.objectContaining({ field: 'discount' }),
+        expect.objectContaining({ field: 'max_discount' }),
+      ])
+    );
+  });
+
+  it('does not collapse same-field field references into literal range operators', () => {
+    const parsed = parseQuery(
+      '(doc.price >= doc.min_price AND doc.price <= doc.max_price)',
+      'AQL'
+    );
+
+    expect(parsed.data).toEqual<DenormalizedQuery>([
+      {
+        type: 'GROUP',
+        value: 'AND',
+        isNegated: false,
+        children: [
+          {
+            field: 'price',
+            operator: 'LARGER_EQUAL',
+            valueSource: 'field',
+            valueField: 'min_price',
+          },
+          {
+            field: 'price',
+            operator: 'SMALLER_EQUAL',
+            valueSource: 'field',
+            valueField: 'max_price',
+          },
+        ],
+      },
+    ]);
+  });
+});

--- a/src/query-formats/aql/format-aql-rule.ts
+++ b/src/query-formats/aql/format-aql-rule.ts
@@ -3,6 +3,7 @@ import type {
   QueryOperator,
   QueryRuleValue,
 } from '../../utils/query-tree';
+import { isFieldComparisonRule } from '../../utils/rule-value-source';
 import {
   formatAqlArrayValue,
   formatAqlScalarValue,
@@ -42,6 +43,14 @@ const ensureStringValue = (
   return value;
 };
 
+const formatFieldOrScalarValue = (
+  rule: IDenormalizedRuleNode,
+  variableName: string
+): string =>
+  isFieldComparisonRule(rule)
+    ? quoteAqlIdentifier(rule.valueField, variableName)
+    : formatAqlScalarValue(rule.value as never);
+
 export const formatAqlRule = (
   rule: IDenormalizedRuleNode,
   variableName: string
@@ -50,17 +59,17 @@ export const formatAqlRule = (
 
   switch (rule.operator) {
     case 'EQUAL':
-      return `${field} == ${formatAqlScalarValue(rule.value as never)}`;
+      return `${field} == ${formatFieldOrScalarValue(rule, variableName)}`;
     case 'NOT_EQUAL':
-      return `${field} != ${formatAqlScalarValue(rule.value as never)}`;
+      return `${field} != ${formatFieldOrScalarValue(rule, variableName)}`;
     case 'LARGER':
-      return `${field} > ${formatAqlScalarValue(rule.value as never)}`;
+      return `${field} > ${formatFieldOrScalarValue(rule, variableName)}`;
     case 'LARGER_EQUAL':
-      return `${field} >= ${formatAqlScalarValue(rule.value as never)}`;
+      return `${field} >= ${formatFieldOrScalarValue(rule, variableName)}`;
     case 'SMALLER':
-      return `${field} < ${formatAqlScalarValue(rule.value as never)}`;
+      return `${field} < ${formatFieldOrScalarValue(rule, variableName)}`;
     case 'SMALLER_EQUAL':
-      return `${field} <= ${formatAqlScalarValue(rule.value as never)}`;
+      return `${field} <= ${formatFieldOrScalarValue(rule, variableName)}`;
     case 'IN':
     case 'ANY_IN':
       return `${field} IN ${formatAqlArrayValue(
@@ -120,4 +129,3 @@ export const formatAqlRule = (
       );
   }
 };
-

--- a/src/query-formats/aql/infer-aql-fields.ts
+++ b/src/query-formats/aql/infer-aql-fields.ts
@@ -4,6 +4,7 @@ import type {
   IDenormalizedRuleNode,
   QueryOperator,
 } from '../../utils/query-tree';
+import { isFieldComparisonRule } from '../../utils/rule-value-source';
 import { aqlOperatorOrder } from './aql-token.types';
 
 const inferAqlFieldType = (
@@ -62,22 +63,34 @@ export const inferAqlFields = (data: DenormalizedQuery): IBuilderFieldProps[] =>
     { type: IBuilderFieldProps['type']; operators: QueryOperator[] }
   >();
 
-  collectAqlRules(data).forEach(rule => {
-    const currentField = fieldMap.get(rule.field);
-    const nextType = inferAqlFieldType(rule);
+  const mergeFieldConfig = (
+    fieldName: string,
+    type: IBuilderFieldProps['type'],
+    operator?: QueryOperator
+  ) => {
+    const currentField = fieldMap.get(fieldName);
 
     if (!currentField) {
-      fieldMap.set(rule.field, {
-        type: nextType,
-        operators: rule.operator ? [rule.operator] : [],
+      fieldMap.set(fieldName, {
+        type,
+        operators: operator ? [operator] : [],
       });
       return;
     }
 
-    currentField.type = mergeAqlFieldType(currentField.type, nextType);
+    currentField.type = mergeAqlFieldType(currentField.type, type);
 
-    if (rule.operator && !currentField.operators.includes(rule.operator)) {
-      currentField.operators.push(rule.operator);
+    if (operator && !currentField.operators.includes(operator)) {
+      currentField.operators.push(operator);
+    }
+  };
+
+  collectAqlRules(data).forEach(rule => {
+    const nextType = inferAqlFieldType(rule);
+    mergeFieldConfig(rule.field, nextType, rule.operator);
+
+    if (isFieldComparisonRule(rule)) {
+      mergeFieldConfig(rule.valueField, nextType, rule.operator);
     }
   });
 
@@ -90,4 +103,3 @@ export const inferAqlFields = (data: DenormalizedQuery): IBuilderFieldProps[] =>
     ),
   })) as IBuilderFieldProps[];
 };
-

--- a/src/query-formats/cel/cel-parser.ts
+++ b/src/query-formats/cel/cel-parser.ts
@@ -3,6 +3,7 @@ import type {
   QueryGroupValue,
   QueryOperator,
 } from '../../utils/query-tree';
+import { isFieldComparisonRule } from '../../utils/rule-value-source';
 import type {
   CelTokenType,
   ICelToken,
@@ -20,6 +21,8 @@ const CEL_STRING_METHODS = new Set([
 ]);
 
 const CEL_LIST_METHODS = new Set(['all', 'exists']);
+
+type CelFieldReference = { kind: 'field'; field: string };
 
 export class CelParser {
   private readonly tokens: ICelToken[];
@@ -170,7 +173,7 @@ export class CelParser {
     }
 
     const operatorToken = this.expect('OPERATOR');
-    const value = this.parseScalarValue();
+    const value = this.parseComparisonValue();
 
     if (operatorToken.value === '==' && value === null) {
       return { field, operator: 'IS_NULL' };
@@ -178,6 +181,15 @@ export class CelParser {
 
     if (operatorToken.value === '!=' && value === null) {
       return { field, operator: 'IS_NOT_NULL' };
+    }
+
+    if (this.isFieldReference(value)) {
+      return {
+        field,
+        operator: this.mapOperator(operatorToken.value),
+        valueSource: 'field',
+        valueField: value.field,
+      };
     }
 
     return {
@@ -196,8 +208,44 @@ export class CelParser {
     }
 
     this.expect('LPAREN');
-    const value = this.parseStringValue();
+    const value = this.parseStringOrFieldReferenceValue();
     this.expect('RPAREN');
+
+    if (this.isFieldReference(value)) {
+      if (methodName === 'contains') {
+        return {
+          field,
+          operator: 'CONTAINS',
+          valueSource: 'field',
+          valueField: value.field,
+        };
+      }
+
+      if (methodName === 'startsWith') {
+        return {
+          field,
+          operator: 'STARTS_WITH',
+          valueSource: 'field',
+          valueField: value.field,
+        };
+      }
+
+      if (methodName === 'endsWith') {
+        return {
+          field,
+          operator: 'ENDS_WITH',
+          valueSource: 'field',
+          valueField: value.field,
+        };
+      }
+
+      return {
+        field,
+        operator: 'LIKE',
+        valueSource: 'field',
+        valueField: value.field,
+      };
+    }
 
     if (methodName === 'contains') {
       return { field, operator: 'CONTAINS', value };
@@ -269,6 +317,19 @@ export class CelParser {
     throw new Error(`Expected a scalar value but found "${token.value}".`);
   }
 
+  private parseComparisonValue():
+    | string
+    | number
+    | boolean
+    | null
+    | CelFieldReference {
+    if (this.peek().type === 'IDENTIFIER') {
+      return { kind: 'field', field: this.parseFieldPath(true) };
+    }
+
+    return this.parseScalarValue();
+  }
+
   private parseStringValue(): string {
     const value = this.parseScalarValue();
 
@@ -277,6 +338,14 @@ export class CelParser {
     }
 
     return value;
+  }
+
+  private parseStringOrFieldReferenceValue(): string | CelFieldReference {
+    if (this.peek().type === 'IDENTIFIER') {
+      return { kind: 'field', field: this.parseFieldPath(true) };
+    }
+
+    return this.parseStringValue();
   }
 
   private parseArrayValue(): string[] | number[] {
@@ -373,6 +442,10 @@ export class CelParser {
       return null;
     }
 
+    if (isFieldComparisonRule(left) || isFieldComparisonRule(right)) {
+      return null;
+    }
+
     if (
       combinator === 'AND' &&
       left.operator === 'LARGER_EQUAL' &&
@@ -406,6 +479,15 @@ export class CelParser {
 
   private isParsedGroup(node: ParsedCelNode): node is IParsedCelGroup {
     return 'kind' in node && node.kind === 'group';
+  }
+
+  private isFieldReference(value: unknown): value is CelFieldReference {
+    return (
+      typeof value === 'object' &&
+      value !== null &&
+      'kind' in value &&
+      value.kind === 'field'
+    );
   }
 
   private isKeyword(value: string): boolean {

--- a/src/query-formats/cel/cel-roundtrip.test.ts
+++ b/src/query-formats/cel/cel-roundtrip.test.ts
@@ -21,4 +21,74 @@ describe('CEL roundtrip', () => {
 
     expect(parsed.data).toEqual(query);
   });
+
+  it('round-trips field-to-field scalar comparisons', () => {
+    const query: DenormalizedQuery = [
+      {
+        type: 'GROUP',
+        value: 'AND',
+        isNegated: false,
+        children: [
+          {
+            field: 'price',
+            operator: 'LARGER_EQUAL',
+            valueSource: 'field',
+            valueField: 'cost',
+          },
+          {
+            field: 'discount',
+            operator: 'SMALLER',
+            valueSource: 'field',
+            valueField: 'max_discount',
+          },
+          {
+            field: 'name',
+            operator: 'EQUAL',
+            valueSource: 'field',
+            valueField: 'fallback_name',
+          },
+          {
+            field: 'status',
+            operator: 'NOT_EQUAL',
+            valueSource: 'field',
+            valueField: 'archived_status',
+          },
+        ],
+      },
+    ];
+
+    const expression = formatQuery(query, 'CEL');
+    const parsed = parseQuery(expression, 'CEL');
+
+    expect(parsed.data).toEqual(query);
+    expect(parsed.fields).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ field: 'price' }),
+        expect.objectContaining({ field: 'cost' }),
+        expect.objectContaining({ field: 'discount' }),
+        expect.objectContaining({ field: 'max_discount' }),
+      ])
+    );
+  });
+
+  it('round-trips native field-to-field string method comparisons', () => {
+    const query: DenormalizedQuery = [
+      {
+        type: 'GROUP',
+        value: 'AND',
+        isNegated: false,
+        children: [
+          { field: 'name', operator: 'CONTAINS', valueSource: 'field', valueField: 'needle' },
+          { field: 'name', operator: 'STARTS_WITH', valueSource: 'field', valueField: 'prefix' },
+          { field: 'name', operator: 'ENDS_WITH', valueSource: 'field', valueField: 'suffix' },
+          { field: 'name', operator: 'LIKE', valueSource: 'field', valueField: 'pattern' },
+        ],
+      },
+    ];
+
+    const expression = formatQuery(query, 'CEL');
+    const parsed = parseQuery(expression, 'CEL');
+
+    expect(parsed.data).toEqual(query);
+  });
 });

--- a/src/query-formats/cel/format-cel-rule.ts
+++ b/src/query-formats/cel/format-cel-rule.ts
@@ -3,6 +3,7 @@ import type {
   QueryOperator,
   QueryRuleValue,
 } from '../../utils/query-tree';
+import { isFieldComparisonRule } from '../../utils/rule-value-source';
 import {
   escapeCelRegex,
   formatCelArrayValue,
@@ -43,20 +44,30 @@ const ensureStringValue = (
   return value;
 };
 
+const formatFieldOrScalarValue = (rule: IDenormalizedRuleNode): string =>
+  isFieldComparisonRule(rule)
+    ? rule.valueField
+    : formatCelScalarValue(rule.value as never);
+
+const formatFieldOrStringValue = (rule: IDenormalizedRuleNode): string =>
+  isFieldComparisonRule(rule)
+    ? rule.valueField
+    : quoteCelString(ensureStringValue(rule.operator, rule.value));
+
 export const formatCelRule = (rule: IDenormalizedRuleNode): string => {
   switch (rule.operator) {
     case 'EQUAL':
-      return `${rule.field} == ${formatCelScalarValue(rule.value as never)}`;
+      return `${rule.field} == ${formatFieldOrScalarValue(rule)}`;
     case 'NOT_EQUAL':
-      return `${rule.field} != ${formatCelScalarValue(rule.value as never)}`;
+      return `${rule.field} != ${formatFieldOrScalarValue(rule)}`;
     case 'LARGER':
-      return `${rule.field} > ${formatCelScalarValue(rule.value as never)}`;
+      return `${rule.field} > ${formatFieldOrScalarValue(rule)}`;
     case 'LARGER_EQUAL':
-      return `${rule.field} >= ${formatCelScalarValue(rule.value as never)}`;
+      return `${rule.field} >= ${formatFieldOrScalarValue(rule)}`;
     case 'SMALLER':
-      return `${rule.field} < ${formatCelScalarValue(rule.value as never)}`;
+      return `${rule.field} < ${formatFieldOrScalarValue(rule)}`;
     case 'SMALLER_EQUAL':
-      return `${rule.field} <= ${formatCelScalarValue(rule.value as never)}`;
+      return `${rule.field} <= ${formatFieldOrScalarValue(rule)}`;
     case 'IN':
       return `${rule.field} in ${formatCelArrayValue(
         ensureArrayValue(rule.operator, rule.value)
@@ -90,29 +101,25 @@ export const formatCelRule = (rule: IDenormalizedRuleNode): string => {
     case 'IS_NOT_NULL':
       return `${rule.field} != null`;
     case 'CONTAINS':
-      return `${rule.field}.contains(${quoteCelString(
-        ensureStringValue(rule.operator, rule.value)
-      )})`;
+      return `${rule.field}.contains(${formatFieldOrStringValue(rule)})`;
     case 'NOT_CONTAINS':
-      return `!(${rule.field}.contains(${quoteCelString(
-        ensureStringValue(rule.operator, rule.value)
-      )}))`;
+      return `!(${rule.field}.contains(${formatFieldOrStringValue(rule)}))`;
     case 'STARTS_WITH':
-      return `${rule.field}.startsWith(${quoteCelString(
-        ensureStringValue(rule.operator, rule.value)
-      )})`;
+      return `${rule.field}.startsWith(${formatFieldOrStringValue(rule)})`;
     case 'ENDS_WITH':
-      return `${rule.field}.endsWith(${quoteCelString(
-        ensureStringValue(rule.operator, rule.value)
-      )})`;
+      return `${rule.field}.endsWith(${formatFieldOrStringValue(rule)})`;
     case 'LIKE':
-      return `${rule.field}.matches(${quoteCelString(
-        `^${escapeCelRegex(ensureStringValue(rule.operator, rule.value))}$`
-      )})`;
+      return isFieldComparisonRule(rule)
+        ? `${rule.field}.matches(${rule.valueField})`
+        : `${rule.field}.matches(${quoteCelString(
+            `^${escapeCelRegex(ensureStringValue(rule.operator, rule.value))}$`
+          )})`;
     case 'NOT_LIKE':
-      return `!(${rule.field}.matches(${quoteCelString(
-        `^${escapeCelRegex(ensureStringValue(rule.operator, rule.value))}$`
-      )}))`;
+      return isFieldComparisonRule(rule)
+        ? `!(${rule.field}.matches(${rule.valueField}))`
+        : `!(${rule.field}.matches(${quoteCelString(
+            `^${escapeCelRegex(ensureStringValue(rule.operator, rule.value))}$`
+          )}))`;
     default:
       throw new Error(
         `Unsupported or missing operator "${rule.operator}" for field "${rule.field}".`

--- a/src/query-formats/cel/infer-cel-fields.ts
+++ b/src/query-formats/cel/infer-cel-fields.ts
@@ -4,6 +4,7 @@ import type {
   IDenormalizedRuleNode,
   QueryOperator,
 } from '../../utils/query-tree';
+import { isFieldComparisonRule } from '../../utils/rule-value-source';
 import { celOperatorOrder } from './cel-token.types';
 
 const inferCelFieldType = (
@@ -37,24 +38,36 @@ export const inferCelFields = (data: DenormalizedQuery): IBuilderFieldProps[] =>
     { type: IBuilderFieldProps['type']; operators: QueryOperator[] }
   >();
 
-  collectRules(data).forEach(rule => {
-    const current = fieldMap.get(rule.field);
-    const nextType = inferCelFieldType(rule);
+  const mergeFieldConfig = (
+    fieldName: string,
+    type: IBuilderFieldProps['type'],
+    operator?: QueryOperator
+  ) => {
+    const current = fieldMap.get(fieldName);
 
     if (!current) {
-      fieldMap.set(rule.field, {
-        type: nextType,
-        operators: rule.operator ? [rule.operator] : [],
+      fieldMap.set(fieldName, {
+        type,
+        operators: operator ? [operator] : [],
       });
       return;
     }
 
-    if (current.type !== nextType) {
+    if (current.type !== type) {
       current.type = 'TEXT';
     }
 
-    if (rule.operator && !current.operators.includes(rule.operator)) {
-      current.operators.push(rule.operator);
+    if (operator && !current.operators.includes(operator)) {
+      current.operators.push(operator);
+    }
+  };
+
+  collectRules(data).forEach(rule => {
+    const nextType = inferCelFieldType(rule);
+    mergeFieldConfig(rule.field, nextType, rule.operator);
+
+    if (isFieldComparisonRule(rule)) {
+      mergeFieldConfig(rule.valueField, nextType, rule.operator);
     }
   });
 

--- a/src/query-formats/django/django-parser.ts
+++ b/src/query-formats/django/django-parser.ts
@@ -2,14 +2,20 @@ import type {
   IDenormalizedRuleNode,
   QueryGroupValue,
 } from '../../utils/query-tree';
+import { isFieldComparisonRule } from '../../utils/rule-value-source';
 import type {
   DjangoTokenType,
   IDjangoToken,
   IParsedDjangoGroup,
   ParsedDjangoNode,
 } from './django-token.types';
-import { inferDjangoLookupOperator } from './shared';
+import {
+  djangoFieldReferenceFunction,
+  inferDjangoLookupOperator,
+} from './shared';
 import { tokenizeDjango } from './tokenize-django';
+
+type DjangoFieldReference = { kind: 'field'; field: string };
 
 export class DjangoParser {
   private readonly tokens: IDjangoToken[];
@@ -129,7 +135,7 @@ export class DjangoParser {
 
   private createRuleFromLookup(
     lookup: string,
-    value: string | number | boolean | null | string[] | number[]
+    value: string | number | boolean | null | string[] | number[] | DjangoFieldReference
   ): IDenormalizedRuleNode {
     const parts = lookup.split('__');
     const field = parts[0];
@@ -158,6 +164,32 @@ export class DjangoParser {
       };
     }
 
+    if (this.isFieldReference(value)) {
+      if (
+        ![
+          'exact',
+          'gt',
+          'gte',
+          'lt',
+          'lte',
+          'contains',
+          'startswith',
+          'endswith',
+        ].includes(suffix)
+      ) {
+        throw new Error(
+          `Django F() field references are supported only for native direct-reference lookups, found "${suffix}".`
+        );
+      }
+
+      return {
+        field,
+        operator: inferDjangoLookupOperator(suffix, value.field),
+        valueSource: 'field',
+        valueField: value.field,
+      };
+    }
+
     if (value === null) {
       return {
         field,
@@ -168,15 +200,19 @@ export class DjangoParser {
     return {
       field,
       operator: inferDjangoLookupOperator(suffix, value),
-      value: value as Exclude<typeof value, null>,
+      value: value as Exclude<typeof value, null | DjangoFieldReference>,
     };
   }
 
-  private parseValue(): string | number | boolean | null | string[] | number[] {
+  private parseValue(): string | number | boolean | null | string[] | number[] | DjangoFieldReference {
     const token = this.peek();
 
     if (token.type === 'LBRACKET') {
       return this.parseList();
+    }
+
+    if (token.type === 'IDENTIFIER' && token.value === djangoFieldReferenceFunction) {
+      return this.parseFieldReference();
     }
 
     this.consume();
@@ -204,6 +240,28 @@ export class DjangoParser {
     throw new Error(`Expected a Django scalar value but found "${token.value}".`);
   }
 
+  private parseFieldReference(): DjangoFieldReference {
+    const identifier = this.consume();
+
+    if (identifier.type !== 'IDENTIFIER' || identifier.value !== djangoFieldReferenceFunction) {
+      throw new Error(`Expected Django field reference function "${djangoFieldReferenceFunction}".`);
+    }
+
+    this.expect('LPAREN');
+    const fieldToken = this.consume();
+
+    if (fieldToken.type !== 'STRING') {
+      throw new Error('Django F() references must contain a quoted field name.');
+    }
+
+    this.expect('RPAREN');
+
+    return {
+      kind: 'field',
+      field: fieldToken.value,
+    };
+  }
+
   private parseList(): string[] | number[] {
     this.expect('LBRACKET');
     const values: Array<string | number> = [];
@@ -211,7 +269,12 @@ export class DjangoParser {
     while (this.peek().type !== 'RBRACKET') {
       const value = this.parseValue();
 
-      if (typeof value === 'boolean' || value === null || Array.isArray(value)) {
+      if (
+        typeof value === 'boolean' ||
+        value === null ||
+        Array.isArray(value) ||
+        this.isFieldReference(value)
+      ) {
         throw new Error('Django lists currently support only string and number values.');
       }
 
@@ -307,7 +370,12 @@ export class DjangoParser {
   private tryCollapseAndRules(
     rules: IDenormalizedRuleNode[]
   ): IDenormalizedRuleNode | null {
-    if (rules.length !== 2 || rules[0].field !== rules[1].field) {
+    if (
+      rules.length !== 2 ||
+      rules[0].field !== rules[1].field ||
+      isFieldComparisonRule(rules[0]) ||
+      isFieldComparisonRule(rules[1])
+    ) {
       return null;
     }
 
@@ -330,7 +398,13 @@ export class DjangoParser {
     left: ParsedDjangoNode,
     right: ParsedDjangoNode
   ): IDenormalizedRuleNode | null {
-    if (!this.isRuleNode(left) || !this.isRuleNode(right) || left.field !== right.field) {
+    if (
+      !this.isRuleNode(left) ||
+      !this.isRuleNode(right) ||
+      left.field !== right.field ||
+      isFieldComparisonRule(left) ||
+      isFieldComparisonRule(right)
+    ) {
       return null;
     }
 
@@ -368,6 +442,17 @@ export class DjangoParser {
     return 'kind' in node && node.kind === 'group';
   }
 
+  private isFieldReference(value: unknown): value is DjangoFieldReference {
+    return (
+      typeof value === 'object' &&
+      value !== null &&
+      'kind' in value &&
+      value.kind === 'field' &&
+      'field' in value &&
+      typeof value.field === 'string'
+    );
+  }
+
   private expect(type: DjangoTokenType): IDjangoToken {
     const token = this.consume();
 
@@ -396,3 +481,4 @@ export class DjangoParser {
     return this.tokens[this.index];
   }
 }
+

--- a/src/query-formats/django/django-roundtrip.test.ts
+++ b/src/query-formats/django/django-roundtrip.test.ts
@@ -21,4 +21,74 @@ describe('Django roundtrip', () => {
 
     expect(parsed.data).toEqual(query);
   });
+
+  it('round-trips field-to-field scalar comparisons through F() expressions', () => {
+    const query: DenormalizedQuery = [
+      {
+        type: 'GROUP',
+        value: 'AND',
+        isNegated: false,
+        children: [
+          {
+            field: 'price',
+            operator: 'LARGER_EQUAL',
+            valueSource: 'field',
+            valueField: 'cost',
+          },
+          {
+            field: 'discount',
+            operator: 'SMALLER',
+            valueSource: 'field',
+            valueField: 'max_discount',
+          },
+          {
+            field: 'name',
+            operator: 'EQUAL',
+            valueSource: 'field',
+            valueField: 'fallback_name',
+          },
+          {
+            field: 'status',
+            operator: 'NOT_EQUAL',
+            valueSource: 'field',
+            valueField: 'archived_status',
+          },
+        ],
+      },
+    ];
+
+    const expression = formatQuery(query, 'Django');
+    const parsed = parseQuery(expression, 'Django');
+
+    expect(parsed.data).toEqual(query);
+    expect(parsed.fields).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ field: 'price' }),
+        expect.objectContaining({ field: 'cost' }),
+        expect.objectContaining({ field: 'discount' }),
+        expect.objectContaining({ field: 'max_discount' }),
+      ])
+    );
+  });
+
+  it('round-trips native field-to-field string lookups through F() expressions', () => {
+    const query: DenormalizedQuery = [
+      {
+        type: 'GROUP',
+        value: 'AND',
+        isNegated: false,
+        children: [
+          { field: 'name', operator: 'CONTAINS', valueSource: 'field', valueField: 'needle' },
+          { field: 'name', operator: 'STARTS_WITH', valueSource: 'field', valueField: 'prefix' },
+          { field: 'name', operator: 'ENDS_WITH', valueSource: 'field', valueField: 'suffix' },
+          { field: 'status', operator: 'NOT_CONTAINS', valueSource: 'field', valueField: 'archived_status' },
+        ],
+      },
+    ];
+
+    const expression = formatQuery(query, 'Django');
+    const parsed = parseQuery(expression, 'Django');
+
+    expect(parsed.data).toEqual(query);
+  });
 });

--- a/src/query-formats/django/format-django-rule.ts
+++ b/src/query-formats/django/format-django-rule.ts
@@ -3,7 +3,11 @@ import type {
   QueryOperator,
   QueryRuleValue,
 } from '../../utils/query-tree';
-import { formatDjangoScalarValue } from './shared';
+import { isFieldComparisonRule } from '../../utils/rule-value-source';
+import {
+  formatDjangoFieldReference,
+  formatDjangoScalarValue,
+} from './shared';
 
 const ensureArrayValue = (
   operator: QueryOperator | undefined,
@@ -38,20 +42,25 @@ const ensureStringValue = (
   return value;
 };
 
+const formatFieldOrScalarValue = (rule: IDenormalizedRuleNode): string =>
+  isFieldComparisonRule(rule)
+    ? formatDjangoFieldReference(rule.valueField)
+    : formatDjangoScalarValue(rule.value as never);
+
 export const formatDjangoRule = (rule: IDenormalizedRuleNode): string => {
   switch (rule.operator) {
     case 'EQUAL':
-      return `Q(${rule.field}=${formatDjangoScalarValue(rule.value as never)})`;
+      return `Q(${rule.field}=${formatFieldOrScalarValue(rule)})`;
     case 'NOT_EQUAL':
-      return `~Q(${rule.field}=${formatDjangoScalarValue(rule.value as never)})`;
+      return `~Q(${rule.field}=${formatFieldOrScalarValue(rule)})`;
     case 'LARGER':
-      return `Q(${rule.field}__gt=${formatDjangoScalarValue(rule.value as never)})`;
+      return `Q(${rule.field}__gt=${formatFieldOrScalarValue(rule)})`;
     case 'LARGER_EQUAL':
-      return `Q(${rule.field}__gte=${formatDjangoScalarValue(rule.value as never)})`;
+      return `Q(${rule.field}__gte=${formatFieldOrScalarValue(rule)})`;
     case 'SMALLER':
-      return `Q(${rule.field}__lt=${formatDjangoScalarValue(rule.value as never)})`;
+      return `Q(${rule.field}__lt=${formatFieldOrScalarValue(rule)})`;
     case 'SMALLER_EQUAL':
-      return `Q(${rule.field}__lte=${formatDjangoScalarValue(rule.value as never)})`;
+      return `Q(${rule.field}__lte=${formatFieldOrScalarValue(rule)})`;
     case 'IN':
     case 'ANY_IN':
       return `Q(${rule.field}__in=[${ensureArrayValue(rule.operator, rule.value)
@@ -82,21 +91,13 @@ export const formatDjangoRule = (rule: IDenormalizedRuleNode): string => {
     case 'IS_NOT_NULL':
       return `Q(${rule.field}__isnull=False)`;
     case 'CONTAINS':
-      return `Q(${rule.field}__contains=${formatDjangoScalarValue(
-        ensureStringValue(rule.operator, rule.value)
-      )})`;
+      return `Q(${rule.field}__contains=${formatFieldOrScalarValue(rule)})`;
     case 'NOT_CONTAINS':
-      return `~Q(${rule.field}__contains=${formatDjangoScalarValue(
-        ensureStringValue(rule.operator, rule.value)
-      )})`;
+      return `~Q(${rule.field}__contains=${formatFieldOrScalarValue(rule)})`;
     case 'STARTS_WITH':
-      return `Q(${rule.field}__startswith=${formatDjangoScalarValue(
-        ensureStringValue(rule.operator, rule.value)
-      )})`;
+      return `Q(${rule.field}__startswith=${formatFieldOrScalarValue(rule)})`;
     case 'ENDS_WITH':
-      return `Q(${rule.field}__endswith=${formatDjangoScalarValue(
-        ensureStringValue(rule.operator, rule.value)
-      )})`;
+      return `Q(${rule.field}__endswith=${formatFieldOrScalarValue(rule)})`;
     case 'LIKE':
       return `Q(${rule.field}__exact=${formatDjangoScalarValue(
         ensureStringValue(rule.operator, rule.value)

--- a/src/query-formats/django/infer-django-fields.ts
+++ b/src/query-formats/django/infer-django-fields.ts
@@ -4,6 +4,7 @@ import type {
   IDenormalizedRuleNode,
   QueryOperator,
 } from '../../utils/query-tree';
+import { isFieldComparisonRule } from '../../utils/rule-value-source';
 import { djangoOperatorOrder } from './django-token.types';
 
 const inferDjangoFieldType = (
@@ -39,24 +40,36 @@ export const inferDjangoFields = (
     { type: IBuilderFieldProps['type']; operators: QueryOperator[] }
   >();
 
-  collectRules(data).forEach(rule => {
-    const current = fieldMap.get(rule.field);
-    const nextType = inferDjangoFieldType(rule);
+  const mergeFieldConfig = (
+    fieldName: string,
+    type: IBuilderFieldProps['type'],
+    operator?: QueryOperator
+  ) => {
+    const current = fieldMap.get(fieldName);
 
     if (!current) {
-      fieldMap.set(rule.field, {
-        type: nextType,
-        operators: rule.operator ? [rule.operator] : [],
+      fieldMap.set(fieldName, {
+        type,
+        operators: operator ? [operator] : [],
       });
       return;
     }
 
-    if (current.type !== nextType) {
+    if (current.type !== type) {
       current.type = 'TEXT';
     }
 
-    if (rule.operator && !current.operators.includes(rule.operator)) {
-      current.operators.push(rule.operator);
+    if (operator && !current.operators.includes(operator)) {
+      current.operators.push(operator);
+    }
+  };
+
+  collectRules(data).forEach(rule => {
+    const nextType = inferDjangoFieldType(rule);
+    mergeFieldConfig(rule.field, nextType, rule.operator);
+
+    if (isFieldComparisonRule(rule)) {
+      mergeFieldConfig(rule.valueField, nextType, rule.operator);
     }
   });
 

--- a/src/query-formats/django/shared.ts
+++ b/src/query-formats/django/shared.ts
@@ -1,5 +1,7 @@
 import type { QueryOperator, QueryRuleValue } from '../../utils/query-tree';
 
+export const djangoFieldReferenceFunction = 'F';
+
 export const quoteDjangoString = (value: string): string =>
   `'${value.replace(/\\/g, '\\\\').replace(/'/g, "\\'")}'`;
 
@@ -16,6 +18,9 @@ export const formatDjangoScalarValue = (
 
   return quoteDjangoString(value);
 };
+
+export const formatDjangoFieldReference = (field: string): string =>
+  `${djangoFieldReferenceFunction}(${quoteDjangoString(field)})`;
 
 export const inferDjangoLookupOperator = (
   lookup: string,

--- a/src/query-formats/dynamo/dynamo-parser.ts
+++ b/src/query-formats/dynamo/dynamo-parser.ts
@@ -3,6 +3,7 @@ import type {
   QueryGroupValue,
   QueryOperator,
 } from '../../utils/query-tree';
+import { isFieldComparisonRule } from '../../utils/rule-value-source';
 import type {
   IDynamoToken,
   DynamoTokenType,
@@ -11,6 +12,8 @@ import type {
 } from './dynamo-token.types';
 import { inferDynamoStringOperator } from './shared';
 import { tokenizeDynamo } from './tokenize-dynamo';
+
+type DynamoFieldReference = { kind: 'field'; field: string };
 
 export class DynamoParser {
   private readonly tokens: IDynamoToken[];
@@ -152,7 +155,7 @@ export class DynamoParser {
     }
 
     const operator = this.expect('OPERATOR').value;
-    const value = this.parseScalarValue();
+    const value = this.parseComparisonValue();
 
     if (operator === '=' && value === null) {
       return { field, operator: 'IS_NULL' };
@@ -160,6 +163,15 @@ export class DynamoParser {
 
     if ((operator === '<>' || operator === '!=') && value === null) {
       return { field, operator: 'IS_NOT_NULL' };
+    }
+
+    if (this.isFieldReference(value)) {
+      return {
+        field,
+        operator: this.mapOperator(operator),
+        valueSource: 'field',
+        valueField: value.field,
+      };
     }
 
     return {
@@ -226,6 +238,19 @@ export class DynamoParser {
     }
 
     throw new Error(`Expected a scalar value but found "${token.value}".`);
+  }
+
+  private parseComparisonValue():
+    | string
+    | number
+    | boolean
+    | null
+    | DynamoFieldReference {
+    if (this.peek().type === 'IDENTIFIER') {
+      return { kind: 'field', field: this.parseIdentifier() };
+    }
+
+    return this.parseScalarValue();
   }
 
   private parseIdentifier(): string {
@@ -300,6 +325,10 @@ export class DynamoParser {
       return null;
     }
 
+    if (isFieldComparisonRule(left) || isFieldComparisonRule(right)) {
+      return null;
+    }
+
     if (
       combinator === 'OR' &&
       left.operator === 'SMALLER' &&
@@ -333,6 +362,15 @@ export class DynamoParser {
 
   private isParsedGroup(node: ParsedDynamoNode): node is IParsedDynamoGroup {
     return 'kind' in node && node.kind === 'group';
+  }
+
+  private isFieldReference(value: unknown): value is DynamoFieldReference {
+    return (
+      typeof value === 'object' &&
+      value !== null &&
+      'kind' in value &&
+      value.kind === 'field'
+    );
   }
 
   private isKeyword(value: string): boolean {

--- a/src/query-formats/dynamo/dynamo-roundtrip.test.ts
+++ b/src/query-formats/dynamo/dynamo-roundtrip.test.ts
@@ -21,4 +21,53 @@ describe('Dynamo roundtrip', () => {
 
     expect(parsed.data).toEqual(query);
   });
+
+  it('round-trips field-to-field scalar comparisons', () => {
+    const query: DenormalizedQuery = [
+      {
+        type: 'GROUP',
+        value: 'AND',
+        isNegated: false,
+        children: [
+          {
+            field: 'price',
+            operator: 'LARGER_EQUAL',
+            valueSource: 'field',
+            valueField: 'cost',
+          },
+          {
+            field: 'discount',
+            operator: 'SMALLER',
+            valueSource: 'field',
+            valueField: 'max_discount',
+          },
+          {
+            field: 'name',
+            operator: 'EQUAL',
+            valueSource: 'field',
+            valueField: 'fallback_name',
+          },
+          {
+            field: 'status',
+            operator: 'NOT_EQUAL',
+            valueSource: 'field',
+            valueField: 'archived_status',
+          },
+        ],
+      },
+    ];
+
+    const expression = formatQuery(query, 'Dynamo');
+    const parsed = parseQuery(expression, 'Dynamo');
+
+    expect(parsed.data).toEqual(query);
+    expect(parsed.fields).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ field: 'price' }),
+        expect.objectContaining({ field: 'cost' }),
+        expect.objectContaining({ field: 'discount' }),
+        expect.objectContaining({ field: 'max_discount' }),
+      ])
+    );
+  });
 });

--- a/src/query-formats/dynamo/format-dynamo-rule.ts
+++ b/src/query-formats/dynamo/format-dynamo-rule.ts
@@ -3,6 +3,7 @@ import type {
   QueryOperator,
   QueryRuleValue,
 } from '../../utils/query-tree';
+import { isFieldComparisonRule } from '../../utils/rule-value-source';
 import { formatDynamoScalarValue } from './shared';
 
 const ensureArrayValue = (
@@ -38,20 +39,25 @@ const ensureStringValue = (
   return value;
 };
 
+const formatFieldOrScalarValue = (rule: IDenormalizedRuleNode): string =>
+  isFieldComparisonRule(rule)
+    ? rule.valueField
+    : formatDynamoScalarValue(rule.value as never);
+
 export const formatDynamoRule = (rule: IDenormalizedRuleNode): string => {
   switch (rule.operator) {
     case 'EQUAL':
-      return `${rule.field} = ${formatDynamoScalarValue(rule.value as never)}`;
+      return `${rule.field} = ${formatFieldOrScalarValue(rule)}`;
     case 'NOT_EQUAL':
-      return `${rule.field} <> ${formatDynamoScalarValue(rule.value as never)}`;
+      return `${rule.field} <> ${formatFieldOrScalarValue(rule)}`;
     case 'LARGER':
-      return `${rule.field} > ${formatDynamoScalarValue(rule.value as never)}`;
+      return `${rule.field} > ${formatFieldOrScalarValue(rule)}`;
     case 'LARGER_EQUAL':
-      return `${rule.field} >= ${formatDynamoScalarValue(rule.value as never)}`;
+      return `${rule.field} >= ${formatFieldOrScalarValue(rule)}`;
     case 'SMALLER':
-      return `${rule.field} < ${formatDynamoScalarValue(rule.value as never)}`;
+      return `${rule.field} < ${formatFieldOrScalarValue(rule)}`;
     case 'SMALLER_EQUAL':
-      return `${rule.field} <= ${formatDynamoScalarValue(rule.value as never)}`;
+      return `${rule.field} <= ${formatFieldOrScalarValue(rule)}`;
     case 'IN':
     case 'ANY_IN':
       return `${rule.field} IN (${ensureArrayValue(rule.operator, rule.value)

--- a/src/query-formats/dynamo/infer-dynamo-fields.ts
+++ b/src/query-formats/dynamo/infer-dynamo-fields.ts
@@ -4,6 +4,7 @@ import type {
   IDenormalizedRuleNode,
   QueryOperator,
 } from '../../utils/query-tree';
+import { isFieldComparisonRule } from '../../utils/rule-value-source';
 import { dynamoOperatorOrder } from './dynamo-token.types';
 
 const inferDynamoFieldType = (
@@ -39,24 +40,36 @@ export const inferDynamoFields = (
     { type: IBuilderFieldProps['type']; operators: QueryOperator[] }
   >();
 
-  collectRules(data).forEach(rule => {
-    const current = fieldMap.get(rule.field);
-    const nextType = inferDynamoFieldType(rule);
+  const mergeFieldConfig = (
+    fieldName: string,
+    type: IBuilderFieldProps['type'],
+    operator?: QueryOperator
+  ) => {
+    const current = fieldMap.get(fieldName);
 
     if (!current) {
-      fieldMap.set(rule.field, {
-        type: nextType,
-        operators: rule.operator ? [rule.operator] : [],
+      fieldMap.set(fieldName, {
+        type,
+        operators: operator ? [operator] : [],
       });
       return;
     }
 
-    if (current.type !== nextType) {
+    if (current.type !== type) {
       current.type = 'TEXT';
     }
 
-    if (rule.operator && !current.operators.includes(rule.operator)) {
-      current.operators.push(rule.operator);
+    if (operator && !current.operators.includes(operator)) {
+      current.operators.push(operator);
+    }
+  };
+
+  collectRules(data).forEach(rule => {
+    const nextType = inferDynamoFieldType(rule);
+    mergeFieldConfig(rule.field, nextType, rule.operator);
+
+    if (isFieldComparisonRule(rule)) {
+      mergeFieldConfig(rule.valueField, nextType, rule.operator);
     }
   });
 

--- a/src/query-formats/elasticsearch/format-elasticsearch-rule.ts
+++ b/src/query-formats/elasticsearch/format-elasticsearch-rule.ts
@@ -3,6 +3,7 @@ import type {
   QueryOperator,
   QueryRuleValue,
 } from '../../utils/query-tree';
+import { isFieldComparisonRule } from '../../utils/rule-value-source';
 import { escapeElasticsearchWildcard } from './shared';
 
 type ElasticsearchClause = Record<string, unknown>;
@@ -40,6 +41,14 @@ const ensureStringValue = (
   return value;
 };
 
+const ensureElasticsearchSupportsRule = (rule: IDenormalizedRuleNode): void => {
+  if (isFieldComparisonRule(rule)) {
+    throw new Error(
+      `Elasticsearch does not support field-to-field comparisons for field "${rule.field}" and operator "${rule.operator}".`
+    );
+  }
+};
+
 const createMustNotClause = (clause: ElasticsearchClause): ElasticsearchClause => ({
   bool: {
     must_not: [clause],
@@ -49,6 +58,8 @@ const createMustNotClause = (clause: ElasticsearchClause): ElasticsearchClause =
 export const formatElasticsearchRule = (
   rule: IDenormalizedRuleNode
 ): ElasticsearchClause => {
+  ensureElasticsearchSupportsRule(rule);
+
   switch (rule.operator) {
     case 'EQUAL':
       return { term: { [rule.field]: rule.value } };

--- a/src/query-formats/elasticsearch/parse-elasticsearch-expression.ts
+++ b/src/query-formats/elasticsearch/parse-elasticsearch-expression.ts
@@ -8,6 +8,9 @@ type ElasticsearchDocument = Record<string, unknown>;
 const isPlainObject = (value: unknown): value is ElasticsearchDocument =>
   typeof value === 'object' && value !== null && !Array.isArray(value);
 
+const isScalarValue = (value: unknown): value is string | number | boolean | null =>
+  value === null || ['string', 'number', 'boolean'].includes(typeof value);
+
 const wrapAndGroup = (children: DenormalizedNode[]): DenormalizedNode => ({
   type: 'GROUP',
   value: 'AND',
@@ -27,10 +30,21 @@ const createGroup = (
 });
 
 const parseTermExpression = (value: ElasticsearchDocument): DenormalizedNode[] => {
-  const [field, fieldValue] = Object.entries(value)[0] ?? [];
+  const [field, rawFieldValue] = Object.entries(value)[0] ?? [];
 
   if (!field) {
     throw new Error('Elasticsearch term query must contain a field.');
+  }
+
+  const fieldValue =
+    isPlainObject(rawFieldValue) && 'value' in rawFieldValue
+      ? rawFieldValue.value
+      : rawFieldValue;
+
+  if (!isScalarValue(fieldValue)) {
+    throw new Error(
+      `Elasticsearch term query for field "${field}" must use a scalar value.`
+    );
   }
 
   return [
@@ -47,6 +61,12 @@ const parseTermsExpression = (value: ElasticsearchDocument): DenormalizedNode[] 
 
   if (!field || !Array.isArray(fieldValue)) {
     throw new Error('Elasticsearch terms query must contain an array field value.');
+  }
+
+  if (!fieldValue.every(isScalarValue)) {
+    throw new Error(
+      `Elasticsearch terms query for field "${field}" must contain only scalar values.`
+    );
   }
 
   return [
@@ -67,7 +87,13 @@ const parseRangeExpression = (value: ElasticsearchDocument): DenormalizedNode[] 
 
   const keys = Object.keys(fieldValue);
 
-  if (keys.length === 2 && keys.includes('gte') && keys.includes('lte')) {
+  if (
+    keys.length === 2 &&
+    keys.includes('gte') &&
+    keys.includes('lte') &&
+    isScalarValue(fieldValue.gte) &&
+    isScalarValue(fieldValue.lte)
+  ) {
     return [
       {
         field,
@@ -79,6 +105,13 @@ const parseRangeExpression = (value: ElasticsearchDocument): DenormalizedNode[] 
 
   if (keys.length === 1) {
     const [key] = keys;
+    const scalarValue = fieldValue[key];
+
+    if (!isScalarValue(scalarValue)) {
+      throw new Error(
+        `Elasticsearch range query for field "${field}" must use scalar boundary values.`
+      );
+    }
 
     switch (key) {
       case 'gt':
@@ -229,38 +262,38 @@ export const parseElasticsearchExpression = (value: unknown): DenormalizedNode[]
     throw new Error('Elasticsearch query must be a JSON object.');
   }
 
-  const document = unwrapQueryContainer(value);
+  const normalized = unwrapQueryContainer(value);
 
-  if ('bool' in document) {
-    if (!isPlainObject(document.bool)) {
+  if ('bool' in normalized) {
+    if (!isPlainObject(normalized.bool)) {
       throw new Error('Elasticsearch bool query must be an object.');
     }
 
-    return parseBoolExpression(document.bool);
+    return parseBoolExpression(normalized.bool);
   }
 
-  if ('term' in document && isPlainObject(document.term)) {
-    return parseTermExpression(document.term);
+  if ('term' in normalized) {
+    return parseTermExpression(normalized.term as ElasticsearchDocument);
   }
 
-  if ('terms' in document && isPlainObject(document.terms)) {
-    return parseTermsExpression(document.terms);
+  if ('terms' in normalized) {
+    return parseTermsExpression(normalized.terms as ElasticsearchDocument);
   }
 
-  if ('range' in document && isPlainObject(document.range)) {
-    return parseRangeExpression(document.range);
+  if ('range' in normalized) {
+    return parseRangeExpression(normalized.range as ElasticsearchDocument);
   }
 
-  if ('exists' in document && isPlainObject(document.exists)) {
-    return parseExistsExpression(document.exists);
+  if ('exists' in normalized) {
+    return parseExistsExpression(normalized.exists as ElasticsearchDocument);
   }
 
-  if ('prefix' in document && isPlainObject(document.prefix)) {
-    return parsePrefixExpression(document.prefix);
+  if ('prefix' in normalized) {
+    return parsePrefixExpression(normalized.prefix as ElasticsearchDocument);
   }
 
-  if ('wildcard' in document && isPlainObject(document.wildcard)) {
-    return parseWildcardExpression(document.wildcard);
+  if ('wildcard' in normalized) {
+    return parseWildcardExpression(normalized.wildcard as ElasticsearchDocument);
   }
 
   throw new Error('Unsupported Elasticsearch query structure.');

--- a/src/query-formats/json-logic/format-json-logic-rule.ts
+++ b/src/query-formats/json-logic/format-json-logic-rule.ts
@@ -3,6 +3,7 @@ import type {
   QueryOperator,
   QueryRuleValue,
 } from '../../utils/query-tree';
+import { isFieldComparisonRule } from '../../utils/rule-value-source';
 import type { JsonLogicRule } from './shared';
 import { createVarRule } from './shared';
 
@@ -39,6 +40,11 @@ const ensureStringValue = (
   return value;
 };
 
+const formatFieldOrScalarValue = (rule: IDenormalizedRuleNode): JsonLogicRule =>
+  isFieldComparisonRule(rule)
+    ? createVarRule(rule.valueField)
+    : (rule.value as JsonLogicRule);
+
 const createNegatedRule = (rule: JsonLogicRule): JsonLogicRule => ({
   '!': rule,
 });
@@ -50,17 +56,17 @@ export const formatJsonLogicRule = (
 
   switch (rule.operator) {
     case 'EQUAL':
-      return { '==': [field, rule.value as JsonLogicRule] };
+      return { '==': [field, formatFieldOrScalarValue(rule)] };
     case 'NOT_EQUAL':
-      return { '!=': [field, rule.value as JsonLogicRule] };
+      return { '!=': [field, formatFieldOrScalarValue(rule)] };
     case 'LARGER':
-      return { '>': [field, rule.value as JsonLogicRule] };
+      return { '>': [field, formatFieldOrScalarValue(rule)] };
     case 'LARGER_EQUAL':
-      return { '>=': [field, rule.value as JsonLogicRule] };
+      return { '>=': [field, formatFieldOrScalarValue(rule)] };
     case 'SMALLER':
-      return { '<': [field, rule.value as JsonLogicRule] };
+      return { '<': [field, formatFieldOrScalarValue(rule)] };
     case 'SMALLER_EQUAL':
-      return { '<=': [field, rule.value as JsonLogicRule] };
+      return { '<=': [field, formatFieldOrScalarValue(rule)] };
     case 'IN':
       return { in: [field, ensureArrayValue(rule.operator, rule.value)] };
     case 'NOT_IN':
@@ -123,4 +129,3 @@ export const formatJsonLogicRule = (
       );
   }
 };
-

--- a/src/query-formats/json-logic/infer-json-logic-fields.ts
+++ b/src/query-formats/json-logic/infer-json-logic-fields.ts
@@ -4,6 +4,7 @@ import type {
   IDenormalizedRuleNode,
   QueryOperator,
 } from '../../utils/query-tree';
+import { isFieldComparisonRule } from '../../utils/rule-value-source';
 
 const operatorOrder: QueryOperator[] = [
   'EQUAL',
@@ -61,24 +62,36 @@ export const inferJsonLogicFields = (
     { type: IBuilderFieldProps['type']; operators: QueryOperator[] }
   >();
 
-  collectRules(data).forEach(rule => {
-    const current = fieldMap.get(rule.field);
-    const nextType = inferFieldType(rule);
+  const mergeFieldConfig = (
+    fieldName: string,
+    type: IBuilderFieldProps['type'],
+    operator?: QueryOperator
+  ) => {
+    const current = fieldMap.get(fieldName);
 
     if (!current) {
-      fieldMap.set(rule.field, {
-        type: nextType,
-        operators: rule.operator ? [rule.operator] : [],
+      fieldMap.set(fieldName, {
+        type,
+        operators: operator ? [operator] : [],
       });
       return;
     }
 
-    if (current.type !== nextType) {
+    if (current.type !== type) {
       current.type = 'TEXT';
     }
 
-    if (rule.operator && !current.operators.includes(rule.operator)) {
-      current.operators.push(rule.operator);
+    if (operator && !current.operators.includes(operator)) {
+      current.operators.push(operator);
+    }
+  };
+
+  collectRules(data).forEach(rule => {
+    const nextType = inferFieldType(rule);
+    mergeFieldConfig(rule.field, nextType, rule.operator);
+
+    if (isFieldComparisonRule(rule)) {
+      mergeFieldConfig(rule.valueField, nextType, rule.operator);
     }
   });
 
@@ -91,4 +104,3 @@ export const inferJsonLogicFields = (
     ),
   })) as IBuilderFieldProps[];
 };
-

--- a/src/query-formats/json-logic/jsonlogic-roundtrip.test.ts
+++ b/src/query-formats/json-logic/jsonlogic-roundtrip.test.ts
@@ -21,5 +21,53 @@ describe('JsonLogic roundtrip', () => {
 
     expect(parsed.data).toEqual(query);
   });
-});
 
+  it('round-trips field-to-field scalar comparisons', () => {
+    const query: DenormalizedQuery = [
+      {
+        type: 'GROUP',
+        value: 'AND',
+        isNegated: false,
+        children: [
+          {
+            field: 'price',
+            operator: 'LARGER_EQUAL',
+            valueSource: 'field',
+            valueField: 'cost',
+          },
+          {
+            field: 'discount',
+            operator: 'SMALLER',
+            valueSource: 'field',
+            valueField: 'max_discount',
+          },
+          {
+            field: 'name',
+            operator: 'EQUAL',
+            valueSource: 'field',
+            valueField: 'fallback_name',
+          },
+          {
+            field: 'status',
+            operator: 'NOT_EQUAL',
+            valueSource: 'field',
+            valueField: 'archived_status',
+          },
+        ],
+      },
+    ];
+
+    const rule = formatQuery(query, 'JsonLogic');
+    const parsed = parseQuery(rule, 'JsonLogic');
+
+    expect(parsed.data).toEqual(query);
+    expect(parsed.fields).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ field: 'price' }),
+        expect.objectContaining({ field: 'cost' }),
+        expect.objectContaining({ field: 'discount' }),
+        expect.objectContaining({ field: 'max_discount' }),
+      ])
+    );
+  });
+});

--- a/src/query-formats/json-logic/parse-json-logic-expression.ts
+++ b/src/query-formats/json-logic/parse-json-logic-expression.ts
@@ -105,6 +105,17 @@ const parseSubstrRule = (rule: JsonLogicRule): IDenormalizedRuleNode | null => {
   return null;
 };
 
+const parseFieldComparisonRule = (
+  field: string,
+  operator: QueryOperator,
+  valueField: string
+): IDenormalizedRuleNode => ({
+  field,
+  operator,
+  valueSource: 'field',
+  valueField,
+});
+
 const parseSimpleRule = (rule: JsonLogicRule): IDenormalizedRuleNode | null => {
   if (!isJsonLogicObject(rule)) {
     return null;
@@ -153,6 +164,11 @@ const parseSimpleRule = (rule: JsonLogicRule): IDenormalizedRuleNode | null => {
       if (args[1] === null) {
         return { field: args[0].var, operator: 'IS_NULL' };
       }
+
+      if (isVarRule(args[1])) {
+        return parseFieldComparisonRule(args[0].var, 'EQUAL', args[1].var);
+      }
+
       return { field: args[0].var, operator: 'EQUAL', value: args[1] as never };
     }
 
@@ -160,6 +176,11 @@ const parseSimpleRule = (rule: JsonLogicRule): IDenormalizedRuleNode | null => {
       if (args[1] === null) {
         return { field: args[0].var, operator: 'IS_NOT_NULL' };
       }
+
+      if (isVarRule(args[1])) {
+        return parseFieldComparisonRule(args[0].var, 'NOT_EQUAL', args[1].var);
+      }
+
       return {
         field: args[0].var,
         operator: 'NOT_EQUAL',
@@ -173,6 +194,14 @@ const parseSimpleRule = (rule: JsonLogicRule): IDenormalizedRuleNode | null => {
       '<': 'SMALLER',
       '<=': 'SMALLER_EQUAL',
     };
+
+    if (isVarRule(args[1])) {
+      return parseFieldComparisonRule(
+        args[0].var,
+        operatorMap[operatorKey],
+        args[1].var
+      );
+    }
 
     return {
       field: args[0].var,
@@ -245,17 +274,17 @@ export const parseJsonLogicExpression = (value: unknown): DenormalizedNode[] => 
     if (childNodes.length === 1 && 'type' in childNodes[0]) {
       const child = childNodes[0];
 
-    if (child.type === 'GROUP') {
-      if ('value' in child && typeof child.value !== 'undefined') {
-        return [
-          {
-            type: 'GROUP',
-            value: child.value,
-            isNegated: !child.isNegated,
-            children: child.children,
-          },
-        ];
-      }
+      if (child.type === 'GROUP') {
+        if ('value' in child && typeof child.value !== 'undefined') {
+          return [
+            {
+              type: 'GROUP',
+              value: child.value,
+              isNegated: !child.isNegated,
+              children: child.children,
+            },
+          ];
+        }
 
         return [
           {

--- a/src/query-formats/jsonata/format-jsonata-rule.ts
+++ b/src/query-formats/jsonata/format-jsonata-rule.ts
@@ -3,6 +3,7 @@ import type {
   QueryOperator,
   QueryRuleValue,
 } from '../../utils/query-tree';
+import { isFieldComparisonRule } from '../../utils/rule-value-source';
 import {
   escapeJsonataRegex,
   formatJsonataArrayValue,
@@ -54,20 +55,25 @@ const joinExpressions = (
   return `(${expressions.join(` ${combinator} `)})`;
 };
 
+const formatFieldOrScalarValue = (rule: IDenormalizedRuleNode): string =>
+  isFieldComparisonRule(rule)
+    ? rule.valueField
+    : formatJsonataScalarValue(rule.value as never);
+
 export const formatJsonataRule = (rule: IDenormalizedRuleNode): string => {
   switch (rule.operator) {
     case 'EQUAL':
-      return `${rule.field} = ${formatJsonataScalarValue(rule.value as never)}`;
+      return `${rule.field} = ${formatFieldOrScalarValue(rule)}`;
     case 'NOT_EQUAL':
-      return `${rule.field} != ${formatJsonataScalarValue(rule.value as never)}`;
+      return `${rule.field} != ${formatFieldOrScalarValue(rule)}`;
     case 'LARGER':
-      return `${rule.field} > ${formatJsonataScalarValue(rule.value as never)}`;
+      return `${rule.field} > ${formatFieldOrScalarValue(rule)}`;
     case 'LARGER_EQUAL':
-      return `${rule.field} >= ${formatJsonataScalarValue(rule.value as never)}`;
+      return `${rule.field} >= ${formatFieldOrScalarValue(rule)}`;
     case 'SMALLER':
-      return `${rule.field} < ${formatJsonataScalarValue(rule.value as never)}`;
+      return `${rule.field} < ${formatFieldOrScalarValue(rule)}`;
     case 'SMALLER_EQUAL':
-      return `${rule.field} <= ${formatJsonataScalarValue(rule.value as never)}`;
+      return `${rule.field} <= ${formatFieldOrScalarValue(rule)}`;
     case 'IN':
       return `${rule.field} in ${formatJsonataArrayValue(
         ensureArrayValue(rule.operator, rule.value)
@@ -136,4 +142,3 @@ export const formatJsonataRule = (rule: IDenormalizedRuleNode): string => {
       );
   }
 };
-

--- a/src/query-formats/jsonata/infer-jsonata-fields.ts
+++ b/src/query-formats/jsonata/infer-jsonata-fields.ts
@@ -4,6 +4,7 @@ import type {
   IDenormalizedRuleNode,
   QueryOperator,
 } from '../../utils/query-tree';
+import { isFieldComparisonRule } from '../../utils/rule-value-source';
 import { jsonataOperatorOrder } from './jsonata-token.types';
 
 const inferJsonataFieldType = (
@@ -39,24 +40,36 @@ export const inferJsonataFields = (
     { type: IBuilderFieldProps['type']; operators: QueryOperator[] }
   >();
 
-  collectRules(data).forEach(rule => {
-    const current = fieldMap.get(rule.field);
-    const nextType = inferJsonataFieldType(rule);
+  const mergeFieldConfig = (
+    fieldName: string,
+    type: IBuilderFieldProps['type'],
+    operator?: QueryOperator
+  ) => {
+    const current = fieldMap.get(fieldName);
 
     if (!current) {
-      fieldMap.set(rule.field, {
-        type: nextType,
-        operators: rule.operator ? [rule.operator] : [],
+      fieldMap.set(fieldName, {
+        type,
+        operators: operator ? [operator] : [],
       });
       return;
     }
 
-    if (current.type !== nextType) {
+    if (current.type !== type) {
       current.type = 'TEXT';
     }
 
-    if (rule.operator && !current.operators.includes(rule.operator)) {
-      current.operators.push(rule.operator);
+    if (operator && !current.operators.includes(operator)) {
+      current.operators.push(operator);
+    }
+  };
+
+  collectRules(data).forEach(rule => {
+    const nextType = inferJsonataFieldType(rule);
+    mergeFieldConfig(rule.field, nextType, rule.operator);
+
+    if (isFieldComparisonRule(rule)) {
+      mergeFieldConfig(rule.valueField, nextType, rule.operator);
     }
   });
 
@@ -69,4 +82,3 @@ export const inferJsonataFields = (
     ),
   })) as IBuilderFieldProps[];
 };
-

--- a/src/query-formats/jsonata/jsonata-parser.ts
+++ b/src/query-formats/jsonata/jsonata-parser.ts
@@ -3,6 +3,7 @@ import type {
   QueryGroupValue,
   QueryOperator,
 } from '../../utils/query-tree';
+import { isFieldComparisonRule } from '../../utils/rule-value-source';
 import type {
   IJsonataToken,
   JsonataTokenType,
@@ -138,7 +139,9 @@ export class JsonataParser {
     }
 
     const operatorToken = this.expect('OPERATOR');
-    const value = this.parseScalarValue();
+    const nextToken = this.peek();
+    const valueField = nextToken.type === 'IDENTIFIER' ? this.parseIdentifier() : undefined;
+    const value = valueField ? undefined : this.parseScalarValue();
 
     if (operatorToken.value === '=' && value === null) {
       return { field, operator: 'IS_NULL' };
@@ -148,11 +151,18 @@ export class JsonataParser {
       return { field, operator: 'IS_NOT_NULL' };
     }
 
-    return {
-      field,
-      operator: this.mapOperator(operatorToken.value),
-      value: value as Exclude<typeof value, null>,
-    };
+    return valueField
+      ? {
+          field,
+          operator: this.mapOperator(operatorToken.value),
+          valueSource: 'field',
+          valueField,
+        }
+      : {
+          field,
+          operator: this.mapOperator(operatorToken.value),
+          value: value as Exclude<typeof value, null>,
+        };
   }
 
   private parseIdentifier(): string {
@@ -239,7 +249,13 @@ export class JsonataParser {
     left: ParsedJsonataNode,
     right: ParsedJsonataNode
   ): IDenormalizedRuleNode | null {
-    if (this.isRuleNode(left) && this.isRuleNode(right) && left.field === right.field) {
+    if (
+      this.isRuleNode(left) &&
+      this.isRuleNode(right) &&
+      left.field === right.field &&
+      !isFieldComparisonRule(left) &&
+      !isFieldComparisonRule(right)
+    ) {
       if (
         combinator === 'AND' &&
         left.operator === 'LARGER_EQUAL' &&
@@ -317,4 +333,3 @@ export class JsonataParser {
     return this.tokens[this.index];
   }
 }
-

--- a/src/query-formats/jsonata/jsonata-roundtrip.test.ts
+++ b/src/query-formats/jsonata/jsonata-roundtrip.test.ts
@@ -21,5 +21,53 @@ describe('JSONata roundtrip', () => {
 
     expect(parsed.data).toEqual(query);
   });
-});
 
+  it('round-trips field-to-field scalar comparisons', () => {
+    const query: DenormalizedQuery = [
+      {
+        type: 'GROUP',
+        value: 'AND',
+        isNegated: false,
+        children: [
+          {
+            field: 'price',
+            operator: 'LARGER_EQUAL',
+            valueSource: 'field',
+            valueField: 'cost',
+          },
+          {
+            field: 'discount',
+            operator: 'SMALLER',
+            valueSource: 'field',
+            valueField: 'max_discount',
+          },
+          {
+            field: 'name',
+            operator: 'EQUAL',
+            valueSource: 'field',
+            valueField: 'fallback_name',
+          },
+          {
+            field: 'status',
+            operator: 'NOT_EQUAL',
+            valueSource: 'field',
+            valueField: 'archived_status',
+          },
+        ],
+      },
+    ];
+
+    const expression = formatQuery(query, 'JSONata');
+    const parsed = parseQuery(expression, 'JSONata');
+
+    expect(parsed.data).toEqual(query);
+    expect(parsed.fields).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ field: 'price' }),
+        expect.objectContaining({ field: 'cost' }),
+        expect.objectContaining({ field: 'discount' }),
+        expect.objectContaining({ field: 'max_discount' }),
+      ])
+    );
+  });
+});

--- a/src/query-formats/mongo/format-mongo-rule.ts
+++ b/src/query-formats/mongo/format-mongo-rule.ts
@@ -1,9 +1,11 @@
 import type {
+  IFieldReferenceRuleNode,
   IDenormalizedRuleNode,
   QueryOperator,
   QueryRuleValue,
 } from '../../utils/query-tree';
-import { escapeRegexPattern } from './shared';
+import { isFieldComparisonRule } from '../../utils/rule-value-source';
+import { createMongoFieldReference, escapeRegexPattern } from './shared';
 
 type MongoFieldValue = QueryRuleValue | Record<string, unknown>;
 
@@ -67,22 +69,46 @@ const createNotBetweenExpression = (
   ],
 });
 
+const createFieldComparisonExpression = (
+  rule: IFieldReferenceRuleNode,
+  operator: '$eq' | '$ne' | '$gt' | '$gte' | '$lt' | '$lte'
+): Record<string, MongoFieldValue> => ({
+  $expr: {
+    [operator]: [
+      createMongoFieldReference(rule.field),
+      createMongoFieldReference(rule.valueField),
+    ],
+  },
+});
+
 export const formatMongoRule = (
   rule: IDenormalizedRuleNode
 ): Record<string, MongoFieldValue> => {
   switch (rule.operator) {
     case 'EQUAL':
-      return { [rule.field]: rule.value as QueryRuleValue };
+      return isFieldComparisonRule(rule)
+        ? createFieldComparisonExpression(rule, '$eq')
+        : { [rule.field]: rule.value as QueryRuleValue };
     case 'NOT_EQUAL':
-      return { [rule.field]: { $ne: rule.value } };
+      return isFieldComparisonRule(rule)
+        ? createFieldComparisonExpression(rule, '$ne')
+        : { [rule.field]: { $ne: rule.value } };
     case 'LARGER':
-      return { [rule.field]: { $gt: rule.value } };
+      return isFieldComparisonRule(rule)
+        ? createFieldComparisonExpression(rule, '$gt')
+        : { [rule.field]: { $gt: rule.value } };
     case 'LARGER_EQUAL':
-      return { [rule.field]: { $gte: rule.value } };
+      return isFieldComparisonRule(rule)
+        ? createFieldComparisonExpression(rule, '$gte')
+        : { [rule.field]: { $gte: rule.value } };
     case 'SMALLER':
-      return { [rule.field]: { $lt: rule.value } };
+      return isFieldComparisonRule(rule)
+        ? createFieldComparisonExpression(rule, '$lt')
+        : { [rule.field]: { $lt: rule.value } };
     case 'SMALLER_EQUAL':
-      return { [rule.field]: { $lte: rule.value } };
+      return isFieldComparisonRule(rule)
+        ? createFieldComparisonExpression(rule, '$lte')
+        : { [rule.field]: { $lte: rule.value } };
     case 'IN':
     case 'ANY_IN':
       return { [rule.field]: { $in: ensureArrayValue(rule.operator, rule.value) } };
@@ -147,4 +173,3 @@ export const formatMongoRule = (
       );
   }
 };
-

--- a/src/query-formats/mongo/infer-mongo-fields.ts
+++ b/src/query-formats/mongo/infer-mongo-fields.ts
@@ -4,6 +4,7 @@ import type {
   IDenormalizedRuleNode,
   QueryOperator,
 } from '../../utils/query-tree';
+import { isFieldComparisonRule } from '../../utils/rule-value-source';
 
 const inferMongoFieldType = (
   rule: IDenormalizedRuleNode
@@ -65,22 +66,34 @@ export const inferMongoFields = (data: DenormalizedQuery): IBuilderFieldProps[] 
     { type: IBuilderFieldProps['type']; operators: QueryOperator[] }
   >();
 
-  collectMongoRules(data).forEach(rule => {
-    const currentField = fieldMap.get(rule.field);
-    const nextType = inferMongoFieldType(rule);
+  const mergeFieldConfig = (
+    fieldName: string,
+    type: IBuilderFieldProps['type'],
+    operator?: QueryOperator
+  ) => {
+    const currentField = fieldMap.get(fieldName);
 
     if (!currentField) {
-      fieldMap.set(rule.field, {
-        type: nextType,
-        operators: rule.operator ? [rule.operator] : [],
+      fieldMap.set(fieldName, {
+        type,
+        operators: operator ? [operator] : [],
       });
       return;
     }
 
-    currentField.type = mergeMongoFieldType(currentField.type, nextType);
+    currentField.type = mergeMongoFieldType(currentField.type, type);
 
-    if (rule.operator && !currentField.operators.includes(rule.operator)) {
-      currentField.operators.push(rule.operator);
+    if (operator && !currentField.operators.includes(operator)) {
+      currentField.operators.push(operator);
+    }
+  };
+
+  collectMongoRules(data).forEach(rule => {
+    const nextType = inferMongoFieldType(rule);
+    mergeFieldConfig(rule.field, nextType, rule.operator);
+
+    if (isFieldComparisonRule(rule)) {
+      mergeFieldConfig(rule.valueField, nextType, rule.operator);
     }
   });
 
@@ -91,4 +104,3 @@ export const inferMongoFields = (data: DenormalizedQuery): IBuilderFieldProps[] 
     operators: config.operators,
   })) as IBuilderFieldProps[];
 };
-

--- a/src/query-formats/mongo/mongo-roundtrip.test.ts
+++ b/src/query-formats/mongo/mongo-roundtrip.test.ts
@@ -30,5 +30,53 @@ describe('Mongo roundtrip', () => {
 
     expect(parsed.data).toEqual(query);
   });
-});
 
+  it('round-trips field-to-field scalar comparisons through $expr', () => {
+    const query: DenormalizedQuery = [
+      {
+        type: 'GROUP',
+        value: 'AND',
+        isNegated: false,
+        children: [
+          {
+            field: 'price',
+            operator: 'LARGER_EQUAL',
+            valueSource: 'field',
+            valueField: 'cost',
+          },
+          {
+            field: 'discount',
+            operator: 'SMALLER',
+            valueSource: 'field',
+            valueField: 'max_discount',
+          },
+          {
+            field: 'name',
+            operator: 'EQUAL',
+            valueSource: 'field',
+            valueField: 'fallback_name',
+          },
+          {
+            field: 'status',
+            operator: 'NOT_EQUAL',
+            valueSource: 'field',
+            valueField: 'archived_status',
+          },
+        ],
+      },
+    ];
+
+    const mongo = formatQuery(query, 'Mongo');
+    const parsed = parseQuery(mongo, 'Mongo');
+
+    expect(parsed.data).toEqual(query);
+    expect(parsed.fields).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ field: 'price' }),
+        expect.objectContaining({ field: 'cost' }),
+        expect.objectContaining({ field: 'discount' }),
+        expect.objectContaining({ field: 'max_discount' }),
+      ])
+    );
+  });
+});

--- a/src/query-formats/mongo/parse-mongo-expression.ts
+++ b/src/query-formats/mongo/parse-mongo-expression.ts
@@ -2,12 +2,13 @@ import type {
   DenormalizedNode,
   IDenormalizedRuleNode,
 } from '../../utils/query-tree';
-import { inferRegexOperator } from './shared';
+import {
+  inferRegexOperator,
+  isMongoDocument,
+  parseMongoFieldReference,
+} from './shared';
 
 type MongoDocument = Record<string, unknown>;
-
-const isPlainObject = (value: unknown): value is MongoDocument =>
-  typeof value === 'object' && value !== null && !Array.isArray(value);
 
 const parseRegexExpression = (
   field: string,
@@ -24,6 +25,77 @@ const parseRegexExpression = (
     field,
     ...inferRegexOperator(pattern, negated),
   };
+};
+
+const parseExprExpression = (value: MongoDocument): IDenormalizedRuleNode => {
+  const operatorKeys = Object.keys(value);
+
+  if (operatorKeys.length !== 1) {
+    throw new Error('Mongo $expr must contain exactly one comparison operator.');
+  }
+
+  const [operatorKey] = operatorKeys;
+  const operands = value[operatorKey];
+
+  if (!Array.isArray(operands) || operands.length != 2) {
+    throw new Error(`Mongo $expr operator "${operatorKey}" must contain two operands.`);
+  }
+
+  const leftField = parseMongoFieldReference(operands[0]);
+  const rightField = parseMongoFieldReference(operands[1]);
+
+  if (!leftField || !rightField) {
+    throw new Error(
+      'Mongo $expr field-to-field comparisons must use field references on both sides.'
+    );
+  }
+
+  switch (operatorKey) {
+    case '$eq':
+      return {
+        field: leftField,
+        operator: 'EQUAL',
+        valueSource: 'field',
+        valueField: rightField,
+      };
+    case '$ne':
+      return {
+        field: leftField,
+        operator: 'NOT_EQUAL',
+        valueSource: 'field',
+        valueField: rightField,
+      };
+    case '$gt':
+      return {
+        field: leftField,
+        operator: 'LARGER',
+        valueSource: 'field',
+        valueField: rightField,
+      };
+    case '$gte':
+      return {
+        field: leftField,
+        operator: 'LARGER_EQUAL',
+        valueSource: 'field',
+        valueField: rightField,
+      };
+    case '$lt':
+      return {
+        field: leftField,
+        operator: 'SMALLER',
+        valueSource: 'field',
+        valueField: rightField,
+      };
+    case '$lte':
+      return {
+        field: leftField,
+        operator: 'SMALLER_EQUAL',
+        valueSource: 'field',
+        valueField: rightField,
+      };
+    default:
+      throw new Error(`Unsupported Mongo $expr operator "${operatorKey}".`);
+  }
 };
 
 const parseFieldOperatorExpression = (
@@ -81,7 +153,7 @@ const parseFieldOperatorExpression = (
       case '$regex':
         return [parseRegexExpression(field, value)];
       case '$not':
-        if (!isPlainObject(value.$not)) {
+        if (!isMongoDocument(value.$not)) {
           throw new Error(`Mongo $not for field "${field}" must wrap an object.`);
         }
 
@@ -130,7 +202,7 @@ const isSameFieldRangeBoundaryGroup = (
 
   const [first, second] = items;
 
-  if (!isPlainObject(first) || !isPlainObject(second)) {
+  if (!isMongoDocument(first) || !isMongoDocument(second)) {
     return false;
   }
 
@@ -142,8 +214,8 @@ const isSameFieldRangeBoundaryGroup = (
   }
 
   return (
-    isPlainObject(first[firstField]) &&
-    isPlainObject(second[secondField]) &&
+    isMongoDocument(first[firstField]) &&
+    isMongoDocument(second[secondField]) &&
     '$lt' in first[firstField] &&
     '$gt' in second[secondField]
   );
@@ -226,7 +298,15 @@ const parseRootDocument = (document: MongoDocument): DenormalizedNode[] =>
       return [createLogicalGroup('OR', value, true)];
     }
 
-    if (isPlainObject(value)) {
+    if (key === '$expr') {
+      if (!isMongoDocument(value)) {
+        throw new Error('Mongo $expr must be an object.');
+      }
+
+      return [parseExprExpression(value)];
+    }
+
+    if (isMongoDocument(value)) {
       return parseFieldOperatorExpression(key, value);
     }
 
@@ -240,7 +320,7 @@ const parseRootDocument = (document: MongoDocument): DenormalizedNode[] =>
   });
 
 export const parseMongoExpression = (value: unknown): DenormalizedNode[] => {
-  if (!isPlainObject(value)) {
+  if (!isMongoDocument(value)) {
     throw new Error('Mongo query must be a JSON object.');
   }
 

--- a/src/query-formats/mongo/shared.ts
+++ b/src/query-formats/mongo/shared.ts
@@ -1,7 +1,27 @@
 import type { QueryOperator } from '../../utils/query-tree';
 
+const isPlainObject = (value: unknown): value is Record<string, unknown> =>
+  typeof value === 'object' && value !== null && !Array.isArray(value);
+
+export const mongoFieldReferencePrefix = '$';
+
+export const createMongoFieldReference = (field: string): string =>
+  `${mongoFieldReferencePrefix}${field}`;
+
+export const parseMongoFieldReference = (value: unknown): string | null => {
+  if (
+    typeof value !== 'string' ||
+    !value.startsWith(mongoFieldReferencePrefix) ||
+    value.length === mongoFieldReferencePrefix.length
+  ) {
+    return null;
+  }
+
+  return value.slice(mongoFieldReferencePrefix.length);
+};
+
 export const escapeRegexPattern = (value: string): string =>
-  value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+  value.replace(/[|\{}()\[\]^$+*?.]/g, '\\$&');
 
 export const stripAnchors = (value: string): string =>
   value.replace(/^\^/, '').replace(/\$$/, '');
@@ -41,3 +61,5 @@ export const inferRegexOperator = (
   };
 };
 
+export const isMongoDocument = (value: unknown): value is Record<string, unknown> =>
+  isPlainObject(value);

--- a/src/query-formats/odata/format-odata-rule.ts
+++ b/src/query-formats/odata/format-odata-rule.ts
@@ -3,6 +3,7 @@ import type {
   QueryOperator,
   QueryRuleValue,
 } from '../../utils/query-tree';
+import { isFieldComparisonRule } from '../../utils/rule-value-source';
 import { formatODataScalarValue } from './shared';
 
 const ensureArrayValue = (
@@ -38,20 +39,30 @@ const ensureStringValue = (
   return value;
 };
 
+const formatFieldOrScalarValue = (rule: IDenormalizedRuleNode): string =>
+  isFieldComparisonRule(rule)
+    ? rule.valueField
+    : formatODataScalarValue(rule.value as never);
+
+const formatFieldOrStringValue = (rule: IDenormalizedRuleNode): string =>
+  isFieldComparisonRule(rule)
+    ? rule.valueField
+    : formatODataScalarValue(ensureStringValue(rule.operator, rule.value));
+
 export const formatODataRule = (rule: IDenormalizedRuleNode): string => {
   switch (rule.operator) {
     case 'EQUAL':
-      return `${rule.field} eq ${formatODataScalarValue(rule.value as never)}`;
+      return `${rule.field} eq ${formatFieldOrScalarValue(rule)}`;
     case 'NOT_EQUAL':
-      return `${rule.field} ne ${formatODataScalarValue(rule.value as never)}`;
+      return `${rule.field} ne ${formatFieldOrScalarValue(rule)}`;
     case 'LARGER':
-      return `${rule.field} gt ${formatODataScalarValue(rule.value as never)}`;
+      return `${rule.field} gt ${formatFieldOrScalarValue(rule)}`;
     case 'LARGER_EQUAL':
-      return `${rule.field} ge ${formatODataScalarValue(rule.value as never)}`;
+      return `${rule.field} ge ${formatFieldOrScalarValue(rule)}`;
     case 'SMALLER':
-      return `${rule.field} lt ${formatODataScalarValue(rule.value as never)}`;
+      return `${rule.field} lt ${formatFieldOrScalarValue(rule)}`;
     case 'SMALLER_EQUAL':
-      return `${rule.field} le ${formatODataScalarValue(rule.value as never)}`;
+      return `${rule.field} le ${formatFieldOrScalarValue(rule)}`;
     case 'IN': {
       const values = ensureArrayValue(rule.operator, rule.value)
         .map(item => `${rule.field} eq ${formatODataScalarValue(item)}`);
@@ -89,21 +100,13 @@ export const formatODataRule = (rule: IDenormalizedRuleNode): string => {
     case 'IS_NOT_NULL':
       return `${rule.field} ne null`;
     case 'CONTAINS':
-      return `contains(${rule.field},${formatODataScalarValue(
-        ensureStringValue(rule.operator, rule.value)
-      )})`;
+      return `contains(${rule.field},${formatFieldOrStringValue(rule)})`;
     case 'NOT_CONTAINS':
-      return `not contains(${rule.field},${formatODataScalarValue(
-        ensureStringValue(rule.operator, rule.value)
-      )})`;
+      return `not contains(${rule.field},${formatFieldOrStringValue(rule)})`;
     case 'STARTS_WITH':
-      return `startswith(${rule.field},${formatODataScalarValue(
-        ensureStringValue(rule.operator, rule.value)
-      )})`;
+      return `startswith(${rule.field},${formatFieldOrStringValue(rule)})`;
     case 'ENDS_WITH':
-      return `endswith(${rule.field},${formatODataScalarValue(
-        ensureStringValue(rule.operator, rule.value)
-      )})`;
+      return `endswith(${rule.field},${formatFieldOrStringValue(rule)})`;
     case 'LIKE':
       return `${rule.field} eq ${formatODataScalarValue(
         ensureStringValue(rule.operator, rule.value)

--- a/src/query-formats/odata/infer-odata-fields.ts
+++ b/src/query-formats/odata/infer-odata-fields.ts
@@ -4,6 +4,7 @@ import type {
   IDenormalizedRuleNode,
   QueryOperator,
 } from '../../utils/query-tree';
+import { isFieldComparisonRule } from '../../utils/rule-value-source';
 import { odataOperatorOrder } from './odata-token.types';
 
 const inferODataFieldType = (
@@ -37,24 +38,36 @@ export const inferODataFields = (data: DenormalizedQuery): IBuilderFieldProps[] 
     { type: IBuilderFieldProps['type']; operators: QueryOperator[] }
   >();
 
-  collectRules(data).forEach(rule => {
-    const current = fieldMap.get(rule.field);
-    const nextType = inferODataFieldType(rule);
+  const mergeFieldConfig = (
+    fieldName: string,
+    type: IBuilderFieldProps['type'],
+    operator?: QueryOperator
+  ) => {
+    const current = fieldMap.get(fieldName);
 
     if (!current) {
-      fieldMap.set(rule.field, {
-        type: nextType,
-        operators: rule.operator ? [rule.operator] : [],
+      fieldMap.set(fieldName, {
+        type,
+        operators: operator ? [operator] : [],
       });
       return;
     }
 
-    if (current.type !== nextType) {
+    if (current.type !== type) {
       current.type = 'TEXT';
     }
 
-    if (rule.operator && !current.operators.includes(rule.operator)) {
-      current.operators.push(rule.operator);
+    if (operator && !current.operators.includes(operator)) {
+      current.operators.push(operator);
+    }
+  };
+
+  collectRules(data).forEach(rule => {
+    const nextType = inferODataFieldType(rule);
+    mergeFieldConfig(rule.field, nextType, rule.operator);
+
+    if (isFieldComparisonRule(rule)) {
+      mergeFieldConfig(rule.valueField, nextType, rule.operator);
     }
   });
 

--- a/src/query-formats/odata/odata-parser.ts
+++ b/src/query-formats/odata/odata-parser.ts
@@ -3,6 +3,7 @@ import type {
   QueryGroupValue,
   QueryOperator,
 } from '../../utils/query-tree';
+import { isFieldComparisonRule } from '../../utils/rule-value-source';
 import type {
   IODataToken,
   IParsedODataGroup,
@@ -11,6 +12,8 @@ import type {
 } from './odata-token.types';
 import { inferODataStringOperator } from './shared';
 import { tokenizeOData } from './tokenize-odata';
+
+type ODataFieldReference = { kind: 'field'; field: string };
 
 export class ODataParser {
   private readonly tokens: IODataToken[];
@@ -105,7 +108,7 @@ export class ODataParser {
     this.expect('LPAREN');
     const field = this.parseIdentifier();
     this.expect('COMMA');
-    const value = this.parseStringValue();
+    const value = this.parseStringOrFieldReferenceValue();
     this.expect('RPAREN');
 
     if (
@@ -114,6 +117,20 @@ export class ODataParser {
       functionName !== 'endswith'
     ) {
       throw new Error(`Unsupported OData function "${functionName}".`);
+    }
+
+    if (this.isFieldReference(value)) {
+      return {
+        field,
+        operator:
+          functionName === 'contains'
+            ? 'CONTAINS'
+            : functionName === 'startswith'
+              ? 'STARTS_WITH'
+              : 'ENDS_WITH',
+        valueSource: 'field',
+        valueField: value.field,
+      };
     }
 
     return {
@@ -132,7 +149,7 @@ export class ODataParser {
       'lt',
       'le',
     ]);
-    const value = this.parseScalarValue();
+    const value = this.parseComparisonValue();
 
     if (operator === 'eq' && value === null) {
       return { field, operator: 'IS_NULL' };
@@ -140,6 +157,15 @@ export class ODataParser {
 
     if (operator === 'ne' && value === null) {
       return { field, operator: 'IS_NOT_NULL' };
+    }
+
+    if (this.isFieldReference(value)) {
+      return {
+        field,
+        operator: this.mapOperator(operator),
+        valueSource: 'field',
+        valueField: value.field,
+      };
     }
 
     return {
@@ -185,6 +211,19 @@ export class ODataParser {
     throw new Error(`Expected a scalar value but found "${token.value}".`);
   }
 
+  private parseComparisonValue():
+    | string
+    | number
+    | boolean
+    | null
+    | ODataFieldReference {
+    if (this.peek().type === 'IDENTIFIER') {
+      return { kind: 'field', field: this.parseIdentifier() };
+    }
+
+    return this.parseScalarValue();
+  }
+
   private parseStringValue(): string {
     const value = this.parseScalarValue();
 
@@ -193,6 +232,14 @@ export class ODataParser {
     }
 
     return value;
+  }
+
+  private parseStringOrFieldReferenceValue(): string | ODataFieldReference {
+    if (this.peek().type === 'IDENTIFIER') {
+      return { kind: 'field', field: this.parseIdentifier() };
+    }
+
+    return this.parseStringValue();
   }
 
   private mapOperator(value: string): QueryOperator {
@@ -256,6 +303,10 @@ export class ODataParser {
       return null;
     }
 
+    if (isFieldComparisonRule(left) || isFieldComparisonRule(right)) {
+      return null;
+    }
+
     if (
       combinator === 'AND' &&
       left.operator === 'LARGER_EQUAL' &&
@@ -313,6 +364,15 @@ export class ODataParser {
 
   private isParsedGroup(node: ParsedODataNode): node is IParsedODataGroup {
     return 'kind' in node && node.kind === 'group';
+  }
+
+  private isFieldReference(value: unknown): value is ODataFieldReference {
+    return (
+      typeof value === 'object' &&
+      value !== null &&
+      'kind' in value &&
+      value.kind === 'field'
+    );
   }
 
   private isKeyword(value: string): boolean {

--- a/src/query-formats/odata/odata-roundtrip.test.ts
+++ b/src/query-formats/odata/odata-roundtrip.test.ts
@@ -21,4 +21,91 @@ describe('OData roundtrip', () => {
 
     expect(parsed.data).toEqual(query);
   });
+
+  it('round-trips field-to-field scalar comparisons', () => {
+    const query: DenormalizedQuery = [
+      {
+        type: 'GROUP',
+        value: 'AND',
+        isNegated: false,
+        children: [
+          {
+            field: 'price',
+            operator: 'LARGER_EQUAL',
+            valueSource: 'field',
+            valueField: 'cost',
+          },
+          {
+            field: 'discount',
+            operator: 'SMALLER',
+            valueSource: 'field',
+            valueField: 'max_discount',
+          },
+        ],
+      },
+    ];
+
+    const expression = formatQuery(query, 'OData');
+    const parsed = parseQuery(expression, 'OData');
+
+    expect(parsed.data).toEqual(query);
+    expect(parsed.fields).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ field: 'price' }),
+        expect.objectContaining({ field: 'cost' }),
+        expect.objectContaining({ field: 'discount' }),
+        expect.objectContaining({ field: 'max_discount' }),
+      ])
+    );
+  });
+
+  it('does not collapse same-field field references into literal range operators', () => {
+    const parsed = parseQuery(
+      '(price ge min_price and price le max_price)',
+      'OData'
+    );
+
+    expect(parsed.data).toEqual<DenormalizedQuery>([
+      {
+        type: 'GROUP',
+        value: 'AND',
+        isNegated: false,
+        children: [
+          {
+            field: 'price',
+            operator: 'LARGER_EQUAL',
+            valueSource: 'field',
+            valueField: 'min_price',
+          },
+          {
+            field: 'price',
+            operator: 'SMALLER_EQUAL',
+            valueSource: 'field',
+            valueField: 'max_price',
+          },
+        ],
+      },
+    ]);
+  });
+
+  it('round-trips native field-to-field string functions', () => {
+    const query: DenormalizedQuery = [
+      {
+        type: 'GROUP',
+        value: 'AND',
+        isNegated: false,
+        children: [
+          { field: 'name', operator: 'CONTAINS', valueSource: 'field', valueField: 'needle' },
+          { field: 'name', operator: 'STARTS_WITH', valueSource: 'field', valueField: 'prefix' },
+          { field: 'name', operator: 'ENDS_WITH', valueSource: 'field', valueField: 'suffix' },
+          { field: 'status', operator: 'NOT_CONTAINS', valueSource: 'field', valueField: 'archived_status' },
+        ],
+      },
+    ];
+
+    const expression = formatQuery(query, 'OData');
+    const parsed = parseQuery(expression, 'OData');
+
+    expect(parsed.data).toEqual(query);
+  });
 });

--- a/src/query-formats/prisma/format-prisma-rule.ts
+++ b/src/query-formats/prisma/format-prisma-rule.ts
@@ -3,6 +3,8 @@ import type {
   QueryOperator,
   QueryRuleValue,
 } from '../../utils/query-tree';
+import { isFieldComparisonRule } from '../../utils/rule-value-source';
+import { createPrismaFieldReference } from './shared';
 
 type PrismaClause = Record<string, unknown>;
 
@@ -39,20 +41,29 @@ const ensureStringValue = (
   return value;
 };
 
+const formatPrismaScalarComparisonValue = (
+  rule: IDenormalizedRuleNode
+): QueryRuleValue | Record<string, string> | undefined =>
+  isFieldComparisonRule(rule)
+    ? createPrismaFieldReference(rule.valueField)
+    : rule.value;
+
 export const formatPrismaRule = (rule: IDenormalizedRuleNode): PrismaClause => {
   switch (rule.operator) {
     case 'EQUAL':
-      return { [rule.field]: rule.value as QueryRuleValue };
+      return isFieldComparisonRule(rule)
+        ? { [rule.field]: { equals: createPrismaFieldReference(rule.valueField) } }
+        : { [rule.field]: rule.value as QueryRuleValue };
     case 'NOT_EQUAL':
-      return { [rule.field]: { not: rule.value } };
+      return { [rule.field]: { not: formatPrismaScalarComparisonValue(rule) } };
     case 'LARGER':
-      return { [rule.field]: { gt: rule.value } };
+      return { [rule.field]: { gt: formatPrismaScalarComparisonValue(rule) } };
     case 'LARGER_EQUAL':
-      return { [rule.field]: { gte: rule.value } };
+      return { [rule.field]: { gte: formatPrismaScalarComparisonValue(rule) } };
     case 'SMALLER':
-      return { [rule.field]: { lt: rule.value } };
+      return { [rule.field]: { lt: formatPrismaScalarComparisonValue(rule) } };
     case 'SMALLER_EQUAL':
-      return { [rule.field]: { lte: rule.value } };
+      return { [rule.field]: { lte: formatPrismaScalarComparisonValue(rule) } };
     case 'IN':
     case 'ANY_IN':
       return { [rule.field]: { in: ensureArrayValue(rule.operator, rule.value) } };

--- a/src/query-formats/prisma/infer-prisma-fields.ts
+++ b/src/query-formats/prisma/infer-prisma-fields.ts
@@ -4,6 +4,7 @@ import type {
   IDenormalizedRuleNode,
   QueryOperator,
 } from '../../utils/query-tree';
+import { isFieldComparisonRule } from '../../utils/rule-value-source';
 
 const inferPrismaFieldType = (
   rule: IDenormalizedRuleNode
@@ -46,24 +47,36 @@ export const inferPrismaFields = (data: DenormalizedQuery): IBuilderFieldProps[]
     { type: IBuilderFieldProps['type']; operators: QueryOperator[] }
   >();
 
-  collectPrismaRules(data).forEach(rule => {
-    const current = fieldMap.get(rule.field);
-    const nextType = inferPrismaFieldType(rule);
+  const mergeFieldConfig = (
+    fieldName: string,
+    type: IBuilderFieldProps['type'],
+    operator?: QueryOperator
+  ) => {
+    const current = fieldMap.get(fieldName);
 
     if (!current) {
-      fieldMap.set(rule.field, {
-        type: nextType,
-        operators: rule.operator ? [rule.operator] : [],
+      fieldMap.set(fieldName, {
+        type,
+        operators: operator ? [operator] : [],
       });
       return;
     }
 
-    if (current.type !== nextType) {
+    if (current.type !== type) {
       current.type = 'TEXT';
     }
 
-    if (rule.operator && !current.operators.includes(rule.operator)) {
-      current.operators.push(rule.operator);
+    if (operator && !current.operators.includes(operator)) {
+      current.operators.push(operator);
+    }
+  };
+
+  collectPrismaRules(data).forEach(rule => {
+    const nextType = inferPrismaFieldType(rule);
+    mergeFieldConfig(rule.field, nextType, rule.operator);
+
+    if (isFieldComparisonRule(rule)) {
+      mergeFieldConfig(rule.valueField, nextType, rule.operator);
     }
   });
 

--- a/src/query-formats/prisma/parse-prisma-expression.ts
+++ b/src/query-formats/prisma/parse-prisma-expression.ts
@@ -1,5 +1,8 @@
-import type { DenormalizedNode } from '../../utils/query-tree';
-import { inferPrismaStringOperator } from './shared';
+import type { DenormalizedNode, QueryOperator } from '../../utils/query-tree';
+import {
+  inferPrismaStringOperator,
+  parsePrismaFieldReference,
+} from './shared';
 
 type PrismaDocument = Record<string, unknown>;
 
@@ -24,6 +27,32 @@ const createLogicalGroup = (
   children: items.flatMap(item => parsePrismaExpression(item)),
 });
 
+const createScalarComparisonNode = (
+  field: string,
+  operator: QueryOperator,
+  value: unknown
+): DenormalizedNode => {
+  const valueField = parsePrismaFieldReference(value);
+
+  if (valueField) {
+    return {
+      field,
+      operator,
+      valueSource: 'field',
+      valueField,
+    };
+  }
+
+  return {
+    field,
+    operator,
+    value: value as never,
+  };
+};
+
+const isLiteralRangeBoundaryValue = (value: unknown): boolean =>
+  parsePrismaFieldReference(value) === null;
+
 const parseFieldOperatorExpression = (
   field: string,
   value: PrismaDocument
@@ -37,7 +66,9 @@ const parseFieldOperatorExpression = (
   if (
     operatorKeys.length === 2 &&
     operatorKeys.includes('gte') &&
-    operatorKeys.includes('lte')
+    operatorKeys.includes('lte') &&
+    isLiteralRangeBoundaryValue(value.gte) &&
+    isLiteralRangeBoundaryValue(value.lte)
   ) {
     return [
       {
@@ -52,16 +83,28 @@ const parseFieldOperatorExpression = (
     const [operatorKey] = operatorKeys;
 
     switch (operatorKey) {
-      case 'equals':
-        return [{ field, operator: 'LIKE', value: value.equals as never }];
+      case 'equals': {
+        const valueField = parsePrismaFieldReference(value.equals);
+
+        return [
+          valueField
+            ? {
+                field,
+                operator: 'EQUAL',
+                valueSource: 'field',
+                valueField,
+              }
+            : { field, operator: 'LIKE', value: value.equals as never },
+        ];
+      }
       case 'gt':
-        return [{ field, operator: 'LARGER', value: value.gt as never }];
+        return [createScalarComparisonNode(field, 'LARGER', value.gt)];
       case 'gte':
-        return [{ field, operator: 'LARGER_EQUAL', value: value.gte as never }];
+        return [createScalarComparisonNode(field, 'LARGER_EQUAL', value.gte)];
       case 'lt':
-        return [{ field, operator: 'SMALLER', value: value.lt as never }];
+        return [createScalarComparisonNode(field, 'SMALLER', value.lt)];
       case 'lte':
-        return [{ field, operator: 'SMALLER_EQUAL', value: value.lte as never }];
+        return [createScalarComparisonNode(field, 'SMALLER_EQUAL', value.lte)];
       case 'in':
         return [{ field, operator: 'IN', value: value.in as never }];
       case 'notIn':
@@ -76,9 +119,22 @@ const parseFieldOperatorExpression = (
         return [{ field, operator: 'STARTS_WITH', value: value.startsWith as never }];
       case 'endsWith':
         return [{ field, operator: 'ENDS_WITH', value: value.endsWith as never }];
-      case 'not':
+      case 'not': {
         if (value.not === null) {
           return [{ field, operator: 'IS_NOT_NULL' }];
+        }
+
+        const fieldReference = parsePrismaFieldReference(value.not);
+
+        if (fieldReference) {
+          return [
+            {
+              field,
+              operator: 'NOT_EQUAL',
+              valueSource: 'field',
+              valueField: fieldReference,
+            },
+          ];
         }
 
         if (!isPlainObject(value.not)) {
@@ -88,7 +144,9 @@ const parseFieldOperatorExpression = (
         if (
           'lt' in value.not &&
           'gt' in value.not &&
-          Object.keys(value.not).length === 2
+          Object.keys(value.not).length === 2 &&
+          isLiteralRangeBoundaryValue(value.not.lt) &&
+          isLiteralRangeBoundaryValue(value.not.gt)
         ) {
           return [
             {
@@ -106,10 +164,11 @@ const parseFieldOperatorExpression = (
         }
 
         if ('equals' in value.not) {
-          return [{ field, operator: 'NOT_LIKE', value: value.not.equals as never }];
+          return [createScalarComparisonNode(field, 'NOT_LIKE', value.not.equals)];
         }
 
         throw new Error(`Unsupported Prisma not expression for field "${field}".`);
+      }
       default:
         throw new Error(`Unsupported Prisma operator "${operatorKey}" for field "${field}".`);
     }
@@ -144,7 +203,9 @@ const isSameFieldRangeBoundaryGroup = (
     isPlainObject(first[firstField]) &&
     isPlainObject(second[secondField]) &&
     'lt' in first[firstField] &&
-    'gt' in second[secondField]
+    'gt' in second[secondField] &&
+    isLiteralRangeBoundaryValue((first[firstField] as { lt: unknown }).lt) &&
+    isLiteralRangeBoundaryValue((second[secondField] as { gt: unknown }).gt)
   );
 };
 

--- a/src/query-formats/prisma/prisma-roundtrip.test.ts
+++ b/src/query-formats/prisma/prisma-roundtrip.test.ts
@@ -21,4 +21,85 @@ describe('Prisma roundtrip', () => {
 
     expect(parsed.data).toEqual(query);
   });
+
+  it('round-trips field-to-field scalar comparisons', () => {
+    const query: DenormalizedQuery = [
+      {
+        type: 'GROUP',
+        value: 'AND',
+        isNegated: false,
+        children: [
+          {
+            field: 'price',
+            operator: 'LARGER_EQUAL',
+            valueSource: 'field',
+            valueField: 'cost',
+          },
+          {
+            field: 'discount',
+            operator: 'SMALLER',
+            valueSource: 'field',
+            valueField: 'max_discount',
+          },
+          {
+            field: 'name',
+            operator: 'EQUAL',
+            valueSource: 'field',
+            valueField: 'fallback_name',
+          },
+          {
+            field: 'status',
+            operator: 'NOT_EQUAL',
+            valueSource: 'field',
+            valueField: 'archived_status',
+          },
+        ],
+      },
+    ];
+
+    const expression = formatQuery(query, 'Prisma');
+    const parsed = parseQuery(expression, 'Prisma');
+
+    expect(parsed.data).toEqual([
+      {
+        type: 'GROUP',
+        value: 'AND',
+        isNegated: false,
+        children: [
+          {
+            field: 'price',
+            operator: 'LARGER_EQUAL',
+            valueSource: 'field',
+            valueField: 'cost',
+          },
+          {
+            field: 'discount',
+            operator: 'SMALLER',
+            valueSource: 'field',
+            valueField: 'max_discount',
+          },
+          {
+            field: 'name',
+            operator: 'EQUAL',
+            valueSource: 'field',
+            valueField: 'fallback_name',
+          },
+          {
+            field: 'status',
+            operator: 'NOT_EQUAL',
+            valueSource: 'field',
+            valueField: 'archived_status',
+          },
+        ],
+      },
+    ]);
+    expect(parsed.fields).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ field: 'price' }),
+        expect.objectContaining({ field: 'cost' }),
+        expect.objectContaining({ field: 'discount' }),
+        expect.objectContaining({ field: 'max_discount' }),
+      ])
+    );
+  });
 });

--- a/src/query-formats/prisma/shared.ts
+++ b/src/query-formats/prisma/shared.ts
@@ -1,5 +1,24 @@
 import type { QueryOperator } from '../../utils/query-tree';
 
+const isPlainObject = (value: unknown): value is Record<string, unknown> =>
+  typeof value === 'object' && value !== null && !Array.isArray(value);
+
+export const prismaFieldReferenceKey = '$ref';
+
+export const createPrismaFieldReference = (field: string): Record<string, string> => ({
+  [prismaFieldReferenceKey]: field,
+});
+
+export const parsePrismaFieldReference = (value: unknown): string | null => {
+  if (!isPlainObject(value) || Object.keys(value).length !== 1) {
+    return null;
+  }
+
+  return typeof value[prismaFieldReferenceKey] === 'string'
+    ? value[prismaFieldReferenceKey]
+    : null;
+};
+
 export const inferPrismaStringOperator = (
   config: Record<string, unknown>,
   negated = false

--- a/src/query-formats/rsql/format-rsql-rule.ts
+++ b/src/query-formats/rsql/format-rsql-rule.ts
@@ -3,6 +3,7 @@ import type {
   QueryOperator,
   QueryRuleValue,
 } from '../../utils/query-tree';
+import { isFieldComparisonRule } from '../../utils/rule-value-source';
 import { formatRsqlValue } from './shared';
 
 const ensureArrayValue = (
@@ -38,6 +39,14 @@ const ensureStringValue = (
   return value;
 };
 
+const ensureRsqlSupportsRule = (rule: IDenormalizedRuleNode): void => {
+  if (isFieldComparisonRule(rule)) {
+    throw new Error(
+      `RSQL does not support field-to-field comparisons for field "${rule.field}" and operator "${rule.operator}".`
+    );
+  }
+};
+
 const joinComparisons = (
   field: string,
   operator: string,
@@ -54,6 +63,8 @@ const joinComparisons = (
 };
 
 export const formatRsqlRule = (rule: IDenormalizedRuleNode): string => {
+  ensureRsqlSupportsRule(rule);
+
   switch (rule.operator) {
     case 'EQUAL':
       return `${rule.field}==${formatRsqlValue(rule.value as never)}`;

--- a/src/query-formats/spel/format-spel-rule.ts
+++ b/src/query-formats/spel/format-spel-rule.ts
@@ -3,6 +3,7 @@ import type {
   QueryOperator,
   QueryRuleValue,
 } from '../../utils/query-tree';
+import { isFieldComparisonRule } from '../../utils/rule-value-source';
 import {
   escapeSpelRegex,
   formatSpelArrayValue,
@@ -43,20 +44,30 @@ const ensureStringValue = (
   return value;
 };
 
+const formatFieldOrScalarValue = (rule: IDenormalizedRuleNode): string =>
+  isFieldComparisonRule(rule)
+    ? rule.valueField
+    : formatSpelScalarValue(rule.value as never);
+
+const formatFieldOrStringValue = (rule: IDenormalizedRuleNode): string =>
+  isFieldComparisonRule(rule)
+    ? rule.valueField
+    : quoteSpelString(ensureStringValue(rule.operator, rule.value));
+
 export const formatSpelRule = (rule: IDenormalizedRuleNode): string => {
   switch (rule.operator) {
     case 'EQUAL':
-      return `${rule.field} == ${formatSpelScalarValue(rule.value as never)}`;
+      return `${rule.field} == ${formatFieldOrScalarValue(rule)}`;
     case 'NOT_EQUAL':
-      return `${rule.field} != ${formatSpelScalarValue(rule.value as never)}`;
+      return `${rule.field} != ${formatFieldOrScalarValue(rule)}`;
     case 'LARGER':
-      return `${rule.field} > ${formatSpelScalarValue(rule.value as never)}`;
+      return `${rule.field} > ${formatFieldOrScalarValue(rule)}`;
     case 'LARGER_EQUAL':
-      return `${rule.field} >= ${formatSpelScalarValue(rule.value as never)}`;
+      return `${rule.field} >= ${formatFieldOrScalarValue(rule)}`;
     case 'SMALLER':
-      return `${rule.field} < ${formatSpelScalarValue(rule.value as never)}`;
+      return `${rule.field} < ${formatFieldOrScalarValue(rule)}`;
     case 'SMALLER_EQUAL':
-      return `${rule.field} <= ${formatSpelScalarValue(rule.value as never)}`;
+      return `${rule.field} <= ${formatFieldOrScalarValue(rule)}`;
     case 'IN':
       return `${formatSpelArrayValue(
         ensureArrayValue(rule.operator, rule.value)
@@ -92,21 +103,13 @@ export const formatSpelRule = (rule: IDenormalizedRuleNode): string => {
     case 'IS_NOT_NULL':
       return `${rule.field} != null`;
     case 'CONTAINS':
-      return `${rule.field}.contains(${quoteSpelString(
-        ensureStringValue(rule.operator, rule.value)
-      )})`;
+      return `${rule.field}.contains(${formatFieldOrStringValue(rule)})`;
     case 'NOT_CONTAINS':
-      return `!(${rule.field}.contains(${quoteSpelString(
-        ensureStringValue(rule.operator, rule.value)
-      )}))`;
+      return `!(${rule.field}.contains(${formatFieldOrStringValue(rule)}))`;
     case 'STARTS_WITH':
-      return `${rule.field}.startsWith(${quoteSpelString(
-        ensureStringValue(rule.operator, rule.value)
-      )})`;
+      return `${rule.field}.startsWith(${formatFieldOrStringValue(rule)})`;
     case 'ENDS_WITH':
-      return `${rule.field}.endsWith(${quoteSpelString(
-        ensureStringValue(rule.operator, rule.value)
-      )})`;
+      return `${rule.field}.endsWith(${formatFieldOrStringValue(rule)})`;
     case 'LIKE':
       return `${rule.field} matches ${quoteSpelString(
         `^${escapeSpelRegex(ensureStringValue(rule.operator, rule.value))}$`

--- a/src/query-formats/spel/infer-spel-fields.ts
+++ b/src/query-formats/spel/infer-spel-fields.ts
@@ -4,6 +4,7 @@ import type {
   IDenormalizedRuleNode,
   QueryOperator,
 } from '../../utils/query-tree';
+import { isFieldComparisonRule } from '../../utils/rule-value-source';
 
 const inferSpelFieldType = (
   rule: IDenormalizedRuleNode
@@ -36,24 +37,36 @@ export const inferSpelFields = (data: DenormalizedQuery): IBuilderFieldProps[] =
     { type: IBuilderFieldProps['type']; operators: QueryOperator[] }
   >();
 
-  collectRules(data).forEach(rule => {
-    const current = fieldMap.get(rule.field);
-    const nextType = inferSpelFieldType(rule);
+  const mergeFieldConfig = (
+    fieldName: string,
+    type: IBuilderFieldProps['type'],
+    operator?: QueryOperator
+  ) => {
+    const current = fieldMap.get(fieldName);
 
     if (!current) {
-      fieldMap.set(rule.field, {
-        type: nextType,
-        operators: rule.operator ? [rule.operator] : [],
+      fieldMap.set(fieldName, {
+        type,
+        operators: operator ? [operator] : [],
       });
       return;
     }
 
-    if (current.type !== nextType) {
+    if (current.type !== type) {
       current.type = 'TEXT';
     }
 
-    if (rule.operator && !current.operators.includes(rule.operator)) {
-      current.operators.push(rule.operator);
+    if (operator && !current.operators.includes(operator)) {
+      current.operators.push(operator);
+    }
+  };
+
+  collectRules(data).forEach(rule => {
+    const nextType = inferSpelFieldType(rule);
+    mergeFieldConfig(rule.field, nextType, rule.operator);
+
+    if (isFieldComparisonRule(rule)) {
+      mergeFieldConfig(rule.valueField, nextType, rule.operator);
     }
   });
 

--- a/src/query-formats/spel/parse-spel-rule.ts
+++ b/src/query-formats/spel/parse-spel-rule.ts
@@ -43,6 +43,16 @@ const parseScalarValue = (
   return undefined;
 };
 
+const parseFieldReference = (value: string): string | undefined => {
+  const trimmed = value.trim();
+
+  if (trimmed === 'true' || trimmed === 'false' || trimmed === 'null') {
+    return undefined;
+  }
+
+  return new RegExp(`^${FIELD_PATTERN}$`).test(trimmed) ? trimmed : undefined;
+};
+
 const splitInlineList = (value: string): string[] => {
   const items: string[] = [];
   let inString = false;
@@ -206,8 +216,9 @@ export const parseSpelRule = (value: string): IDenormalizedRuleNode | null => {
   if (match) {
     const [, field, operator, rawValue] = match;
     const parsedValue = parseScalarValue(rawValue);
+    const valueField = parseFieldReference(rawValue);
 
-    if (typeof parsedValue === 'undefined') {
+    if (typeof parsedValue === 'undefined' && !valueField) {
       return null;
     }
 
@@ -228,11 +239,18 @@ export const parseSpelRule = (value: string): IDenormalizedRuleNode | null => {
       '<=': 'SMALLER_EQUAL',
     } as const;
 
-    return {
-      field,
-      operator: operatorMap[operator as keyof typeof operatorMap],
-      value: parsedValue as Exclude<typeof parsedValue, null>,
-    };
+    return valueField
+      ? {
+          field,
+          operator: operatorMap[operator as keyof typeof operatorMap],
+          valueSource: 'field',
+          valueField,
+        }
+      : {
+          field,
+          operator: operatorMap[operator as keyof typeof operatorMap],
+          value: parsedValue as Exclude<typeof parsedValue, null>,
+        };
   }
 
   match = normalized.match(
@@ -242,12 +260,15 @@ export const parseSpelRule = (value: string): IDenormalizedRuleNode | null => {
   if (match) {
     const [, field, rawValue] = match;
     const parsedValue = parseStringLiteral(rawValue);
+    const valueField = parseFieldReference(rawValue);
 
-    if (parsedValue === null) {
+    if (parsedValue === null && !valueField) {
       return null;
     }
 
-    return { field, operator: 'CONTAINS', value: parsedValue };
+    return valueField
+      ? { field, operator: 'CONTAINS', valueSource: 'field', valueField }
+      : { field, operator: 'CONTAINS', value: parsedValue as string };
   }
 
   match = normalized.match(
@@ -257,12 +278,15 @@ export const parseSpelRule = (value: string): IDenormalizedRuleNode | null => {
   if (match) {
     const [, field, rawValue] = match;
     const parsedValue = parseStringLiteral(rawValue);
+    const valueField = parseFieldReference(rawValue);
 
-    if (parsedValue === null) {
+    if (parsedValue === null && !valueField) {
       return null;
     }
 
-    return { field, operator: 'STARTS_WITH', value: parsedValue };
+    return valueField
+      ? { field, operator: 'STARTS_WITH', valueSource: 'field', valueField }
+      : { field, operator: 'STARTS_WITH', value: parsedValue as string };
   }
 
   match = normalized.match(
@@ -272,12 +296,15 @@ export const parseSpelRule = (value: string): IDenormalizedRuleNode | null => {
   if (match) {
     const [, field, rawValue] = match;
     const parsedValue = parseStringLiteral(rawValue);
+    const valueField = parseFieldReference(rawValue);
 
-    if (parsedValue === null) {
+    if (parsedValue === null && !valueField) {
       return null;
     }
 
-    return { field, operator: 'ENDS_WITH', value: parsedValue };
+    return valueField
+      ? { field, operator: 'ENDS_WITH', valueSource: 'field', valueField }
+      : { field, operator: 'ENDS_WITH', value: parsedValue as string };
   }
 
   match = normalized.match(
@@ -320,10 +347,10 @@ export const parseSpelRule = (value: string): IDenormalizedRuleNode | null => {
   );
 
   if (match) {
-    const [, rawList, field] = match;
+    const [, rawList, field, size] = match;
     const parsedList = parseInlineList(rawList);
 
-    if (!parsedList) {
+    if (!parsedList || parsedList.length !== Number(size)) {
       return null;
     }
 
@@ -349,3 +376,4 @@ export const parseSpelRule = (value: string): IDenormalizedRuleNode | null => {
 
   return null;
 };
+

--- a/src/query-formats/spel/spel-roundtrip.test.ts
+++ b/src/query-formats/spel/spel-roundtrip.test.ts
@@ -21,4 +21,82 @@ describe('SpEL roundtrip', () => {
 
     expect(parsed.data).toEqual(query);
   });
+
+  it('round-trips field-to-field scalar comparisons', () => {
+    const query: DenormalizedQuery = [
+      {
+        type: 'GROUP',
+        value: 'AND',
+        isNegated: false,
+        children: [
+          {
+            field: 'price',
+            operator: 'LARGER_EQUAL',
+            valueSource: 'field',
+            valueField: 'cost',
+          },
+          {
+            field: 'discount',
+            operator: 'SMALLER',
+            valueSource: 'field',
+            valueField: 'max_discount',
+          },
+          {
+            field: 'name',
+            operator: 'EQUAL',
+            valueSource: 'field',
+            valueField: 'fallback_name',
+          },
+          {
+            field: 'status',
+            operator: 'NOT_EQUAL',
+            valueSource: 'field',
+            valueField: 'archived_status',
+          },
+        ],
+      },
+    ];
+
+    const expression = formatQuery(query, 'SpEL');
+    const parsed = parseQuery(expression, 'SpEL');
+
+    expect(parsed.data).toEqual(query);
+    expect(parsed.fields).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ field: 'price' }),
+        expect.objectContaining({ field: 'cost' }),
+        expect.objectContaining({ field: 'discount' }),
+        expect.objectContaining({ field: 'max_discount' }),
+      ])
+    );
+  });
+
+  it('round-trips native field-to-field string methods', () => {
+    const query: DenormalizedQuery = [
+      {
+        type: 'GROUP',
+        value: 'AND',
+        isNegated: false,
+        children: [
+          { field: 'name', operator: 'CONTAINS', valueSource: 'field', valueField: 'needle' },
+          { field: 'name', operator: 'STARTS_WITH', valueSource: 'field', valueField: 'prefix' },
+          { field: 'name', operator: 'ENDS_WITH', valueSource: 'field', valueField: 'suffix' },
+          { field: 'status', operator: 'NOT_CONTAINS', valueSource: 'field', valueField: 'archived_status' },
+        ],
+      },
+    ];
+
+    const expression = formatQuery(query, 'SpEL');
+    const parsed = parseQuery(expression, 'SpEL');
+
+    expect(parsed.data).toEqual(query);
+    expect(parsed.fields).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ field: 'needle' }),
+        expect.objectContaining({ field: 'prefix' }),
+        expect.objectContaining({ field: 'suffix' }),
+        expect.objectContaining({ field: 'archived_status' }),
+      ])
+    );
+  });
 });

--- a/src/query-formats/sql/format-sql.ts
+++ b/src/query-formats/sql/format-sql.ts
@@ -7,6 +7,7 @@ import type {
 } from '../../utils/query-tree';
 import type { IBuilderFieldProps } from '../../builder';
 import type { IFormatSqlOptions } from '../types';
+import { isFieldComparisonRule } from '../../utils/rule-value-source';
 import {
   DEFAULT_MODIFIERLESS_GROUP_COMBINATOR,
   DEFAULT_ROOTLESS_COMBINATOR,
@@ -62,6 +63,20 @@ const formatArrayValueWithField = (
 ): string =>
   `(${value.map(item => formatValueWithField(item, field)).join(', ')})`;
 
+const formatRuleValue = (
+  rule: IDenormalizedRuleNode,
+  field?: IBuilderFieldProps
+): string => {
+  if (isFieldComparisonRule(rule)) {
+    return quoteIdentifier(rule.valueField);
+  }
+
+  return formatValueWithField(
+    rule.value as number | string | boolean,
+    field
+  );
+};
+
 const joinFragments = (
   fragments: string[],
   combinator: QueryGroupValue
@@ -91,10 +106,26 @@ const formatLikePattern = (
   return `${prefix}${rule.value}${suffix}`;
 };
 
+const ensureSqlSupportsRule = (rule: IDenormalizedRuleNode): void => {
+  if (!isFieldComparisonRule(rule)) {
+    return;
+  }
+
+  if (isSqlRuleFormattable(rule)) {
+    return;
+  }
+
+  throw new Error(
+    `SQL does not support field-to-field comparisons for field "${rule.field}" and operator "${rule.operator}".`
+  );
+};
+
 const formatRule = (
   rule: IDenormalizedRuleNode,
   fields?: IBuilderFieldProps[]
 ): string => {
+  ensureSqlSupportsRule(rule);
+
   if (!isSqlRuleFormattable(rule)) {
     return '';
   }
@@ -104,35 +135,17 @@ const formatRule = (
 
   switch (rule.operator) {
     case 'LARGER':
-      return `${field} > ${formatValueWithField(
-        rule.value as number | string | boolean,
-        fieldConfig
-      )}`;
+      return `${field} > ${formatRuleValue(rule, fieldConfig)}`;
     case 'SMALLER':
-      return `${field} < ${formatValueWithField(
-        rule.value as number | string | boolean,
-        fieldConfig
-      )}`;
+      return `${field} < ${formatRuleValue(rule, fieldConfig)}`;
     case 'LARGER_EQUAL':
-      return `${field} >= ${formatValueWithField(
-        rule.value as number | string | boolean,
-        fieldConfig
-      )}`;
+      return `${field} >= ${formatRuleValue(rule, fieldConfig)}`;
     case 'SMALLER_EQUAL':
-      return `${field} <= ${formatValueWithField(
-        rule.value as number | string | boolean,
-        fieldConfig
-      )}`;
+      return `${field} <= ${formatRuleValue(rule, fieldConfig)}`;
     case 'EQUAL':
-      return `${field} = ${formatValueWithField(
-        rule.value as number | string | boolean,
-        fieldConfig
-      )}`;
+      return `${field} = ${formatRuleValue(rule, fieldConfig)}`;
     case 'NOT_EQUAL':
-      return `${field} <> ${formatValueWithField(
-        rule.value as number | string | boolean,
-        fieldConfig
-      )}`;
+      return `${field} <> ${formatRuleValue(rule, fieldConfig)}`;
     case 'ALL_IN':
     case 'ANY_IN':
     case 'IN':
@@ -182,15 +195,9 @@ const formatRule = (
     case 'IS_NOT_NULL':
       return `${field} IS NOT NULL`;
     case 'LIKE':
-      return `${field} LIKE ${formatValueWithField(
-        rule.value as number | string | boolean,
-        fieldConfig
-      )}`;
+      return `${field} LIKE ${formatRuleValue(rule, fieldConfig)}`;
     case 'NOT_LIKE':
-      return `${field} NOT LIKE ${formatValueWithField(
-        rule.value as number | string | boolean,
-        fieldConfig
-      )}`;
+      return `${field} NOT LIKE ${formatRuleValue(rule, fieldConfig)}`;
     case 'CONTAINS':
       return `${field} LIKE ${formatValueWithField(
         formatLikePattern(rule, '%', '%'),
@@ -303,3 +310,5 @@ export const formatSql = (
 
   return normalizedOptions.wrapWhereClause ? `WHERE ${sql}` : sql;
 };
+
+

--- a/src/query-formats/sql/infer-sql-fields.ts
+++ b/src/query-formats/sql/infer-sql-fields.ts
@@ -4,6 +4,7 @@ import type {
   IDenormalizedRuleNode,
   QueryOperator,
 } from '../../utils/query-tree';
+import { isFieldComparisonRule } from '../../utils/rule-value-source';
 import { isDateString } from './shared';
 import { sqlOperatorOrder } from './sql-token.types';
 
@@ -87,22 +88,35 @@ export const inferSqlFields = (data: DenormalizedQuery): IBuilderFieldProps[] =>
     { type: IBuilderFieldProps['type']; operators: QueryOperator[] }
   >();
 
-  collectSqlRules(data).forEach(rule => {
-    const currentField = fieldMap.get(rule.field);
-    const nextType = inferSqlFieldType(rule);
+  const mergeFieldConfig = (
+    fieldName: string,
+    type: IBuilderFieldProps['type'],
+    operator?: QueryOperator
+  ) => {
+    const currentField = fieldMap.get(fieldName);
 
     if (!currentField) {
-      fieldMap.set(rule.field, {
-        type: nextType,
-        operators: rule.operator ? [rule.operator] : [],
+      fieldMap.set(fieldName, {
+        type,
+        operators: operator ? [operator] : [],
       });
       return;
     }
 
-    currentField.type = mergeSqlFieldType(currentField.type, nextType);
+    currentField.type = mergeSqlFieldType(currentField.type, type);
 
-    if (rule.operator && !currentField.operators.includes(rule.operator)) {
-      currentField.operators.push(rule.operator);
+    if (operator && !currentField.operators.includes(operator)) {
+      currentField.operators.push(operator);
+    }
+  };
+
+  collectSqlRules(data).forEach(rule => {
+    const nextType = inferSqlFieldType(rule);
+
+    mergeFieldConfig(rule.field, nextType, rule.operator);
+
+    if (isFieldComparisonRule(rule)) {
+      mergeFieldConfig(rule.valueField, nextType, rule.operator);
     }
   });
 

--- a/src/query-formats/sql/sql-parser.ts
+++ b/src/query-formats/sql/sql-parser.ts
@@ -10,6 +10,14 @@ import { getMissingSqlTokenMessage } from './utils/get-missing-sql-token-message
 import { createSqlParseError } from './utils/create-sql-parse-error';
 import { getSqlParserString } from './utils/get-sql-parser-string';
 
+interface IParsedSqlFieldReferenceValue {
+  valueField: string;
+  range: {
+    start: number;
+    end: number;
+  };
+}
+
 export class SqlParser {
   private readonly tokens: IToken[];
   private readonly textModeStrings?: IStrings['textMode'];
@@ -173,7 +181,12 @@ export class SqlParser {
 
       if (this.isKeyword('LIKE')) {
         const likeToken = this.expectKeyword('LIKE');
-        return this.createLikeRule(fieldToken, true, likeToken, this.parseScalarValue());
+        return this.createLikeRule(
+          fieldToken,
+          true,
+          likeToken,
+          this.parseScalarOrFieldReferenceValue()
+        );
       }
 
       if (this.isKeyword('BETWEEN')) {
@@ -231,7 +244,12 @@ export class SqlParser {
 
     if (this.isKeyword('LIKE')) {
       const likeToken = this.expectKeyword('LIKE');
-      return this.createLikeRule(fieldToken, false, likeToken, this.parseScalarValue());
+      return this.createLikeRule(
+        fieldToken,
+        false,
+        likeToken,
+        this.parseScalarOrFieldReferenceValue()
+      );
     }
 
     if (this.isKeyword('BETWEEN')) {
@@ -255,7 +273,23 @@ export class SqlParser {
     }
 
     const operatorToken = this.expect('OPERATOR');
-    const value = this.parseScalarValue();
+    const value = this.parseScalarOrFieldReferenceValue();
+
+    if ('valueField' in value) {
+      return {
+        field,
+        operator: this.mapOperator(operatorToken.value),
+        valueSource: 'field',
+        valueField: value.valueField,
+        source: {
+          field: this.toTokenRange(fieldToken),
+          operator: this.toTokenRange(operatorToken),
+          value: value.range,
+          valueField: value.range,
+          values: [value.range],
+        },
+      };
+    }
 
     return {
       field,
@@ -274,9 +308,25 @@ export class SqlParser {
     fieldToken: IToken,
     negated: boolean,
     operatorToken: IToken,
-    value: IParsedSqlScalarValue
+    value: IParsedSqlScalarValue | IParsedSqlFieldReferenceValue
   ): IParsedSqlRuleNode {
     const field = fieldToken.value;
+
+    if ('valueField' in value) {
+      return {
+        field,
+        operator: negated ? 'NOT_LIKE' : 'LIKE',
+        valueSource: 'field',
+        valueField: value.valueField,
+        source: {
+          field: this.toTokenRange(fieldToken),
+          operator: this.toTokenRange(operatorToken),
+          value: value.range,
+          valueField: value.range,
+          values: [value.range],
+        },
+      };
+    }
 
     if (typeof value.value !== 'string') {
       return {
@@ -484,6 +534,20 @@ export class SqlParser {
       token.start,
       token.end
     );
+  }
+
+  private parseScalarOrFieldReferenceValue():
+    | IParsedSqlScalarValue
+    | IParsedSqlFieldReferenceValue {
+    if (this.peek().type === 'IDENTIFIER') {
+      const valueFieldToken = this.parseIdentifier();
+      return {
+        valueField: valueFieldToken.value,
+        range: this.toTokenRange(valueFieldToken),
+      };
+    }
+
+    return this.parseScalarValue();
   }
 
   private parseIdentifier(): IToken {

--- a/src/query-formats/sql/sql-roundtrip.test.ts
+++ b/src/query-formats/sql/sql-roundtrip.test.ts
@@ -45,5 +45,34 @@ describe('SQL roundtrip', () => {
 
     expect(parsed.data).toEqual(query);
   });
+
+  it('round-trips supported field-to-field comparisons', () => {
+    const query: DenormalizedQuery = [
+      {
+        type: 'GROUP',
+        value: 'AND',
+        isNegated: false,
+        children: [
+          {
+            field: 'price',
+            operator: 'LARGER_EQUAL',
+            valueSource: 'field',
+            valueField: 'cost',
+          },
+          {
+            field: 'name',
+            operator: 'LIKE',
+            valueSource: 'field',
+            valueField: 'name_pattern',
+          },
+        ],
+      },
+    ];
+
+    const sql = formatQuery(query, 'SQL');
+    const parsed = parseQuery(sql, 'SQL');
+
+    expect(parsed.data).toEqual(query);
+  });
 });
 

--- a/src/query-formats/sql/types/parsed-sql-rule-node.ts
+++ b/src/query-formats/sql/types/parsed-sql-rule-node.ts
@@ -1,6 +1,6 @@
 import { IDenormalizedRuleNode } from '../../../utils/query-tree';
 import { IParsedSqlRuleSource } from './parsed-sql-rule-source';
 
-export interface IParsedSqlRuleNode extends IDenormalizedRuleNode {
+export type IParsedSqlRuleNode = IDenormalizedRuleNode & {
   source: IParsedSqlRuleSource;
-}
+};

--- a/src/query-formats/sql/types/parsed-sql-rule-source.ts
+++ b/src/query-formats/sql/types/parsed-sql-rule-source.ts
@@ -4,5 +4,6 @@ export interface IParsedSqlRuleSource {
   field: ISqlSourceRange;
   operator?: ISqlSourceRange;
   value?: ISqlSourceRange;
+  valueField?: ISqlSourceRange;
   values?: ISqlSourceRange[];
 }

--- a/src/query-formats/sql/utils/is-sql-rule-formattable.ts
+++ b/src/query-formats/sql/utils/is-sql-rule-formattable.ts
@@ -1,8 +1,19 @@
 import type { IDenormalizedRuleNode } from '../../../utils/query-tree';
+import { isFieldComparisonRule } from '../../../utils/rule-value-source';
 
 const operatorsWithoutValue = new Set(['IS_NULL', 'IS_NOT_NULL']);
 const operatorsWithArrayValue = new Set(['ALL_IN', 'ANY_IN', 'IN', 'NOT_IN']);
 const operatorsWithRangeValue = new Set(['BETWEEN', 'NOT_BETWEEN']);
+const operatorsWithSqlFieldReferenceValue = new Set([
+  'EQUAL',
+  'NOT_EQUAL',
+  'LARGER',
+  'LARGER_EQUAL',
+  'SMALLER',
+  'SMALLER_EQUAL',
+  'LIKE',
+  'NOT_LIKE',
+]);
 
 export const isSqlRuleFormattable = (rule: IDenormalizedRuleNode): boolean => {
   if (!rule.field || !rule.operator) {
@@ -11,6 +22,12 @@ export const isSqlRuleFormattable = (rule: IDenormalizedRuleNode): boolean => {
 
   if (operatorsWithoutValue.has(rule.operator)) {
     return true;
+  }
+
+  if (isFieldComparisonRule(rule)) {
+    return Boolean(
+      rule.valueField && operatorsWithSqlFieldReferenceValue.has(rule.operator)
+    );
   }
 
   if (typeof rule.value === 'undefined') {

--- a/src/rule/rule.test.tsx
+++ b/src/rule/rule.test.tsx
@@ -47,12 +47,20 @@ const fields: IBuilderFieldProps[] = [
     label: 'Mock Field 6',
     operators: ['EQUAL'],
     type: 'LIST',
+    value: [{ label: 'Text value', value: 'text-value' }],
+    fieldComparison: { type: 'string' },
   },
   {
     field: 'MOCK_FIELD_7',
     label: 'Mock Field 7',
     operators: ['EQUAL'],
     type: 'MULTI_LIST',
+  },
+  {
+    field: 'MOCK_FIELD_8',
+    label: 'Mock Field 8',
+    operators: ['EQUAL'],
+    type: 'TEXT',
   },
 ];
 const data: any[] = [
@@ -264,5 +272,42 @@ describe('#components/Rule', () => {
     expect(
       container.querySelector('[data-test="Switch"]')
     ).toHaveAttribute('aria-disabled', 'true');
+  });
+
+  it('renders value-source and value-field selectors for field comparisons', () => {
+    const { container } = renderWithContext(
+      <>
+        <Rule
+          id="test-3"
+          field="MOCK_FIELD_2"
+          operator="EQUAL"
+          valueSource="field"
+          valueField="MOCK_FIELD_8"
+        />
+        <Rule
+          id="test-7"
+          field="MOCK_FIELD_6"
+          operator="EQUAL"
+          valueSource="field"
+          valueField="MOCK_FIELD_8"
+        />
+      </>,
+      {
+        allowFieldComparisons: true,
+      }
+    );
+
+    expect(
+      container.querySelector('#query-builder-rule-test-3-value-source-trigger')
+    ).toBeTruthy();
+    expect(
+      container.querySelector('#query-builder-rule-test-3-value-field-trigger')
+    ).toBeTruthy();
+    expect(
+      container.querySelector('#query-builder-rule-test-7-value-source-trigger')
+    ).toBeTruthy();
+    expect(
+      container.querySelector('#query-builder-rule-test-7-value-field-trigger')
+    ).toBeTruthy();
   });
 });

--- a/src/rule/rule.tsx
+++ b/src/rule/rule.tsx
@@ -18,7 +18,10 @@ import { Input } from '../widgets/input';
 import { OperatorSelect } from '../widgets/operator-select';
 import { Select } from '../widgets/select';
 import { SelectMulti } from '../widgets/select-multi/select-multi';
+import { ValueFieldSelect } from '../widgets/value-field-select';
+import { ValueSourceSelect } from '../widgets/value-source-select';
 import { isBoolean } from '../utils/is-boolean.util';
+import { getCompatibleValueFields, supportsFieldComparisonForOperator } from '../utils/field-comparison-support';
 import { isNumber } from '../utils/is-number.util';
 import { isNumberArray } from '../utils/is-number-array.util';
 import { isOptionList } from '../utils/is-option-list.util';
@@ -27,11 +30,12 @@ import { isStringArray } from '../utils/is-string-array.util';
 import { isStringOrNumberArray } from '../utils/is-string-or-number-array.util';
 import { operatorRequiresValue } from '../utils/operator-requires-value.util';
 import { isNormalizedGroupNode } from '../utils/is-normalized-group-node.util';
-import { QueryRuleValue, RuleReadOnlyTarget } from '../utils/query-tree';
+import { QueryRuleValue, QueryRuleValueSource, RuleReadOnlyTarget } from '../utils/query-tree';
 import { getCloneButtonTitle } from '../utils/get-clone-button-title.util';
 import { getLockToggleTitle } from '../utils/get-lock-toggle-title.util';
 import { isNodeDeletionProtected } from '../utils/is-node-deletion-protected.util';
 import { updateRuleLockState } from '../utils/read-only/update-rule-lock-state.util';
+import { getRuleValueSource } from '../utils/rule-value-source';
 import { useBuilderFieldOptionState } from '../builder/hooks/use-builder-field-option-state';
 
 const BooleanContainer = styled.div`
@@ -66,6 +70,16 @@ const ValueContent = styled(LayoutItem)`
   `}
 `;
 
+const ValueEditorGrid = styled.div`
+  display: grid;
+  gap: 0.5rem;
+  grid-template-columns: minmax(0, 0.8fr) minmax(0, 1.6fr);
+
+  ${compactBuilderMedia`
+    grid-template-columns: 1fr;
+  `}
+`;
+
 const ValidationIssues = styled.ul`
   margin: 0.4rem 0 0;
   padding-left: 1rem;
@@ -76,6 +90,8 @@ const ValidationIssues = styled.ul`
 export interface IRuleProps {
   field: string;
   value?: QueryRuleValue;
+  valueSource?: QueryRuleValueSource;
+  valueField?: string;
   operator?: BuilderFieldOperator;
   id: string;
   readOnly?: boolean;
@@ -89,6 +105,8 @@ export interface IRuleProps {
 export const Rule: FC<IRuleProps> = ({
   field: fieldRef,
   value: selectedValue,
+  valueSource,
+  valueField,
   operator,
   id,
   readOnly: localReadOnly = false,
@@ -105,6 +123,7 @@ export const Rule: FC<IRuleProps> = ({
     components,
     strings,
     readOnly,
+    allowFieldComparisons = false,
     readOnlyProtectsDelete = true,
     cloneable,
     lockable,
@@ -264,6 +283,142 @@ export const Rule: FC<IRuleProps> = ({
       label: (strings.operators && strings.operators[item]) || item,
     }));
   const shouldRenderValueInput = operatorRequiresValue(operator);
+  const resolvedValueSource = getRuleValueSource({ valueSource });
+  const compatibleValueFields = getCompatibleValueFields(fields, fieldConfig, operator);
+  const supportsFieldComparison =
+    (allowFieldComparisons && supportsFieldComparisonForOperator(fieldConfig, operator)) ||
+    resolvedValueSource === 'field';
+  const usesFieldComparison = resolvedValueSource === 'field';
+
+  const renderValueEditor = () => {
+    if (!shouldRenderValueInput) {
+      return null;
+    }
+
+    if (type === 'BOOLEAN') {
+      if (usesFieldComparison) {
+        return compatibleValueFields.length > 0 ? (
+          <ValueFieldSelect
+            id={id}
+            selectedValue={valueField}
+            compatibleFields={compatibleValueFields}
+            disabled={isValueReadOnly}
+          />
+        ) : null;
+      }
+
+      return isBoolean(selectedValue) ? (
+        <BooleanContainer>
+          <Boolean
+            id={id}
+            selectedValue={selectedValue}
+            disabled={isValueReadOnly}
+          />
+        </BooleanContainer>
+      ) : null;
+    }
+
+    if (type === 'TEXT') {
+      if (usesFieldComparison) {
+        return compatibleValueFields.length > 0 ? (
+          <ValueFieldSelect
+            id={id}
+            selectedValue={valueField}
+            compatibleFields={compatibleValueFields}
+            disabled={isValueReadOnly}
+          />
+        ) : null;
+      }
+
+      return isString(selectedValue) ? (
+        <Input
+          id={id}
+          type="text"
+          value={selectedValue}
+          disabled={isValueReadOnly}
+        />
+      ) : null;
+    }
+
+    if (type === 'DATE') {
+      if (usesFieldComparison) {
+        return compatibleValueFields.length > 0 ? (
+          <ValueFieldSelect
+            id={id}
+            selectedValue={valueField}
+            compatibleFields={compatibleValueFields}
+            disabled={isValueReadOnly}
+          />
+        ) : null;
+      }
+
+      return isString(selectedValue) || isStringOrNumberArray(selectedValue) ? (
+        <Input
+          id={id}
+          type="date"
+          value={selectedValue}
+          disabled={isValueReadOnly}
+        />
+      ) : null;
+    }
+
+    if (type === 'NUMBER') {
+      if (usesFieldComparison) {
+        return compatibleValueFields.length > 0 ? (
+          <ValueFieldSelect
+            id={id}
+            selectedValue={valueField}
+            compatibleFields={compatibleValueFields}
+            disabled={isValueReadOnly}
+          />
+        ) : null;
+      }
+
+      return isNumber(selectedValue) || isNumberArray(selectedValue) ? (
+        <Input
+          id={id}
+          type="number"
+          value={selectedValue}
+          disabled={isValueReadOnly}
+        />
+      ) : null;
+    }
+
+    if (type === 'LIST' && isOptionList(fieldValue)) {
+      if (usesFieldComparison) {
+        return compatibleValueFields.length > 0 ? (
+          <ValueFieldSelect
+            id={id}
+            selectedValue={valueField}
+            compatibleFields={compatibleValueFields}
+            disabled={isValueReadOnly}
+          />
+        ) : null;
+      }
+
+      return (
+        <Select
+          id={id}
+          selectedValue={isString(selectedValue) ? selectedValue : ''}
+          values={fieldValue}
+          disabled={isValueReadOnly}
+        />
+      );
+    }
+
+    if (type === 'MULTI_LIST' && isOptionList(fieldValue)) {
+      return (
+        <SelectMulti
+          id={id}
+          values={fieldValue}
+          selectedValue={isStringArray(selectedValue) ? selectedValue : []}
+          disabled={isValueReadOnly}
+        />
+      );
+    }
+
+    return null;
+  };
 
   return (
     <RuleContainer
@@ -293,148 +448,185 @@ export const Rule: FC<IRuleProps> = ({
                   />
                 </LayoutItem>
               )}
-              {shouldRenderValueInput && isBoolean(selectedValue) && (
+              {shouldRenderValueInput && (
                 <ValueContent>
-                  <BooleanContainer>
-                    <Boolean
-                      id={id}
-                      selectedValue={selectedValue}
-                      disabled={isValueReadOnly}
-                    />
-                  </BooleanContainer>
+                  {supportsFieldComparison ? (
+                    <ValueEditorGrid>
+                      <ValueSourceSelect
+                        id={id}
+                        field={fieldConfig}
+                        selectedValueSource={resolvedValueSource}
+                        compatibleFields={compatibleValueFields}
+                        fieldComparisonEnabled={allowFieldComparisons}
+                        disabled={isValueReadOnly}
+                      />
+                      {renderValueEditor()}
+                    </ValueEditorGrid>
+                  ) : (
+                    renderValueEditor()
+                  )}
                 </ValueContent>
               )}
             </>
           )}
 
-            {type === 'LIST' &&
-              isOptionList(fieldValue) &&
-              isOptionList(operatorsOptionList) && (
-                <>
-                  <LayoutItem>
-                    <OperatorSelect
-                      id={id}
-                      values={operatorsOptionList}
-                      selectedValue={operator}
-                      disabled={isOperatorReadOnly}
-                    />
-                  </LayoutItem>
-                  {operator && shouldRenderValueInput && (
-                      <ValueContent>
-                        <Select
+          {type === 'LIST' &&
+            isOptionList(fieldValue) &&
+            isOptionList(operatorsOptionList) &&
+            operator && (
+              <>
+                <LayoutItem>
+                  <OperatorSelect
+                    id={id}
+                    values={operatorsOptionList}
+                    selectedValue={operator}
+                    disabled={isOperatorReadOnly}
+                  />
+                </LayoutItem>
+                {shouldRenderValueInput && (
+                  <ValueContent>
+                    {supportsFieldComparison ? (
+                      <ValueEditorGrid>
+                        <ValueSourceSelect
                           id={id}
-                          selectedValue={isString(selectedValue) ? selectedValue : ''}
-                          values={fieldValue}
+                          field={fieldConfig}
+                          selectedValueSource={resolvedValueSource}
+                          compatibleFields={compatibleValueFields}
+                          fieldComparisonEnabled={allowFieldComparisons}
                           disabled={isValueReadOnly}
                         />
-                      </ValueContent>
+                        {renderValueEditor()}
+                      </ValueEditorGrid>
+                    ) : (
+                      renderValueEditor()
                     )}
-                </>
-              )}
+                  </ValueContent>
+                )}
+              </>
+            )}
 
-            {type === 'MULTI_LIST' &&
-              isOptionList(fieldValue) &&
-              isOptionList(operatorsOptionList) && (
-                <>
-                  <LayoutItem>
-                    <OperatorSelect
-                      id={id}
-                      values={operatorsOptionList}
-                      selectedValue={operator}
-                      disabled={isOperatorReadOnly}
-                    />
-                  </LayoutItem>
-                  {operator && shouldRenderValueInput && (
-                      <ValueContent>
-                        <SelectMulti
+          {type === 'MULTI_LIST' &&
+            isOptionList(fieldValue) &&
+            isOptionList(operatorsOptionList) && (
+              <>
+                <LayoutItem>
+                  <OperatorSelect
+                    id={id}
+                    values={operatorsOptionList}
+                    selectedValue={operator}
+                    disabled={isOperatorReadOnly}
+                  />
+                </LayoutItem>
+                {operator && shouldRenderValueInput && (
+                  <ValueContent>
+                    {renderValueEditor()}
+                  </ValueContent>
+                )}
+              </>
+            )}
+
+          {type === 'TEXT' &&
+            isOptionList(operatorsOptionList) &&
+            operator && (
+              <>
+                <LayoutItem>
+                  <OperatorSelect
+                    id={id}
+                    values={operatorsOptionList}
+                    selectedValue={operator}
+                    disabled={isOperatorReadOnly}
+                  />
+                </LayoutItem>
+                {shouldRenderValueInput && (
+                  <ValueContent>
+                    {supportsFieldComparison ? (
+                      <ValueEditorGrid>
+                        <ValueSourceSelect
                           id={id}
-                          values={fieldValue}
-                          selectedValue={isStringArray(selectedValue) ? selectedValue : []}
+                          field={fieldConfig}
+                          selectedValueSource={resolvedValueSource}
+                          compatibleFields={compatibleValueFields}
+                          fieldComparisonEnabled={allowFieldComparisons}
                           disabled={isValueReadOnly}
                         />
-                      </ValueContent>
+                        {renderValueEditor()}
+                      </ValueEditorGrid>
+                    ) : (
+                      renderValueEditor()
                     )}
-                </>
-              )}
+                  </ValueContent>
+                )}
+              </>
+            )}
 
-            {type === 'TEXT' &&
-              isOptionList(operatorsOptionList) &&
-              operator &&
-              isString(selectedValue) && (
-                <>
-                  <LayoutItem>
-                    <OperatorSelect
-                      id={id}
-                      values={operatorsOptionList}
-                      selectedValue={operator}
-                      disabled={isOperatorReadOnly}
-                    />
-                  </LayoutItem>
-                  {shouldRenderValueInput && (
-                    <ValueContent>
-                      <Input
-                        id={id}
-                        type="text"
-                        value={selectedValue}
-                        disabled={isValueReadOnly}
-                      />
-                    </ValueContent>
-                  )}
-                </>
-              )}
+          {type === 'DATE' &&
+            isOptionList(operatorsOptionList) &&
+            operator && (
+              <>
+                <LayoutItem>
+                  <OperatorSelect
+                    id={id}
+                    values={operatorsOptionList}
+                    selectedValue={operator}
+                    disabled={isOperatorReadOnly}
+                  />
+                </LayoutItem>
+                {shouldRenderValueInput && (
+                  <ValueContent>
+                    {supportsFieldComparison ? (
+                      <ValueEditorGrid>
+                        <ValueSourceSelect
+                          id={id}
+                          field={fieldConfig}
+                          selectedValueSource={resolvedValueSource}
+                          compatibleFields={compatibleValueFields}
+                          fieldComparisonEnabled={allowFieldComparisons}
+                          disabled={isValueReadOnly}
+                        />
+                        {renderValueEditor()}
+                      </ValueEditorGrid>
+                    ) : (
+                      renderValueEditor()
+                    )}
+                  </ValueContent>
+                )}
+              </>
+            )}
 
-            {type === 'DATE' &&
-              isOptionList(operatorsOptionList) &&
-              operator &&
-              (isString(selectedValue) || isStringOrNumberArray(selectedValue)) && (
-                <>
-                  <LayoutItem>
-                    <OperatorSelect
-                      id={id}
-                      values={operatorsOptionList}
-                      selectedValue={operator}
-                      disabled={isOperatorReadOnly}
-                    />
-                  </LayoutItem>
-                  {shouldRenderValueInput && (
-                    <ValueContent>
-                      <Input
-                        id={id}
-                        type="date"
-                        value={selectedValue}
-                        disabled={isValueReadOnly}
-                      />
-                    </ValueContent>
-                  )}
-                </>
-              )}
-
-            {type === 'NUMBER' &&
-              isOptionList(operatorsOptionList) &&
-              operator &&
-              (isNumber(selectedValue) || isNumberArray(selectedValue)) && (
-                <>
-                  <LayoutItem>
-                    <OperatorSelect
-                      id={id}
-                      values={operatorsOptionList}
-                      selectedValue={operator}
-                      disabled={isOperatorReadOnly}
-                    />
-                  </LayoutItem>
-                  {shouldRenderValueInput && (
-                    <ValueContent>
-                      <Input
-                        id={id}
-                        type="number"
-                        value={selectedValue}
-                        disabled={isValueReadOnly}
-                      />
-                    </ValueContent>
-                  )}
-                </>
-              )}
-          </FieldsContent>
+          {type === 'NUMBER' &&
+            isOptionList(operatorsOptionList) &&
+            operator && (
+              <>
+                <LayoutItem>
+                  <OperatorSelect
+                    id={id}
+                    values={operatorsOptionList}
+                    selectedValue={operator}
+                    disabled={isOperatorReadOnly}
+                  />
+                </LayoutItem>
+                {shouldRenderValueInput && (
+                  <ValueContent>
+                    {supportsFieldComparison ? (
+                      <ValueEditorGrid>
+                        <ValueSourceSelect
+                          id={id}
+                          field={fieldConfig}
+                          selectedValueSource={resolvedValueSource}
+                          compatibleFields={compatibleValueFields}
+                          fieldComparisonEnabled={allowFieldComparisons}
+                          disabled={isValueReadOnly}
+                        />
+                        {renderValueEditor()}
+                      </ValueEditorGrid>
+                    ) : (
+                      renderValueEditor()
+                    )}
+                  </ValueContent>
+                )}
+              </>
+            )}
+        </FieldsContent>
         {validationIssues.length > 0 && (
           <ValidationIssues>
             {validationIssues.map((issue) => (
@@ -448,3 +640,4 @@ export const Rule: FC<IRuleProps> = ({
     </RuleContainer>
   );
 };
+

--- a/src/utils/create-rule-state-for-field.util.test.ts
+++ b/src/utils/create-rule-state-for-field.util.test.ts
@@ -11,6 +11,7 @@ describe('#utils/createRuleStateForField', () => {
 
     expect(createRuleStateForField(field)).toEqual({
       field: 'IS_ACTIVE',
+      valueSource: 'value',
       value: false,
     });
   });
@@ -27,6 +28,7 @@ describe('#utils/createRuleStateForField', () => {
       field: 'NAME',
       operator: 'BETWEEN',
       operators: ['BETWEEN'],
+      valueSource: 'value',
       value: ['', ''],
     });
   });
@@ -47,6 +49,7 @@ describe('#utils/createRuleStateForField', () => {
       field: 'STATUS',
       operator: 'EQUAL',
       operators: ['EQUAL'],
+      valueSource: 'value',
       value: 'draft',
     });
   });
@@ -64,6 +67,7 @@ describe('#utils/createRuleStateForField', () => {
       field: 'CITY',
       operator: 'EQUAL',
       operators: ['EQUAL'],
+      valueSource: 'value',
     });
   });
 
@@ -79,6 +83,7 @@ describe('#utils/createRuleStateForField', () => {
       field: 'PRICE',
       operator: 'EQUAL',
       operators: ['EQUAL'],
+      valueSource: 'value',
       value: 0,
     });
   });
@@ -95,6 +100,7 @@ describe('#utils/createRuleStateForField', () => {
       field: 'PRICE_RANGE',
       operator: 'BETWEEN',
       operators: ['BETWEEN'],
+      valueSource: 'value',
       value: [0, 0],
     });
   });
@@ -111,6 +117,7 @@ describe('#utils/createRuleStateForField', () => {
       field: 'DELETED_AT',
       operator: 'IS_NULL',
       operators: ['IS_NULL'],
+      valueSource: 'value',
     });
   });
 
@@ -124,6 +131,7 @@ describe('#utils/createRuleStateForField', () => {
 
     expect(createRuleStateForField(field)).toEqual({
       field: 'NOTE',
+      valueSource: 'value',
       value: 'Read only text',
     });
   });

--- a/src/utils/create-rule-state-for-field.util.ts
+++ b/src/utils/create-rule-state-for-field.util.ts
@@ -7,6 +7,7 @@ export const createRuleStateForField = (field: IBuilderFieldProps) => {
     field: field.field,
     operator: nextOperator,
     operators: field.operators,
+    valueSource: 'value' as const,
   };
   const nextValue = createRuleValueForFieldOperator(field, nextOperator);
 
@@ -30,12 +31,14 @@ export const createRuleStateForField = (field: IBuilderFieldProps) => {
     case 'STATEMENT':
       return {
         field: field.field,
+        valueSource: 'value' as const,
         value: field.value,
       };
 
     default:
       return {
         field: field.field,
+        valueSource: 'value' as const,
       };
   }
 };

--- a/src/utils/emit-builder-field-change.util.ts
+++ b/src/utils/emit-builder-field-change.util.ts
@@ -1,6 +1,10 @@
 import { IBuilderFieldChange } from '../builder/types';
 import { emitQuery } from './emit-query.util';
-import { NormalizedQuery, QueryRuleValue } from './query-tree';
+import {
+  NormalizedQuery,
+  QueryRuleValue,
+  QueryRuleValueSource,
+} from './query-tree';
 
 export const emitBuilderFieldChange = (
   onFieldChange: ((change: IBuilderFieldChange) => void) | undefined,
@@ -8,7 +12,13 @@ export const emitBuilderFieldChange = (
   nodeId: string,
   field: string,
   previousValue: QueryRuleValue | undefined,
-  value: QueryRuleValue | undefined
+  value: QueryRuleValue | undefined,
+  options: {
+    previousValueSource?: QueryRuleValueSource;
+    previousValueField?: string;
+    valueSource?: QueryRuleValueSource;
+    valueField?: string;
+  } = {}
 ) => {
   if (!onFieldChange) {
     return;
@@ -17,8 +27,12 @@ export const emitBuilderFieldChange = (
   onFieldChange({
     nodeId,
     field,
+    previousValueSource: options.previousValueSource,
     previousValue,
+    previousValueField: options.previousValueField,
+    valueSource: options.valueSource,
     value,
+    valueField: options.valueField,
     data: emitQuery(data),
   });
 };

--- a/src/utils/field-comparison-support.test.ts
+++ b/src/utils/field-comparison-support.test.ts
@@ -1,0 +1,127 @@
+import {
+  BuilderFieldComparisonType,
+  IBuilderFieldComparisonConfig,
+  IBuilderFieldProps,
+} from '../builder';
+import {
+  areFieldsCompatibleForComparison,
+  getCompatibleValueFields,
+  resolveFieldComparisonType,
+  supportsFieldComparisonForOperator,
+} from './field-comparison-support';
+
+describe('field comparison support', () => {
+  const explicitConfig: IBuilderFieldComparisonConfig = {
+    type: 'string',
+    comparableFields: ['TEXT_B', 'LIST_STRING'],
+  };
+  const explicitType: BuilderFieldComparisonType = 'string';
+  void explicitType;
+
+  const fields: IBuilderFieldProps[] = [
+    {
+      field: 'TEXT_A',
+      label: 'Text A',
+      type: 'TEXT',
+      fieldComparison: explicitConfig,
+    },
+    { field: 'TEXT_B', label: 'Text B', type: 'TEXT' },
+    { field: 'NUMBER_A', label: 'Number A', type: 'NUMBER' },
+    {
+      field: 'LIST_STRING',
+      label: 'List String',
+      type: 'LIST',
+      value: [
+        { value: 'a', label: 'A' },
+        { value: 'b', label: 'B' },
+      ],
+    },
+    {
+      field: 'LIST_NUMBER',
+      label: 'List Number',
+      type: 'LIST',
+      value: [
+        { value: 1, label: 'One' },
+        { value: 2, label: 'Two' },
+      ],
+    },
+    {
+      field: 'LIST_MIXED',
+      label: 'List Mixed',
+      type: 'LIST',
+      value: [
+        { value: 'a', label: 'A' },
+        { value: 1, label: 'One' },
+      ],
+    },
+    {
+      field: 'LIST_EXPLICIT_NUMBER',
+      label: 'List Explicit Number',
+      type: 'LIST',
+      value: [{ value: '1', label: 'One' }],
+      fieldComparison: {
+        type: 'number',
+      },
+    },
+    { field: 'MULTI_A', label: 'Multi A', type: 'MULTI_LIST' },
+  ];
+
+  it('resolves implicit and explicit field comparison types', () => {
+    expect(resolveFieldComparisonType(fields[0])).toBe('string');
+    expect(resolveFieldComparisonType(fields[2])).toBe('number');
+    expect(resolveFieldComparisonType(fields[3])).toBe('string');
+    expect(resolveFieldComparisonType(fields[4])).toBe('number');
+    expect(resolveFieldComparisonType(fields[5])).toBeUndefined();
+    expect(resolveFieldComparisonType(fields[6])).toBe('number');
+    expect(resolveFieldComparisonType(fields[7])).toBeUndefined();
+  });
+
+  it('supports scalar and configured single-value field comparisons', () => {
+    expect(supportsFieldComparisonForOperator(fields[0], 'EQUAL')).toBe(true);
+    expect(supportsFieldComparisonForOperator(fields[2], 'LARGER')).toBe(true);
+    expect(supportsFieldComparisonForOperator(fields[3], 'EQUAL')).toBe(true);
+    expect(supportsFieldComparisonForOperator(fields[6], 'LARGER_EQUAL')).toBe(true);
+  });
+
+  it('rejects unsupported operators and fields without semantic comparison types', () => {
+    expect(supportsFieldComparisonForOperator(fields[0], 'BETWEEN')).toBe(false);
+    expect(supportsFieldComparisonForOperator(fields[0], 'IN')).toBe(false);
+    expect(supportsFieldComparisonForOperator(fields[0], 'IS_NULL')).toBe(false);
+    expect(supportsFieldComparisonForOperator(fields[5], 'EQUAL')).toBe(false);
+    expect(supportsFieldComparisonForOperator(fields[7], 'EQUAL')).toBe(false);
+  });
+
+  it('matches fields by semantic comparison type instead of raw builder type', () => {
+    expect(areFieldsCompatibleForComparison(fields[0], fields[1])).toBe(true);
+    expect(areFieldsCompatibleForComparison(fields[0], fields[3])).toBe(true);
+    expect(areFieldsCompatibleForComparison(fields[0], fields[2])).toBe(false);
+    expect(areFieldsCompatibleForComparison(fields[3], fields[1])).toBe(true);
+    expect(areFieldsCompatibleForComparison(fields[4], fields[2])).toBe(true);
+  });
+
+  it('applies the source-owned comparableFields allowlist', () => {
+    expect(areFieldsCompatibleForComparison(fields[0], fields[1])).toBe(true);
+    expect(areFieldsCompatibleForComparison(fields[0], fields[3])).toBe(true);
+    expect(areFieldsCompatibleForComparison(fields[0], fields[4])).toBe(false);
+  });
+
+  it('returns only semantically compatible candidate fields other than the source field', () => {
+    expect(getCompatibleValueFields(fields, fields[0], 'EQUAL')).toEqual([
+      fields[1],
+      fields[3],
+    ]);
+    expect(getCompatibleValueFields(fields, fields[4], 'EQUAL')).toEqual([
+      fields[2],
+      fields[6],
+    ]);
+  });
+
+  it('returns no compatible candidates for operators that cannot compare fields', () => {
+    expect(getCompatibleValueFields(fields, fields[0], 'BETWEEN')).toEqual([]);
+    expect(getCompatibleValueFields(fields, fields[0], 'IS_NULL')).toEqual([]);
+  });
+
+  it('accepts the new field-comparison config shape on field definitions', () => {
+    expect(fields[0].fieldComparison).toEqual(explicitConfig);
+  });
+});

--- a/src/utils/field-comparison-support.ts
+++ b/src/utils/field-comparison-support.ts
@@ -1,0 +1,134 @@
+import {
+  BuilderFieldComparisonType,
+  IBuilderFieldProps,
+} from '../builder';
+import { QueryOperator } from './query-tree';
+import { isRangeOperator } from './is-range-operator.util';
+import { operatorRequiresValue } from './operator-requires-value.util';
+
+const fieldComparisonUnsupportedOperators = new Set<QueryOperator>([
+  'ALL_IN',
+  'ANY_IN',
+  'IN',
+  'NOT_IN',
+  'BETWEEN',
+  'NOT_BETWEEN',
+]);
+
+const inferListFieldComparisonType = (
+  field: IBuilderFieldProps
+): BuilderFieldComparisonType | undefined => {
+  if (
+    field.type !== 'LIST' ||
+    !Array.isArray(field.value) ||
+    field.value.length === 0 ||
+    !field.value.every(
+      option =>
+        typeof option === 'object' &&
+        option !== null &&
+        typeof option.label === 'string' &&
+        (typeof option.value === 'string' || typeof option.value === 'number')
+    )
+  ) {
+    return undefined;
+  }
+
+  const optionValues = field.value.map(option => option.value);
+  const allStrings = optionValues.every(value => typeof value === 'string');
+  const allNumbers = optionValues.every(value => typeof value === 'number');
+
+  if (allStrings) {
+    return 'string';
+  }
+
+  if (allNumbers) {
+    return 'number';
+  }
+
+  return undefined;
+};
+
+export const resolveFieldComparisonType = (
+  field: IBuilderFieldProps
+): BuilderFieldComparisonType | undefined => {
+  if (field.fieldComparison?.type) {
+    return field.fieldComparison.type;
+  }
+
+  switch (field.type) {
+    case 'TEXT':
+      return 'string';
+    case 'NUMBER':
+      return 'number';
+    case 'DATE':
+      return 'date';
+    case 'BOOLEAN':
+      return 'boolean';
+    case 'LIST':
+      return inferListFieldComparisonType(field);
+    default:
+      return undefined;
+  }
+};
+
+export const supportsFieldComparisonForOperator = (
+  field: IBuilderFieldProps,
+  operator?: QueryOperator
+): boolean => {
+  if (!resolveFieldComparisonType(field)) {
+    return false;
+  }
+
+  if (!operatorRequiresValue(operator)) {
+    return false;
+  }
+
+  if (isRangeOperator(operator)) {
+    return false;
+  }
+
+  return !fieldComparisonUnsupportedOperators.has(operator as QueryOperator);
+};
+
+export const areFieldsCompatibleForComparison = (
+  sourceField: IBuilderFieldProps,
+  candidateField: IBuilderFieldProps
+): boolean => {
+  const sourceComparisonType = resolveFieldComparisonType(sourceField);
+  const candidateComparisonType = resolveFieldComparisonType(candidateField);
+
+  if (!sourceComparisonType || !candidateComparisonType) {
+    return false;
+  }
+
+  if (sourceField.field === candidateField.field) {
+    return false;
+  }
+
+  if (sourceComparisonType !== candidateComparisonType) {
+    return false;
+  }
+
+  if (
+    sourceField.fieldComparison?.comparableFields &&
+    !sourceField.fieldComparison.comparableFields.includes(candidateField.field)
+  ) {
+    return false;
+  }
+
+  return true;
+};
+
+export const getCompatibleValueFields = (
+  fields: IBuilderFieldProps[],
+  sourceField: IBuilderFieldProps,
+  operator?: QueryOperator
+): IBuilderFieldProps[] => {
+  if (!supportsFieldComparisonForOperator(sourceField, operator)) {
+    return [];
+  }
+
+  return fields.filter(candidate =>
+    areFieldsCompatibleForComparison(sourceField, candidate)
+  );
+};

--- a/src/utils/is-same-query.util.test.ts
+++ b/src/utils/is-same-query.util.test.ts
@@ -45,4 +45,69 @@ describe('#utils/isSameQuery', () => {
 
     expect(isSameQuery(leftQuery, rightQuery)).toBe(false);
   });
+
+  it('Returns true for identical field comparison rules', () => {
+    const leftQuery: DenormalizedQuery = [
+      {
+        field: 'PRICE',
+        operator: 'LARGER',
+        valueSource: 'field',
+        valueField: 'COST',
+      },
+    ];
+
+    const rightQuery: DenormalizedQuery = [
+      {
+        field: 'PRICE',
+        operator: 'LARGER',
+        valueSource: 'field',
+        valueField: 'COST',
+      },
+    ];
+
+    expect(isSameQuery(leftQuery, rightQuery)).toBe(true);
+  });
+
+  it('Returns false when a rule changes from literal to field comparison', () => {
+    const leftQuery: DenormalizedQuery = [
+      {
+        field: 'PRICE',
+        operator: 'LARGER',
+        value: 100,
+      },
+    ];
+
+    const rightQuery: DenormalizedQuery = [
+      {
+        field: 'PRICE',
+        operator: 'LARGER',
+        valueSource: 'field',
+        valueField: 'COST',
+      },
+    ];
+
+    expect(isSameQuery(leftQuery, rightQuery)).toBe(false);
+  });
+
+  it('Returns false when field comparison rhs changes', () => {
+    const leftQuery: DenormalizedQuery = [
+      {
+        field: 'PRICE',
+        operator: 'LARGER',
+        valueSource: 'field',
+        valueField: 'COST',
+      },
+    ];
+
+    const rightQuery: DenormalizedQuery = [
+      {
+        field: 'PRICE',
+        operator: 'LARGER',
+        valueSource: 'field',
+        valueField: 'DISCOUNT',
+      },
+    ];
+
+    expect(isSameQuery(leftQuery, rightQuery)).toBe(false);
+  });
 });

--- a/src/utils/is-same-query.util.ts
+++ b/src/utils/is-same-query.util.ts
@@ -4,6 +4,7 @@ import {
   IDenormalizedRuleNode,
 } from './query-tree';
 import { isDenormalizedGroupNode } from './is-denormalized-group-node.util';
+import { getRuleValueSource } from './rule-value-source';
 
 const isSameReadOnly = (leftReadOnly: unknown, rightReadOnly: unknown): boolean =>
   JSON.stringify(leftReadOnly ?? null) === JSON.stringify(rightReadOnly ?? null);
@@ -39,7 +40,9 @@ const isSameNode = (left: DenormalizedNode, right: DenormalizedNode): boolean =>
   return (
     leftRule.field === rightRule.field &&
     leftRule.operator === rightRule.operator &&
+    getRuleValueSource(leftRule) === getRuleValueSource(rightRule) &&
     isSameValue(leftRule.value, rightRule.value) &&
+    leftRule.valueField === rightRule.valueField &&
     isSameReadOnly(leftRule.readOnly, rightRule.readOnly)
   );
 };

--- a/src/utils/query-tree.ts
+++ b/src/utils/query-tree.ts
@@ -8,6 +8,7 @@ export type GroupReadOnly = boolean | IGroupReadOnlyConfig;
 export type RuleReadOnly = boolean | IRuleReadOnlyConfig;
 export type GroupReadOnlyTarget = 'negation' | 'combinator';
 export type RuleReadOnlyTarget = 'field' | 'operator' | 'value';
+export type QueryRuleValueSource = 'value' | 'field';
 
 export type QueryRuleValue =
   | string
@@ -27,15 +28,28 @@ export interface IRuleReadOnlyConfig {
   targets?: RuleReadOnlyTarget[];
 }
 
-export interface IDenormalizedRuleNode {
+interface IRuleNodeBase {
   id?: string;
   parent?: string;
   field: string;
-  value?: QueryRuleValue;
   operator?: QueryOperator;
   operators?: QueryOperator[];
   readOnly?: RuleReadOnly;
 }
+
+export interface ILiteralRuleNode extends IRuleNodeBase {
+  valueSource?: 'value';
+  value?: QueryRuleValue;
+  valueField?: undefined;
+}
+
+export interface IFieldReferenceRuleNode extends IRuleNodeBase {
+  valueSource: 'field';
+  value?: undefined;
+  valueField: string;
+}
+
+export type IDenormalizedRuleNode = ILiteralRuleNode | IFieldReferenceRuleNode;
 
 export interface IDenormalizedGroupNodeBase {
   id?: string;
@@ -63,10 +77,27 @@ export type DenormalizedGroupNode =
 
 export type DenormalizedNode = IDenormalizedRuleNode | DenormalizedGroupNode;
 
-export interface INormalizedRuleNode extends IDenormalizedRuleNode {
+interface INormalizedRuleNodeBase extends IRuleNodeBase {
   id: string;
   parent?: string;
 }
+
+export interface INormalizedLiteralRuleNode extends INormalizedRuleNodeBase {
+  valueSource?: 'value';
+  value?: QueryRuleValue;
+  valueField?: undefined;
+}
+
+export interface INormalizedFieldReferenceRuleNode
+  extends INormalizedRuleNodeBase {
+  valueSource: 'field';
+  value?: undefined;
+  valueField: string;
+}
+
+export type INormalizedRuleNode =
+  | INormalizedLiteralRuleNode
+  | INormalizedFieldReferenceRuleNode;
 
 export interface INormalizedGroupNodeBase {
   id: string;

--- a/src/utils/rule-value-source.test.ts
+++ b/src/utils/rule-value-source.test.ts
@@ -1,0 +1,55 @@
+import {
+  getRuleValueSource,
+  isFieldComparisonRule,
+  isLiteralComparisonRule,
+} from './rule-value-source';
+
+describe('#utils/rule-value-source', () => {
+  it('Defaults missing valueSource to literal mode', () => {
+    expect(getRuleValueSource({})).toEqual('value');
+  });
+
+  it('Returns explicit value sources unchanged', () => {
+    expect(getRuleValueSource({ valueSource: 'value' })).toEqual('value');
+    expect(getRuleValueSource({ valueSource: 'field' })).toEqual('field');
+  });
+
+  it('Recognizes field comparison rules', () => {
+    expect(
+      isFieldComparisonRule({
+        field: 'PRICE',
+        valueSource: 'field',
+        valueField: 'COST',
+      })
+    ).toBe(true);
+  });
+
+  it('Does not treat literal rules as field comparisons', () => {
+    expect(
+      isFieldComparisonRule({
+        field: 'PRICE',
+        valueSource: 'value',
+        value: 100,
+      } as any)
+    ).toBe(false);
+  });
+
+  it('Recognizes literal comparison rules', () => {
+    expect(
+      isLiteralComparisonRule({
+        field: 'PRICE',
+        value: 100,
+      })
+    ).toBe(true);
+  });
+
+  it('Does not treat field comparisons as literal rules', () => {
+    expect(
+      isLiteralComparisonRule({
+        field: 'PRICE',
+        valueSource: 'field',
+        valueField: 'COST',
+      } as any)
+    ).toBe(false);
+  });
+});

--- a/src/utils/rule-value-source.ts
+++ b/src/utils/rule-value-source.ts
@@ -1,0 +1,21 @@
+import {
+  IFieldReferenceRuleNode,
+  IDenormalizedRuleNode,
+  INormalizedRuleNode,
+  QueryRuleValueSource,
+} from './query-tree';
+
+type QueryRuleNode = IDenormalizedRuleNode | INormalizedRuleNode;
+
+export const getRuleValueSource = (
+  rule: { valueSource?: QueryRuleValueSource }
+): QueryRuleValueSource => rule.valueSource ?? 'value';
+
+export const isFieldComparisonRule = (
+  rule: QueryRuleNode
+): rule is IFieldReferenceRuleNode & Pick<INormalizedRuleNode, 'id' | 'parent'> =>
+  getRuleValueSource(rule) === 'field';
+
+export const isLiteralComparisonRule = (
+  rule: QueryRuleNode
+): boolean => getRuleValueSource(rule) === 'value';

--- a/src/utils/validate-builder-query.util.test.ts
+++ b/src/utils/validate-builder-query.util.test.ts
@@ -57,6 +57,7 @@ describe('validateBuilderQuery', () => {
     singleRootGroup: true,
     groupTypes: 'with-modifiers',
     allowGroupNegation: true,
+    allowFieldComparisons: false,
     strings,
   };
 
@@ -306,3 +307,124 @@ describe('validateBuilderQuery', () => {
     expect(result.issuesByRuleId['rule-3']).toBeUndefined();
   });
 });
+
+
+describe('validateBuilderQuery field comparisons', () => {
+  const fieldComparisonContext: IBuilderValidationContext = {
+    fields: [
+      {
+        field: 'TEXT_A',
+        label: 'Text A',
+        type: 'TEXT',
+        operators: ['EQUAL', 'BETWEEN'],
+        fieldComparison: {
+          type: 'string',
+          comparableFields: ['TEXT_B'],
+        },
+      },
+      {
+        field: 'TEXT_B',
+        label: 'Text B',
+        type: 'TEXT',
+        operators: ['EQUAL'],
+        fieldComparison: {
+          type: 'string',
+        },
+      },
+      {
+        field: 'NUMBER_A',
+        label: 'Number A',
+        type: 'NUMBER',
+        operators: ['EQUAL'],
+        fieldComparison: {
+          type: 'number',
+        },
+      },
+    ],
+    singleRootGroup: true,
+    groupTypes: 'with-modifiers',
+    allowGroupNegation: true,
+    allowFieldComparisons: true,
+    strings,
+  };
+
+  it('accepts valid field-to-field comparisons at the query-validation level', async () => {
+    const result = await validateBuilderQuery(
+      [
+        {
+          type: 'GROUP',
+          value: 'AND',
+          isNegated: false,
+          children: [
+            {
+              id: 'rule-field-ok',
+              field: 'TEXT_A',
+              operator: 'EQUAL',
+              valueSource: 'field',
+              valueField: 'TEXT_B',
+            },
+          ],
+        },
+      ],
+      fieldComparisonContext
+    );
+
+    expect(result.isValid).toEqual(true);
+    expect(result.issuesByRuleId['rule-field-ok']).toBeUndefined();
+  });
+
+  it('surfaces disabled and incompatible field-comparison issues at the query-validation level', async () => {
+    const disabledResult = await validateBuilderQuery(
+      [
+        {
+          type: 'GROUP',
+          value: 'AND',
+          isNegated: false,
+          children: [
+            {
+              id: 'rule-field-disabled',
+              field: 'TEXT_A',
+              operator: 'EQUAL',
+              valueSource: 'field',
+              valueField: 'TEXT_B',
+            },
+          ],
+        },
+      ],
+      {
+        ...fieldComparisonContext,
+        allowFieldComparisons: false,
+      }
+    );
+    const incompatibleResult = await validateBuilderQuery(
+      [
+        {
+          type: 'GROUP',
+          value: 'AND',
+          isNegated: false,
+          children: [
+            {
+              id: 'rule-field-incompatible',
+              field: 'TEXT_A',
+              operator: 'EQUAL',
+              valueSource: 'field',
+              valueField: 'NUMBER_A',
+            },
+          ],
+        },
+      ],
+      fieldComparisonContext
+    );
+
+    expect(disabledResult.isValid).toEqual(false);
+    expect(disabledResult.issuesByRuleId['rule-field-disabled'][0].code).toEqual(
+      'field_comparison_disabled'
+    );
+    expect(incompatibleResult.isValid).toEqual(false);
+    expect(
+      incompatibleResult.issuesByRuleId['rule-field-incompatible'][0].code
+    ).toEqual('field_comparison_incompatible');
+  });
+});
+
+

--- a/src/utils/validation/validate-builder-rule.util.test.ts
+++ b/src/utils/validation/validate-builder-rule.util.test.ts
@@ -1,0 +1,159 @@
+import { strings } from '../../constants/strings';
+import { validateBuilderRule } from './validate-builder-rule.util';
+
+describe('validateBuilderRule field comparisons', () => {
+  const validationContext: any = {
+    fields: [
+      {
+        field: 'TEXT_A',
+        label: 'Text A',
+        type: 'TEXT',
+        operators: ['EQUAL', 'BETWEEN', 'CONTAINS', 'STARTS_WITH', 'ENDS_WITH', 'NOT_CONTAINS'],
+        validation: { required: true },
+        fieldComparison: { type: 'string', comparableFields: ['TEXT_B', 'LIST_A'] },
+      },
+      {
+        field: 'TEXT_B',
+        label: 'Text B',
+        type: 'TEXT',
+        operators: ['EQUAL'],
+        fieldComparison: { type: 'string' },
+      },
+      {
+        field: 'TEXT_C',
+        label: 'Text C',
+        type: 'TEXT',
+        operators: ['EQUAL'],
+        fieldComparison: { type: 'string' },
+      },
+      {
+        field: 'LIST_A',
+        label: 'List A',
+        type: 'LIST',
+        operators: ['EQUAL'],
+        value: [{ value: 'a', label: 'A' }],
+        fieldComparison: { type: 'string' },
+      },
+    ],
+    singleRootGroup: true,
+    groupTypes: 'with-modifiers',
+    allowGroupNegation: true,
+    allowFieldComparisons: true,
+    strings,
+  };
+
+  it('does not report required-value errors for valid field comparisons', () => {
+    expect(
+      validateBuilderRule(
+        {
+          id: 'rule-1',
+          field: 'TEXT_A',
+          operator: 'EQUAL',
+          valueSource: 'field',
+          valueField: 'TEXT_B',
+        },
+        validationContext.fields[0],
+        validationContext
+      )
+    ).toEqual([]);
+  });
+
+  it('accepts supported string-method field comparisons', () => {
+    expect(
+      validateBuilderRule(
+        {
+          id: 'rule-string-method',
+          field: 'TEXT_A',
+          operator: 'CONTAINS',
+          valueSource: 'field',
+          valueField: 'TEXT_B',
+        },
+        validationContext.fields[0],
+        validationContext
+      )
+    ).toEqual([]);
+  });
+
+  it('rejects field comparisons when the Builder flag is disabled', () => {
+    expect(
+      validateBuilderRule(
+        {
+          id: 'rule-flag-off',
+          field: 'TEXT_A',
+          operator: 'EQUAL',
+          valueSource: 'field',
+          valueField: 'TEXT_B',
+        },
+        validationContext.fields[0],
+        {
+          ...validationContext,
+          allowFieldComparisons: false,
+        }
+      )
+    ).toEqual([
+      expect.objectContaining({
+        code: 'field_comparison_disabled',
+      }),
+    ]);
+  });
+
+  it('rejects operators that do not support field comparisons', () => {
+    expect(
+      validateBuilderRule(
+        {
+          id: 'rule-operator',
+          field: 'TEXT_A',
+          operator: 'BETWEEN',
+          valueSource: 'field',
+          valueField: 'TEXT_B',
+        },
+        validationContext.fields[0],
+        validationContext
+      )
+    ).toEqual([
+      expect.objectContaining({
+        code: 'field_comparison_operator_not_allowed',
+      }),
+    ]);
+  });
+
+  it('rejects incompatible comparison fields', () => {
+    expect(
+      validateBuilderRule(
+        {
+          id: 'rule-2',
+          field: 'TEXT_A',
+          operator: 'EQUAL',
+          valueSource: 'field',
+          valueField: 'TEXT_A',
+        },
+        validationContext.fields[0],
+        validationContext
+      )
+    ).toEqual([
+      expect.objectContaining({
+        code: 'field_comparison_incompatible',
+      }),
+    ]);
+  });
+
+  it('rejects comparison fields outside the source allowlist', () => {
+    expect(
+      validateBuilderRule(
+        {
+          id: 'rule-allowlist',
+          field: 'TEXT_A',
+          operator: 'EQUAL',
+          valueSource: 'field',
+          valueField: 'TEXT_C',
+        },
+        validationContext.fields[0],
+        validationContext
+      )
+    ).toEqual([
+      expect.objectContaining({
+        code: 'field_comparison_incompatible',
+      }),
+    ]);
+  });
+});

--- a/src/utils/validation/validate-builder-rule.util.ts
+++ b/src/utils/validation/validate-builder-rule.util.ts
@@ -35,6 +35,7 @@ import { resolveRangeBoundValidation } from './resolve-range-bound-validation.ut
 import { validateBooleanValue } from './validate-boolean-value.util';
 import { validateBuilderRange } from './validate-builder-range.util';
 import { validateDateValue } from './validate-date-value.util';
+import { validateFieldComparison } from './validate-field-comparison.util';
 import { validateListValue } from './validate-list-value.util';
 import { validateMultiListValue } from './validate-multi-list-value.util';
 import { validateNumberValue } from './validate-number-value.util';
@@ -298,6 +299,76 @@ const validateDateRule = (
   return issues;
 };
 
+const createFieldComparisonIssue = (
+  result: ReturnType<typeof validateFieldComparison>,
+  baseIssue: Omit<IBuilderValidationIssue, 'message'>,
+  validationContext: IBuilderValidationContext
+): IBuilderValidationIssue | null => {
+  if (!result) {
+    return null;
+  }
+
+  const { code, params } = result;
+
+  switch (code) {
+    case 'field_comparison_disabled':
+      return {
+        ...baseIssue,
+        code,
+        message: getValidationString(
+          validationContext.strings.validation,
+          'fieldComparisonDisabled',
+          'Field-to-field comparison is not allowed'
+        ),
+      };
+    case 'field_comparison_operator_not_allowed':
+      return {
+        ...baseIssue,
+        code,
+        message: getValidationString(
+          validationContext.strings.validation,
+          'fieldComparisonOperatorNotAllowed',
+          'Operator "{operator}" does not support field-to-field comparison for field "{field}"',
+          params
+        ),
+      };
+    case 'field_comparison_incompatible':
+      return {
+        ...baseIssue,
+        code,
+        message: getValidationString(
+          validationContext.strings.validation,
+          'fieldComparisonIncompatible',
+          'Comparison field "{valueField}" is not compatible with field "{field}" for operator "{operator}"',
+          params
+        ),
+      };
+    case 'value_field_required':
+      return {
+        ...baseIssue,
+        code,
+        message: getValidationString(
+          validationContext.strings.validation,
+          'valueFieldRequired',
+          'A comparison field is required'
+        ),
+      };
+    case 'value_field_not_found':
+      return {
+        ...baseIssue,
+        code,
+        message: getValidationString(
+          validationContext.strings.validation,
+          'valueFieldNotFound',
+          'Comparison field "{field}" was not found',
+          params
+        ),
+      };
+    default:
+      return null;
+  }
+};
+
 export const validateBuilderRule = (
   rule: IDenormalizedRuleNode,
   field: IBuilderValidationContext['fields'][number],
@@ -333,10 +404,6 @@ export const validateBuilderRule = (
     });
   }
 
-  if (!validation) {
-    return issues;
-  }
-
   if (!operatorRequiresValue(rule.operator)) {
     if (typeof rule.value !== 'undefined') {
       issues.push({
@@ -350,6 +417,34 @@ export const validateBuilderRule = (
       });
     }
 
+    return issues;
+  }
+
+  if (rule.valueSource === 'field') {
+    if (issues.some(issue => issue.code === 'operator_not_allowed')) {
+      return issues;
+    }
+
+    const fieldComparisonIssue = createFieldComparisonIssue(
+      validateFieldComparison({
+        allowFieldComparisons: validationContext.allowFieldComparisons,
+        field,
+        fields: validationContext.fields,
+        operator: rule.operator,
+        valueField: rule.valueField,
+      }),
+      baseIssue,
+      validationContext
+    );
+
+    if (fieldComparisonIssue) {
+      issues.push(fieldComparisonIssue);
+    }
+
+    return issues;
+  }
+
+  if (!validation) {
     return issues;
   }
 
@@ -527,3 +622,4 @@ export const validateBuilderRule = (
 
   return issues;
 };
+

--- a/src/utils/validation/validate-field-comparison.util.ts
+++ b/src/utils/validation/validate-field-comparison.util.ts
@@ -1,0 +1,85 @@
+import { IBuilderFieldProps } from '../../builder';
+import {
+  areFieldsCompatibleForComparison,
+  supportsFieldComparisonForOperator,
+} from '../field-comparison-support';
+import { QueryOperator } from '../query-operators';
+
+export type FieldComparisonValidationCode =
+  | 'field_comparison_disabled'
+  | 'field_comparison_operator_not_allowed'
+  | 'field_comparison_incompatible'
+  | 'value_field_required'
+  | 'value_field_not_found';
+
+export interface IFieldComparisonValidationResult {
+  code: FieldComparisonValidationCode;
+  params: Record<string, string>;
+}
+
+interface IValidateFieldComparisonArgs {
+  allowFieldComparisons: boolean;
+  field: IBuilderFieldProps;
+  fields: IBuilderFieldProps[];
+  operator?: QueryOperator;
+  valueField?: string;
+}
+
+export const validateFieldComparison = ({
+  allowFieldComparisons,
+  field,
+  fields,
+  operator,
+  valueField,
+}: IValidateFieldComparisonArgs): IFieldComparisonValidationResult | null => {
+  if (!allowFieldComparisons) {
+    return {
+      code: 'field_comparison_disabled',
+      params: {
+        field: field.field,
+        operator: operator || '',
+      },
+    };
+  }
+
+  if (!supportsFieldComparisonForOperator(field, operator)) {
+    return {
+      code: 'field_comparison_operator_not_allowed',
+      params: {
+        field: field.field,
+        operator: operator || '',
+      },
+    };
+  }
+
+  if (!valueField) {
+    return {
+      code: 'value_field_required',
+      params: {},
+    };
+  }
+
+  const resolvedValueField = fields.find(fieldItem => fieldItem.field === valueField);
+
+  if (!resolvedValueField) {
+    return {
+      code: 'value_field_not_found',
+      params: {
+        field: valueField,
+      },
+    };
+  }
+
+  if (!areFieldsCompatibleForComparison(field, resolvedValueField)) {
+    return {
+      code: 'field_comparison_incompatible',
+      params: {
+        field: field.field,
+        valueField: resolvedValueField.field,
+        operator: operator || '',
+      },
+    };
+  }
+
+  return null;
+};

--- a/src/widgets/boolean.tsx
+++ b/src/widgets/boolean.tsx
@@ -49,6 +49,8 @@ export const Boolean: FC<IBooleanProps> = ({
           return;
         }
 
+        item.valueSource = 'value';
+        delete item.valueField;
         item.value = value;
       });
 
@@ -65,7 +67,12 @@ export const Boolean: FC<IBooleanProps> = ({
         id,
         currentRule.field,
         currentRule.value,
-        value
+        value,
+        {
+          previousValueSource: currentRule.valueSource ?? 'value',
+          previousValueField: currentRule.valueField,
+          valueSource: 'value',
+        }
       );
       return;
     }
@@ -77,7 +84,9 @@ export const Boolean: FC<IBooleanProps> = ({
     dispatchAction(
       createReplaceNodeAction(id, {
         ...currentRule,
+        valueSource: 'value',
         value,
+        valueField: undefined,
       })
     );
     emitBuilderFieldChange(
@@ -87,12 +96,19 @@ export const Boolean: FC<IBooleanProps> = ({
           return;
         }
 
+        item.valueSource = 'value';
+        delete item.valueField;
         item.value = value;
       }),
       id,
       currentRule.field,
       currentRule.value,
-      value
+      value,
+      {
+        previousValueSource: currentRule.valueSource ?? 'value',
+        previousValueField: currentRule.valueField,
+        valueSource: 'value',
+      }
     );
   };
 

--- a/src/widgets/field-select.test.tsx
+++ b/src/widgets/field-select.test.tsx
@@ -13,15 +13,29 @@ const fields: IBuilderFieldProps[] = [
   { field: 'MOCK_FIELD_1', label: 'Mock Field', type: 'BOOLEAN' },
   { field: 'MOCK_FIELD_2', label: 'Mock Field', type: 'DATE', operators: ['BETWEEN'] },
   { field: 'MOCK_FIELD_3', label: 'Mock Field', type: 'DATE', operators: ['LARGER'] },
-  { field: 'MOCK_FIELD_4', label: 'Mock Field', type: 'TEXT', operators: ['EQUAL'] },
-  { field: 'MOCK_FIELD_5', label: 'Mock Field', type: 'TEXT', operators: ['BETWEEN'] },
+  {
+    field: 'MOCK_FIELD_4',
+    label: 'Mock Field',
+    type: 'TEXT',
+    operators: ['EQUAL'],
+    fieldComparison: { type: 'string' },
+  },
+  {
+    field: 'MOCK_FIELD_5',
+    label: 'Mock Field',
+    type: 'TEXT',
+    operators: ['BETWEEN'],
+    fieldComparison: { type: 'string' },
+  },
   { field: 'MOCK_FIELD_6', label: 'Mock Field', type: 'NUMBER', operators: ['EQUAL'] },
   { field: 'MOCK_FIELD_7', label: 'Mock Field', type: 'NUMBER', operators: ['BETWEEN'] },
   {
     field: 'MOCK_FIELD_8',
     label: 'Mock Field',
     type: 'LIST',
+    operators: ['EQUAL'],
     value: [{ label: 'test', value: 'test' }],
+    fieldComparison: { type: 'string' },
   },
   {
     field: 'MOCK_FIELD_9',
@@ -139,7 +153,97 @@ describe('#components/Widgets/FieldSelect', () => {
 
     fireEvent.click(getByDataTest(container, 'SelectMultiTrigger'));
 
-    expect(getByDataTest(container, 'SelectMultiOption[MOCK_FIELD_1]')).toBeDisabled();
-    expect(getByDataTest(container, 'SelectMultiOption[MOCK_FIELD_2]')).not.toBeDisabled();
+    expect(
+      getByDataTest(container, 'SelectMultiOption[MOCK_FIELD_1]').hasAttribute(
+        'disabled'
+      )
+    ).toBe(true);
+    expect(
+      getByDataTest(container, 'SelectMultiOption[MOCK_FIELD_2]').hasAttribute(
+        'disabled'
+      )
+    ).toBe(false);
+  });
+
+  it('preserves field-comparison mode when the next field still supports it', () => {
+    const onFieldChange = jest.fn();
+    const fieldComparisonData: any[] = [
+      {
+        id: 'test',
+        field: 'MOCK_FIELD_4',
+        operator: 'EQUAL',
+        valueSource: 'field',
+        valueField: 'MOCK_FIELD_5',
+      },
+    ];
+    const { container } = renderWithContext(
+      <FieldSelect id="test" selectedValue="MOCK_FIELD_4" />,
+      {
+        data: fieldComparisonData,
+        allowFieldComparisons: true,
+        onFieldChange,
+      }
+    );
+
+    fireEvent.click(getByDataTest(container, 'SelectMultiTrigger'));
+    fireEvent.click(getByDataTest(container, 'SelectMultiOption[MOCK_FIELD_8]'));
+
+    expect(onFieldChange).toHaveBeenCalledWith(
+      expect.objectContaining({
+        field: 'MOCK_FIELD_8',
+        previousValueSource: 'field',
+        previousValueField: 'MOCK_FIELD_5',
+        valueSource: 'field',
+        valueField: 'MOCK_FIELD_5',
+        data: [
+          {
+            field: 'MOCK_FIELD_8',
+            operator: 'EQUAL',
+            valueSource: 'field',
+            valueField: 'MOCK_FIELD_5',
+          },
+        ],
+      })
+    );
+  });
+
+  it('emits source metadata when changing a field from a field-comparison rule', () => {
+    const onFieldChange = jest.fn();
+    const fieldComparisonData: any[] = [
+      {
+        id: 'test',
+        field: 'MOCK_FIELD_4',
+        operator: 'EQUAL',
+        valueSource: 'field',
+        valueField: 'MOCK_FIELD_5',
+      },
+    ];
+    const { container } = renderWithContext(
+      <FieldSelect id="test" selectedValue="MOCK_FIELD_4" />,
+      {
+        data: fieldComparisonData,
+        onFieldChange,
+      }
+    );
+
+    fireEvent.click(getByDataTest(container, 'SelectMultiTrigger'));
+    fireEvent.click(getByDataTest(container, 'SelectMultiOption[MOCK_FIELD_1]'));
+
+    expect(onFieldChange).toHaveBeenCalledWith(
+      expect.objectContaining({
+        field: 'MOCK_FIELD_1',
+        previousValueSource: 'field',
+        previousValueField: 'MOCK_FIELD_5',
+        valueSource: 'value',
+        value: false,
+        data: [
+          {
+            field: 'MOCK_FIELD_1',
+            valueSource: 'value',
+            value: false,
+          },
+        ],
+      })
+    );
   });
 });

--- a/src/widgets/field-select.tsx
+++ b/src/widgets/field-select.tsx
@@ -1,20 +1,32 @@
 import React, { FC, useContext } from 'react';
 import { BuilderContext } from '../builder-context';
+import { isBuilderFieldUsageExhausted } from '../builder/utils/resolve-builder-field-usage.util';
 import { Select as DefaultSelect } from '../form/select';
 import { createReplaceNodeAction } from '../history/create-replace-node-action';
 import { findNodeById } from '../history/find-node-by-id';
 import { applyDataUpdate } from '../utils/apply-data-update.util';
 import { createRuleStateForField } from '../utils/create-rule-state-for-field.util';
 import { emitBuilderFieldChange } from '../utils/emit-builder-field-change.util';
+import { getCompatibleValueFields } from '../utils/field-comparison-support';
 import { isNormalizedGroupNode } from '../utils/is-normalized-group-node.util';
+import { QueryRuleValue, QueryRuleValueSource } from '../utils/query-tree';
+import { getRuleValueSource } from '../utils/rule-value-source';
 import { updateItem } from '../utils/update-item.util';
-import { isBuilderFieldUsageExhausted } from '../builder/utils/resolve-builder-field-usage.util';
 
 export interface IFieldSelectProps {
   selectedValue: string;
   id: string;
   disabled?: boolean;
 }
+
+type NextRuleState = {
+  field: string;
+  operator?: any;
+  operators?: any;
+  valueSource: QueryRuleValueSource;
+  value?: QueryRuleValue;
+  valueField?: string;
+};
 
 export const FieldSelect: FC<IFieldSelectProps> = ({
   selectedValue,
@@ -31,6 +43,7 @@ export const FieldSelect: FC<IFieldSelectProps> = ({
     components,
     strings,
     readOnly,
+    allowFieldComparisons = false,
     onFieldChange,
   } = useContext(BuilderContext);
   const Select = components.form?.Select || DefaultSelect;
@@ -39,20 +52,54 @@ export const FieldSelect: FC<IFieldSelectProps> = ({
   const parentId =
     currentRule && !isNormalizedGroupNode(currentRule) ? currentRule.parent : undefined;
 
+  const createNextRuleState = (value: string) => {
+    const nextField = fields.find(item => item.field === value);
+    const currentRuleNode = findNodeById(data, id);
+
+    if (!nextField || !currentRuleNode || isNormalizedGroupNode(currentRuleNode)) {
+      return null;
+    }
+
+    const nextRuleState: NextRuleState = {
+      ...createRuleStateForField(nextField),
+    };
+    const currentValueSource = getRuleValueSource(currentRuleNode);
+    const nextCompatibleFields =
+      allowFieldComparisons && nextRuleState.operator
+        ? getCompatibleValueFields(fields, nextField, nextRuleState.operator as any)
+        : [];
+
+    if (currentValueSource === 'field' && nextCompatibleFields.length > 0) {
+      nextRuleState.valueSource = 'field';
+      nextRuleState.valueField =
+        currentRuleNode.valueField &&
+        nextCompatibleFields.some(fieldItem => fieldItem.field === currentRuleNode.valueField)
+          ? currentRuleNode.valueField
+          : nextCompatibleFields[0].field;
+      delete nextRuleState.value;
+    }
+
+    return {
+      currentRule: currentRuleNode,
+      nextField,
+      nextRuleState,
+    };
+  };
+
   const handleChange = (value: string) => {
     if (isDisabled) {
       return;
     }
 
-    const nextField = fields.find(item => item.field === value);
-    const currentRule = findNodeById(data, id);
+    const nextState = createNextRuleState(value);
 
-    if (!nextField || !currentRule || isNormalizedGroupNode(currentRule)) {
+    if (!nextState) {
       return;
     }
 
+    const { currentRule, nextField, nextRuleState } = nextState;
+
     if (!dispatchAction && setData && onChange) {
-      const nextRuleState = createRuleStateForField(nextField);
       const nextData = updateItem(data, id, item => {
         if (isNormalizedGroupNode(item)) {
           return;
@@ -79,7 +126,13 @@ export const FieldSelect: FC<IFieldSelectProps> = ({
         id,
         nextField.field,
         currentRule.value,
-        nextRuleState.value
+        nextRuleState.value,
+        {
+          previousValueSource: currentRule.valueSource ?? 'value',
+          previousValueField: currentRule.valueField,
+          valueSource: nextRuleState.valueSource ?? 'value',
+          valueField: nextRuleState.valueField,
+        }
       );
       return;
     }
@@ -88,15 +141,16 @@ export const FieldSelect: FC<IFieldSelectProps> = ({
       return;
     }
 
-    const nextRuleState = createRuleStateForField(nextField);
-
     dispatchAction(
-      createReplaceNodeAction(id, {
-        id: currentRule.id,
-        parent: currentRule.parent,
-        readOnly: currentRule.readOnly,
-        ...nextRuleState,
-      })
+      createReplaceNodeAction(
+        id,
+        {
+          id: currentRule.id,
+          parent: currentRule.parent,
+          readOnly: currentRule.readOnly,
+          ...nextRuleState,
+        } as any
+      )
     );
     emitBuilderFieldChange(
       onFieldChange,
@@ -115,11 +169,17 @@ export const FieldSelect: FC<IFieldSelectProps> = ({
       id,
       nextField.field,
       currentRule.value,
-      nextRuleState.value
+      nextRuleState.value,
+      {
+        previousValueSource: currentRule.valueSource ?? 'value',
+        previousValueField: currentRule.valueField,
+        valueSource: nextRuleState.valueSource ?? 'value',
+        valueField: nextRuleState.valueField,
+      }
     );
   };
 
-  const fieldNames = fields.map((field) => ({
+  const fieldNames = fields.map(field => ({
     value: field.field,
     label: field.label,
     disabled:

--- a/src/widgets/input.test.tsx
+++ b/src/widgets/input.test.tsx
@@ -69,4 +69,56 @@ describe('#components/Widgets/Input', () => {
 
     expect(container.querySelector('input')).toBeTruthy();
   });
+
+  it('resets field-comparison rules back to literal mode in the non-dispatch path', () => {
+    const onChange = jest.fn();
+    const onFieldChange = jest.fn();
+    const fieldComparisonData: any[] = [
+      {
+        id: 'test',
+        field: 'MOCK_FIELD',
+        operator: 'EQUAL',
+        valueSource: 'field',
+        valueField: 'OTHER_FIELD',
+      },
+    ];
+    const { container } = renderWithContext(
+      <Input id="test" value="" type="text" />,
+      {
+        data: fieldComparisonData,
+        onChange,
+        onFieldChange,
+      }
+    );
+
+    fireEvent.change(container.querySelector('input') as HTMLElement, {
+      target: { value: 'next' },
+    });
+
+    expect(onChange).toHaveBeenCalledWith([
+      {
+        id: 'test',
+        field: 'MOCK_FIELD',
+        operator: 'EQUAL',
+        valueSource: 'value',
+        value: 'next',
+      },
+    ]);
+    expect(onFieldChange).toHaveBeenCalledWith(
+      expect.objectContaining({
+        previousValueSource: 'field',
+        previousValueField: 'OTHER_FIELD',
+        valueSource: 'value',
+        value: 'next',
+        data: [
+          {
+            field: 'MOCK_FIELD',
+            operator: 'EQUAL',
+            valueSource: 'value',
+            value: 'next',
+          },
+        ],
+      })
+    );
+  });
 });

--- a/src/widgets/input.tsx
+++ b/src/widgets/input.tsx
@@ -73,12 +73,25 @@ export const Input: FC<IInputProps> = ({
         if (isStringOrNumberArray(item.value)) {
           const nextRangeValue = item.value.slice() as typeof item.value;
           nextRangeValue[index] = nextValue;
+          item.valueSource = 'value';
+          delete item.valueField;
           item.value = nextRangeValue;
           return;
         }
 
+        item.valueSource = 'value';
+        delete item.valueField;
         item.value = nextValue;
       });
+
+      const emittedValue = isStringOrNumberArray(currentRule.value)
+        ? (() => {
+            const nextRangeValue =
+              currentRule.value.slice() as typeof currentRule.value;
+            nextRangeValue[index] = nextValue;
+            return nextRangeValue;
+          })()
+        : nextValue;
 
       applyDataUpdate(
         data,
@@ -93,14 +106,12 @@ export const Input: FC<IInputProps> = ({
         id,
         currentRule.field,
         currentRule.value,
-        isStringOrNumberArray(currentRule.value)
-          ? (() => {
-              const nextRangeValue =
-                currentRule.value.slice() as typeof currentRule.value;
-              nextRangeValue[index] = nextValue;
-              return nextRangeValue;
-            })()
-          : nextValue
+        emittedValue,
+        {
+          previousValueSource: currentRule.valueSource ?? 'value',
+          previousValueField: currentRule.valueField,
+          valueSource: 'value',
+        }
       );
       return;
     }
@@ -120,6 +131,9 @@ export const Input: FC<IInputProps> = ({
       nextRule.value = nextValue;
     }
 
+    nextRule.valueSource = 'value';
+    delete nextRule.valueField;
+
     dispatchAction(createReplaceNodeAction(id, nextRule));
     emitBuilderFieldChange(
       onFieldChange,
@@ -128,12 +142,19 @@ export const Input: FC<IInputProps> = ({
           return;
         }
 
+        item.valueSource = 'value';
+        delete item.valueField;
         item.value = nextRule.value;
       }),
       id,
       currentRule.field,
       currentRule.value,
-      nextRule.value
+      nextRule.value,
+      {
+        previousValueSource: currentRule.valueSource ?? 'value',
+        previousValueField: currentRule.valueField,
+        valueSource: nextRule.valueSource ?? 'value',
+      }
     );
   };
 

--- a/src/widgets/operator-select.test.tsx
+++ b/src/widgets/operator-select.test.tsx
@@ -30,6 +30,7 @@ const operatorSelectValues: IOperatorSelectValuesProps[][] = [
   ],
   [{ value: 'ALL_IN', label: 'Test' }, { value: 'ANY_IN', label: 'Test' }],
   [{ value: 'IS_NULL', label: 'Test' }, { value: 'IS_NOT_NULL', label: 'Test' }],
+  [{ value: 'NOT_EQUAL', label: 'Test' }],
 ];
 
 const getByDataTest = (container: HTMLElement, value: string): HTMLElement => {
@@ -111,7 +112,13 @@ describe('#components/Widgets/OperatorSelect', () => {
 
     expect(onChange).toHaveBeenCalledWith([
       { field: 'MOCK_FIELD_1', id: 'test-1', value: 'Test' },
-      { field: 'MOCK_FIELD_2', id: 'test-2', value: [0, 0], operator: 'BETWEEN' },
+      {
+        field: 'MOCK_FIELD_2',
+        id: 'test-2',
+        value: [0, 0],
+        operator: 'BETWEEN',
+        valueSource: 'value',
+      },
       { field: 'MOCK_FIELD_2', id: 'test-3', value: [1, 2], operator: 'NOT_BETWEEN' },
     ]);
   });
@@ -128,7 +135,13 @@ describe('#components/Widgets/OperatorSelect', () => {
 
     expect(onChange).toHaveBeenCalledWith([
       { field: 'MOCK_FIELD_1', id: 'test-1', value: 'Test' },
-      { field: 'MOCK_FIELD_2', id: 'test-2', value: 'Test', operator: 'ALL_IN' },
+      {
+        field: 'MOCK_FIELD_2',
+        id: 'test-2',
+        value: 'Test',
+        operator: 'ALL_IN',
+        valueSource: 'value',
+      },
       { field: 'MOCK_FIELD_2', id: 'test-3', value: [1, 2], operator: 'NOT_BETWEEN' },
     ]);
   });
@@ -146,7 +159,13 @@ describe('#components/Widgets/OperatorSelect', () => {
     expect(onChange).toHaveBeenCalledWith([
       { field: 'MOCK_FIELD_1', id: 'test-1', value: 'Test' },
       { field: 'MOCK_FIELD_2', id: 'test-2', value: 'Test' },
-      { field: 'MOCK_FIELD_2', id: 'test-3', value: 0, operator: 'ALL_IN' },
+      {
+        field: 'MOCK_FIELD_2',
+        id: 'test-3',
+        value: 0,
+        operator: 'ALL_IN',
+        valueSource: 'value',
+      },
     ]);
   });
 
@@ -170,9 +189,134 @@ describe('#components/Widgets/OperatorSelect', () => {
     fireEvent.click(getByDataTest(container, 'SelectMultiOption[IS_NULL]'));
 
     expect(onChange).toHaveBeenCalledWith([
-      { field: 'MOCK_FIELD_1', id: 'test-1', operator: 'IS_NULL' },
+      { field: 'MOCK_FIELD_1', id: 'test-1', operator: 'IS_NULL', valueSource: 'value' },
       { field: 'MOCK_FIELD_2', id: 'test-2', value: 'Test' },
       { field: 'MOCK_FIELD_2', id: 'test-3', value: [1, 2], operator: 'NOT_BETWEEN' },
+    ]);
+  });
+
+  it('clears field-comparison metadata when switching to a valueless operator', () => {
+    const onChange = jest.fn();
+    const onFieldChange = jest.fn();
+    const fieldComparisonData: any[] = [
+      {
+        field: 'MOCK_FIELD_1',
+        id: 'test-1',
+        operator: 'EQUAL',
+        valueSource: 'field',
+        valueField: 'MOCK_FIELD_2',
+      },
+    ];
+    const { container } = renderWithContext(
+      <OperatorSelect id="test-1" values={operatorSelectValues[2]} />,
+      {
+        data: fieldComparisonData,
+        onChange,
+        onFieldChange,
+      }
+    );
+
+    fireEvent.click(getByDataTest(container, 'SelectMultiTrigger'));
+    fireEvent.click(getByDataTest(container, 'SelectMultiOption[IS_NULL]'));
+
+    expect(onChange).toHaveBeenCalledWith([
+      {
+        field: 'MOCK_FIELD_1',
+        id: 'test-1',
+        operator: 'IS_NULL',
+        valueSource: 'value',
+      },
+    ]);
+    expect(onFieldChange).toHaveBeenCalledWith(
+      expect.objectContaining({
+        previousValueSource: 'field',
+        previousValueField: 'MOCK_FIELD_2',
+        valueSource: 'value',
+        value: undefined,
+        data: [
+          {
+            field: 'MOCK_FIELD_1',
+            operator: 'IS_NULL',
+            valueSource: 'value',
+          },
+        ],
+      })
+    );
+  });
+
+  it('preserves field-comparison mode when switching to another supported operator', () => {
+    const onChange = jest.fn();
+    const fieldComparisonData: any[] = [
+      {
+        field: 'MOCK_FIELD_1',
+        id: 'test-1',
+        operator: 'EQUAL',
+        valueSource: 'field',
+        valueField: 'MOCK_FIELD_1_TARGET',
+      },
+    ];
+    const { container } = renderWithContext(
+      <OperatorSelect id="test-1" values={operatorSelectValues[3]} />,
+      {
+        data: fieldComparisonData,
+        fields: [
+          ...fields,
+          { field: 'MOCK_FIELD_1_TARGET', label: 'Target Field', type: 'TEXT' },
+        ],
+        onChange,
+      }
+    );
+
+    fireEvent.click(getByDataTest(container, 'SelectMultiTrigger'));
+    fireEvent.click(getByDataTest(container, 'SelectMultiOption[NOT_EQUAL]'));
+
+    expect(onChange).toHaveBeenCalledWith([
+      {
+        field: 'MOCK_FIELD_1',
+        id: 'test-1',
+        operator: 'NOT_EQUAL',
+        valueSource: 'field',
+        valueField: 'MOCK_FIELD_1_TARGET',
+      },
+    ]);
+  });
+});
+
+describe('#components/Widgets/OperatorSelect unsupported field comparisons', () => {
+  it('preserves field-comparison mode when switching to an unsupported value operator', () => {
+    const onChange = jest.fn();
+    const fieldComparisonData: any[] = [
+      {
+        field: 'MOCK_FIELD_1',
+        id: 'test-1',
+        operator: 'EQUAL',
+        valueSource: 'field',
+        valueField: 'MOCK_FIELD_1_TARGET',
+      },
+    ];
+    const { container } = renderWithContext(
+      <OperatorSelect id="test-1" values={[{ value: 'BETWEEN', label: 'Test' }]} />,
+      {
+        data: fieldComparisonData,
+        fields: [
+          ...fields,
+          { field: 'MOCK_FIELD_1_TARGET', label: 'Target Field', type: 'TEXT' },
+        ],
+        onChange,
+      }
+    );
+
+    fireEvent.click(getByDataTest(container, 'SelectMultiTrigger'));
+    fireEvent.click(getByDataTest(container, 'SelectMultiOption[BETWEEN]'));
+
+    expect(onChange).toHaveBeenCalledWith([
+      {
+        field: 'MOCK_FIELD_1',
+        id: 'test-1',
+        operator: 'BETWEEN',
+        valueSource: 'field',
+        valueField: 'MOCK_FIELD_1_TARGET',
+      },
     ]);
   });
 });

--- a/src/widgets/operator-select.tsx
+++ b/src/widgets/operator-select.tsx
@@ -7,9 +7,11 @@ import { findNodeById } from '../history/find-node-by-id';
 import { applyDataUpdate } from '../utils/apply-data-update.util';
 import { createRuleValueForFieldOperator } from '../utils/create-rule-value-for-field-operator.util';
 import { emitBuilderFieldChange } from '../utils/emit-builder-field-change.util';
+import { getCompatibleValueFields, supportsFieldComparisonForOperator } from '../utils/field-comparison-support';
 import { isNormalizedGroupNode } from '../utils/is-normalized-group-node.util';
 import { isRangeOperator } from '../utils/is-range-operator.util';
 import { operatorRequiresValue } from '../utils/operator-requires-value.util';
+import { getRuleValueSource } from '../utils/rule-value-source';
 import { updateItem } from '../utils/update-item.util';
 
 export interface IOperatorSelectValuesProps {
@@ -65,11 +67,16 @@ export const OperatorSelect: FC<IOperatorSelectProps> = ({
       return;
     }
 
+    const currentValueSource = getRuleValueSource(currentRule);
     const getNextRuleValue = () => {
       const nextRequiresValue = operatorRequiresValue(value);
       const currentRequiresValue = operatorRequiresValue(currentRule.operator);
 
       if (!nextRequiresValue) {
+        return undefined;
+      }
+
+      if (currentValueSource === 'field') {
         return undefined;
       }
 
@@ -83,6 +90,16 @@ export const OperatorSelect: FC<IOperatorSelectProps> = ({
       return currentRule.value;
     };
     const nextRuleValue = getNextRuleValue();
+    const canKeepFieldComparison =
+      currentValueSource === 'field' &&
+      supportsFieldComparisonForOperator(nextField, value);
+    const shouldPreserveUnsupportedFieldComparison =
+      currentValueSource === 'field' && operatorRequiresValue(value);
+    const nextCompatibleFields = getCompatibleValueFields(fields, nextField, value);
+    const hasRuleValueChanged =
+      nextRuleValue !== currentRule.value ||
+      currentValueSource !== 'value' ||
+      typeof currentRule.valueField !== 'undefined';
 
     if (!dispatchAction && setData && onChange) {
       const nextData = updateItem(data, id, item => {
@@ -91,8 +108,26 @@ export const OperatorSelect: FC<IOperatorSelectProps> = ({
         }
 
         if (typeof nextRuleValue === 'undefined') {
-          delete item.value;
+          if (canKeepFieldComparison && nextCompatibleFields.length > 0) {
+            item.valueSource = 'field';
+            item.valueField =
+              currentRule.valueField &&
+              nextCompatibleFields.some(fieldItem => fieldItem.field === currentRule.valueField)
+                ? currentRule.valueField
+                : nextCompatibleFields[0].field;
+            delete item.value;
+          } else if (shouldPreserveUnsupportedFieldComparison) {
+            item.valueSource = 'field';
+            item.valueField = currentRule.valueField;
+            delete item.value;
+          } else {
+            item.valueSource = 'value';
+            delete item.valueField;
+            delete item.value;
+          }
         } else {
+          item.valueSource = 'value';
+          delete item.valueField;
           item.value = nextRuleValue;
         }
 
@@ -111,7 +146,7 @@ export const OperatorSelect: FC<IOperatorSelectProps> = ({
       if (
         nextRule &&
         !isNormalizedGroupNode(nextRule) &&
-        nextRule.value !== currentRule.value
+        hasRuleValueChanged
       ) {
         emitBuilderFieldChange(
           onFieldChange,
@@ -119,7 +154,13 @@ export const OperatorSelect: FC<IOperatorSelectProps> = ({
           id,
           currentRule.field,
           currentRule.value,
-          nextRule.value
+          nextRule.value,
+          {
+            previousValueSource: currentRule.valueSource ?? 'value',
+            previousValueField: currentRule.valueField,
+            valueSource: nextRule.valueSource ?? 'value',
+            valueField: nextRule.valueField,
+          }
         );
       }
       return;
@@ -131,15 +172,33 @@ export const OperatorSelect: FC<IOperatorSelectProps> = ({
 
     const nextRule = { ...currentRule };
     if (typeof nextRuleValue === 'undefined') {
-      delete nextRule.value;
+      if (canKeepFieldComparison && nextCompatibleFields.length > 0) {
+        nextRule.valueSource = 'field';
+        nextRule.valueField =
+          currentRule.valueField &&
+          nextCompatibleFields.some(fieldItem => fieldItem.field === currentRule.valueField)
+            ? currentRule.valueField
+            : nextCompatibleFields[0].field;
+        delete nextRule.value;
+      } else if (shouldPreserveUnsupportedFieldComparison) {
+        nextRule.valueSource = 'field';
+        nextRule.valueField = currentRule.valueField;
+        delete nextRule.value;
+      } else {
+        nextRule.valueSource = 'value';
+        delete nextRule.valueField;
+        delete nextRule.value;
+      }
     } else {
+      nextRule.valueSource = 'value';
+      delete nextRule.valueField;
       nextRule.value = nextRuleValue;
     }
 
     nextRule.operator = value;
 
     dispatchAction(createReplaceNodeAction(id, nextRule));
-    if (nextRule.value !== currentRule.value) {
+    if (hasRuleValueChanged) {
       emitBuilderFieldChange(
         onFieldChange,
         updateItem(data, id, item => {
@@ -148,12 +207,25 @@ export const OperatorSelect: FC<IOperatorSelectProps> = ({
           }
 
           item.operator = nextRule.operator;
-          item.value = nextRule.value;
+          item.valueSource = nextRule.valueSource;
+          if (nextRule.valueSource === 'field') {
+            item.valueField = nextRule.valueField;
+            delete item.value;
+          } else {
+            delete item.valueField;
+            item.value = nextRule.value;
+          }
         }),
         id,
         currentRule.field,
         currentRule.value,
-        nextRule.value
+        nextRule.value,
+        {
+          previousValueSource: currentRule.valueSource ?? 'value',
+          previousValueField: currentRule.valueField,
+          valueSource: nextRule.valueSource ?? 'value',
+          valueField: nextRule.valueField,
+        }
       );
     }
   };

--- a/src/widgets/select-multi/select-multi.tsx
+++ b/src/widgets/select-multi/select-multi.tsx
@@ -63,6 +63,8 @@ export const SelectMulti: FC<ISelectMultiProps> = ({
           return;
         }
 
+        item.valueSource = 'value';
+        delete item.valueField;
         item.value = nextValue;
       });
 
@@ -79,7 +81,12 @@ export const SelectMulti: FC<ISelectMultiProps> = ({
         id,
         currentRule.field,
         currentRule.value,
-        nextValue
+        nextValue,
+        {
+          previousValueSource: currentRule.valueSource ?? 'value',
+          previousValueField: currentRule.valueField,
+          valueSource: 'value',
+        }
       );
       return;
     }
@@ -96,7 +103,9 @@ export const SelectMulti: FC<ISelectMultiProps> = ({
     dispatchAction(
       createReplaceNodeAction(id, {
         ...currentRule,
+        valueSource: 'value',
         value: nextValue,
+        valueField: undefined,
       })
     );
     emitBuilderFieldChange(
@@ -106,12 +115,19 @@ export const SelectMulti: FC<ISelectMultiProps> = ({
           return;
         }
 
+        item.valueSource = 'value';
+        delete item.valueField;
         item.value = nextValue;
       }),
       id,
       currentRule.field,
       currentRule.value,
-      nextValue
+      nextValue,
+      {
+        previousValueSource: currentRule.valueSource ?? 'value',
+        previousValueField: currentRule.valueField,
+        valueSource: 'value',
+      }
     );
   };
 
@@ -139,6 +155,8 @@ export const SelectMulti: FC<ISelectMultiProps> = ({
           return;
         }
 
+        item.valueSource = 'value';
+        delete item.valueField;
         item.value = nextValue;
       });
 
@@ -155,7 +173,12 @@ export const SelectMulti: FC<ISelectMultiProps> = ({
         id,
         currentRule.field,
         currentRule.value,
-        nextValue
+        nextValue,
+        {
+          previousValueSource: currentRule.valueSource ?? 'value',
+          previousValueField: currentRule.valueField,
+          valueSource: 'value',
+        }
       );
       return;
     }
@@ -171,7 +194,9 @@ export const SelectMulti: FC<ISelectMultiProps> = ({
     dispatchAction(
       createReplaceNodeAction(id, {
         ...currentRule,
+        valueSource: 'value',
         value: nextValue,
+        valueField: undefined,
       })
     );
     emitBuilderFieldChange(
@@ -181,12 +206,19 @@ export const SelectMulti: FC<ISelectMultiProps> = ({
           return;
         }
 
+        item.valueSource = 'value';
+        delete item.valueField;
         item.value = nextValue;
       }),
       id,
       currentRule.field,
       currentRule.value,
-      nextValue
+      nextValue,
+      {
+        previousValueSource: currentRule.valueSource ?? 'value',
+        previousValueField: currentRule.valueField,
+        valueSource: 'value',
+      }
     );
   };
 

--- a/src/widgets/select.test.tsx
+++ b/src/widgets/select.test.tsx
@@ -84,4 +84,58 @@ describe('#components/Widgets/Select', () => {
 
     expect(container.querySelector('[data-test="SelectMultiTrigger"]')).toBeTruthy();
   });
+
+  it('resets field-comparison rules back to literal mode in the dispatch path', () => {
+    const dispatchAction = jest.fn();
+    const onFieldChange = jest.fn();
+    const fieldComparisonData: any[] = [
+      {
+        id: 'test',
+        field: 'MOCK_FIELD',
+        operator: 'EQUAL',
+        valueSource: 'field',
+        valueField: 'OTHER_FIELD',
+      },
+    ];
+    const { container } = renderWithContext(
+      <Select id="test" selectedValue="" values={selectValues} />,
+      {
+        data: fieldComparisonData,
+        dispatchAction,
+        onFieldChange,
+      }
+    );
+
+    fireEvent.click(getByDataTest(container, 'SelectMultiTrigger'));
+    fireEvent.click(getByDataTest(container, 'SelectMultiOption[test]'));
+
+    expect(dispatchAction).toHaveBeenCalledWith({
+      type: 'replace-node',
+      nodeId: 'test',
+      node: {
+        id: 'test',
+        field: 'MOCK_FIELD',
+        operator: 'EQUAL',
+        valueSource: 'value',
+        value: 'test',
+        valueField: undefined,
+      },
+    });
+    expect(onFieldChange).toHaveBeenCalledWith(
+      expect.objectContaining({
+        previousValueSource: 'field',
+        previousValueField: 'OTHER_FIELD',
+        valueSource: 'value',
+        value: 'test',
+        data: [
+          {
+            field: 'MOCK_FIELD',
+            operator: 'EQUAL',
+            valueSource: 'value',
+            value: 'test',
+          },
+        ],
+      })
+    );
+  });
 });

--- a/src/widgets/select.tsx
+++ b/src/widgets/select.tsx
@@ -51,6 +51,8 @@ export const Select: FC<ISelectProps> = ({
           return;
         }
 
+        item.valueSource = 'value';
+        delete item.valueField;
         item.value = value;
       });
 
@@ -67,7 +69,12 @@ export const Select: FC<ISelectProps> = ({
         id,
         currentRule.field,
         currentRule.value,
-        value
+        value,
+        {
+          previousValueSource: currentRule.valueSource ?? 'value',
+          previousValueField: currentRule.valueField,
+          valueSource: 'value',
+        }
       );
       return;
     }
@@ -79,7 +86,9 @@ export const Select: FC<ISelectProps> = ({
     dispatchAction(
       createReplaceNodeAction(id, {
         ...currentRule,
+        valueSource: 'value',
         value,
+        valueField: undefined,
       })
     );
     emitBuilderFieldChange(
@@ -89,12 +98,19 @@ export const Select: FC<ISelectProps> = ({
           return;
         }
 
+        item.valueSource = 'value';
+        delete item.valueField;
         item.value = value;
       }),
       id,
       currentRule.field,
       currentRule.value,
-      value
+      value,
+      {
+        previousValueSource: currentRule.valueSource ?? 'value',
+        previousValueField: currentRule.valueField,
+        valueSource: 'value',
+      }
     );
   };
 

--- a/src/widgets/value-field-select.test.tsx
+++ b/src/widgets/value-field-select.test.tsx
@@ -1,0 +1,145 @@
+import React, { ReactElement } from 'react';
+import { fireEvent, render } from '@testing-library/react';
+import {
+  IBuilderComponentsProps,
+  IBuilderFieldProps,
+  defaultComponents,
+} from '../builder';
+import { BuilderContext } from '../builder-context';
+import { ValueFieldSelect } from './value-field-select';
+
+const components: IBuilderComponentsProps = defaultComponents;
+const fields: IBuilderFieldProps[] = [
+  { field: 'TEXT_A', label: 'Text A', type: 'TEXT', operators: ['EQUAL'] },
+  { field: 'TEXT_B', label: 'Text B', type: 'TEXT', operators: ['EQUAL'] },
+  { field: 'TEXT_C', label: 'Text C', type: 'TEXT', operators: ['EQUAL'] },
+];
+
+const getByDataTest = (container: HTMLElement, value: string): HTMLElement => {
+  const element = container.querySelector(`[data-test="${value}"]`);
+
+  if (!element) {
+    throw new Error(`Unable to find element with data-test="${value}"`);
+  }
+
+  return element as HTMLElement;
+};
+
+const renderWithContext = (
+  element: ReactElement,
+  overrides?: Partial<React.ComponentProps<typeof BuilderContext.Provider>['value']>
+) =>
+  render(
+    <BuilderContext.Provider
+      value={{
+        components,
+        fields,
+        data: [
+          {
+            id: 'test',
+            field: 'TEXT_A',
+            operator: 'EQUAL',
+            valueSource: 'field',
+            valueField: 'TEXT_B',
+          },
+        ] as any,
+        strings: { form: {} },
+        setData: jest.fn(),
+        onChange: jest.fn(),
+        readOnly: false,
+        ...overrides,
+      }}
+    >
+      {element}
+    </BuilderContext.Provider>
+  );
+
+describe('#components/Widgets/ValueFieldSelect', () => {
+  it('changes the referenced comparison field', () => {
+    const onChange = jest.fn();
+    const onFieldChange = jest.fn();
+    const { container } = renderWithContext(
+      <ValueFieldSelect
+        id="test"
+        selectedValue="TEXT_B"
+        compatibleFields={[fields[1], fields[2]]}
+      />,
+      { onChange, onFieldChange }
+    );
+
+    fireEvent.click(getByDataTest(container, 'SelectMultiTrigger'));
+    fireEvent.click(getByDataTest(container, 'SelectMultiOption[TEXT_C]'));
+
+    expect(onChange).toHaveBeenCalledWith([
+      {
+        id: 'test',
+        field: 'TEXT_A',
+        operator: 'EQUAL',
+        valueSource: 'field',
+        valueField: 'TEXT_C',
+      },
+    ]);
+    expect(onFieldChange).toHaveBeenCalledWith(
+      expect.objectContaining({
+        previousValueSource: 'field',
+        previousValueField: 'TEXT_B',
+        valueSource: 'field',
+        valueField: 'TEXT_C',
+      })
+    );
+  });
+
+  it('dispatches a replace action in the history-enabled path', () => {
+    const dispatchAction = jest.fn();
+    const onFieldChange = jest.fn();
+    const { container } = renderWithContext(
+      <ValueFieldSelect
+        id="test"
+        selectedValue="TEXT_B"
+        compatibleFields={[fields[1], fields[2]]}
+      />,
+      { dispatchAction, onFieldChange }
+    );
+
+    fireEvent.click(getByDataTest(container, 'SelectMultiTrigger'));
+    fireEvent.click(getByDataTest(container, 'SelectMultiOption[TEXT_C]'));
+
+    expect(dispatchAction).toHaveBeenCalledWith({
+      type: 'replace-node',
+      nodeId: 'test',
+      node: {
+        id: 'test',
+        field: 'TEXT_A',
+        operator: 'EQUAL',
+        valueSource: 'field',
+        valueField: 'TEXT_C',
+        value: undefined,
+      },
+    });
+    expect(onFieldChange).toHaveBeenCalledWith(
+      expect.objectContaining({
+        previousValueSource: 'field',
+        previousValueField: 'TEXT_B',
+        valueSource: 'field',
+        valueField: 'TEXT_C',
+      })
+    );
+  });
+
+  it('does not change the comparison field while read-only', () => {
+    const onChange = jest.fn();
+    const { container } = renderWithContext(
+      <ValueFieldSelect
+        id="test"
+        selectedValue="TEXT_B"
+        compatibleFields={[fields[1], fields[2]]}
+      />,
+      { onChange, readOnly: true }
+    );
+
+    fireEvent.click(getByDataTest(container, 'SelectMultiTrigger'));
+
+    expect(container.querySelector('[data-test="SelectMultiOption[TEXT_C]"]')).toBeNull();
+    expect(onChange).not.toHaveBeenCalled();
+  });
+});

--- a/src/widgets/value-field-select.tsx
+++ b/src/widgets/value-field-select.tsx
@@ -1,0 +1,133 @@
+import React, { FC, useContext } from 'react';
+import { IBuilderFieldProps } from '../builder';
+import { BuilderContext } from '../builder-context';
+import { Select as DefaultSelect } from '../form/select';
+import { createReplaceNodeAction } from '../history/create-replace-node-action';
+import { findNodeById } from '../history/find-node-by-id';
+import { applyDataUpdate } from '../utils/apply-data-update.util';
+import { emitBuilderFieldChange } from '../utils/emit-builder-field-change.util';
+import { isNormalizedGroupNode } from '../utils/is-normalized-group-node.util';
+import { updateItem } from '../utils/update-item.util';
+
+export interface IValueFieldSelectProps {
+  id: string;
+  selectedValue?: string;
+  compatibleFields: IBuilderFieldProps[];
+  disabled?: boolean;
+}
+
+export const ValueFieldSelect: FC<IValueFieldSelectProps> = ({
+  id,
+  selectedValue,
+  compatibleFields,
+  disabled = false,
+}) => {
+  const {
+    data,
+    setData,
+    onChange,
+    updateData,
+    dispatchAction,
+    components,
+    strings,
+    readOnly,
+    onFieldChange,
+  } = useContext(BuilderContext);
+  const Select = components.form?.Select || DefaultSelect;
+  const isDisabled = Boolean(readOnly || disabled);
+
+  const handleChange = (value: string) => {
+    if (isDisabled) {
+      return;
+    }
+
+    const currentRule = findNodeById(data, id);
+
+    if (!currentRule || isNormalizedGroupNode(currentRule)) {
+      return;
+    }
+
+    if (!dispatchAction && setData && onChange) {
+      const nextData = updateItem(data, id, item => {
+        if (isNormalizedGroupNode(item)) {
+          return;
+        }
+
+        item.valueSource = 'field';
+        item.valueField = value;
+        delete item.value;
+      });
+
+      applyDataUpdate(data, setData, onChange, () => nextData, updateData);
+      emitBuilderFieldChange(
+        onFieldChange,
+        nextData,
+        id,
+        currentRule.field,
+        currentRule.value,
+        undefined,
+        {
+          previousValueSource: currentRule.valueSource ?? 'value',
+          previousValueField: currentRule.valueField,
+          valueSource: 'field',
+          valueField: value,
+        }
+      );
+      return;
+    }
+
+    if (!dispatchAction) {
+      return;
+    }
+
+    dispatchAction(
+      createReplaceNodeAction(id, {
+        ...currentRule,
+        valueSource: 'field',
+        valueField: value,
+        value: undefined,
+      })
+    );
+    emitBuilderFieldChange(
+      onFieldChange,
+      updateItem(data, id, item => {
+        if (isNormalizedGroupNode(item)) {
+          return;
+        }
+
+        item.valueSource = 'field';
+        item.valueField = value;
+        delete item.value;
+      }),
+      id,
+      currentRule.field,
+      currentRule.value,
+      undefined,
+      {
+        previousValueSource: currentRule.valueSource ?? 'value',
+        previousValueField: currentRule.valueField,
+        valueSource: 'field',
+        valueField: value,
+      }
+    );
+  };
+
+  if (!strings.form) {
+    return null;
+  }
+
+  return (
+    <Select
+      id={`query-builder-rule-${id}-value-field`}
+      name={`query-builder-rule-${id}-value-field`}
+      values={compatibleFields.map(field => ({
+        value: field.field,
+        label: field.label,
+      }))}
+      selectedValue={selectedValue}
+      emptyValue={strings.form.selectField || 'Select field'}
+      onChange={handleChange}
+      disabled={isDisabled}
+    />
+  );
+};

--- a/src/widgets/value-source-select.test.tsx
+++ b/src/widgets/value-source-select.test.tsx
@@ -1,0 +1,159 @@
+import React, { ReactElement } from 'react';
+import { fireEvent, render } from '@testing-library/react';
+import {
+  IBuilderComponentsProps,
+  IBuilderFieldProps,
+  defaultComponents,
+} from '../builder';
+import { BuilderContext } from '../builder-context';
+import { ValueSourceSelect } from './value-source-select';
+
+const components: IBuilderComponentsProps = defaultComponents;
+const fields: IBuilderFieldProps[] = [
+  { field: 'TEXT_A', label: 'Text A', type: 'TEXT', operators: ['EQUAL'] },
+  { field: 'TEXT_B', label: 'Text B', type: 'TEXT', operators: ['EQUAL'] },
+];
+
+const getByDataTest = (container: HTMLElement, value: string): HTMLElement => {
+  const element = container.querySelector(`[data-test="${value}"]`);
+
+  if (!element) {
+    throw new Error(`Unable to find element with data-test="${value}"`);
+  }
+
+  return element as HTMLElement;
+};
+
+const renderWithContext = (
+  element: ReactElement,
+  overrides?: Partial<React.ComponentProps<typeof BuilderContext.Provider>['value']>
+) =>
+  render(
+    <BuilderContext.Provider
+      value={{
+        components,
+        fields,
+        data: [
+          {
+            id: 'test',
+            field: 'TEXT_A',
+            operator: 'EQUAL',
+            valueSource: 'value',
+            value: 'alpha',
+          },
+        ] as any,
+        strings: { form: {} },
+        setData: jest.fn(),
+        onChange: jest.fn(),
+        readOnly: false,
+        ...overrides,
+      }}
+    >
+      {element}
+    </BuilderContext.Provider>
+  );
+
+describe('#components/Widgets/ValueSourceSelect', () => {
+  it('switches a rule from literal to field comparison mode', () => {
+    const onChange = jest.fn();
+    const onFieldChange = jest.fn();
+    const { container } = renderWithContext(
+      <ValueSourceSelect
+        id="test"
+        field={fields[0]}
+        selectedValueSource="value"
+        compatibleFields={[fields[1]]}
+        fieldComparisonEnabled
+      />,
+      { onChange, onFieldChange }
+    );
+
+    fireEvent.click(getByDataTest(container, 'SelectMultiTrigger'));
+    fireEvent.click(getByDataTest(container, 'SelectMultiOption[field]'));
+
+    expect(onChange).toHaveBeenCalledWith([
+      {
+        id: 'test',
+        field: 'TEXT_A',
+        operator: 'EQUAL',
+        valueSource: 'field',
+        valueField: 'TEXT_B',
+      },
+    ]);
+    expect(onFieldChange).toHaveBeenCalledWith(
+      expect.objectContaining({
+        previousValue: 'alpha',
+        previousValueSource: 'value',
+        value: undefined,
+        valueSource: 'field',
+        valueField: 'TEXT_B',
+      })
+    );
+  });
+
+  it('switches a rule from field comparison mode back to literal mode', () => {
+    const onChange = jest.fn();
+    const onFieldChange = jest.fn();
+    const { container } = renderWithContext(
+      <ValueSourceSelect
+        id="test"
+        field={fields[0]}
+        selectedValueSource="field"
+        compatibleFields={[fields[1]]}
+        fieldComparisonEnabled
+      />,
+      {
+        data: [
+          {
+            id: 'test',
+            field: 'TEXT_A',
+            operator: 'EQUAL',
+            valueSource: 'field',
+            valueField: 'TEXT_B',
+          },
+        ] as any,
+        onChange,
+        onFieldChange,
+      }
+    );
+
+    fireEvent.click(getByDataTest(container, 'SelectMultiTrigger'));
+    fireEvent.click(getByDataTest(container, 'SelectMultiOption[value]'));
+
+    expect(onChange).toHaveBeenCalledWith([
+      {
+        id: 'test',
+        field: 'TEXT_A',
+        operator: 'EQUAL',
+        valueSource: 'value',
+        value: '',
+      },
+    ]);
+    expect(onFieldChange).toHaveBeenCalledWith(
+      expect.objectContaining({
+        previousValueSource: 'field',
+        previousValueField: 'TEXT_B',
+        valueSource: 'value',
+        value: '',
+      })
+    );
+  });
+
+  it('disables the field option when field comparisons are unavailable', () => {
+    const { container } = renderWithContext(
+      <ValueSourceSelect
+        id="test"
+        field={fields[0]}
+        selectedValueSource="value"
+        compatibleFields={[]}
+        fieldComparisonEnabled={false}
+      />
+    );
+
+    fireEvent.click(getByDataTest(container, 'SelectMultiTrigger'));
+
+    expect(
+      getByDataTest(container, 'SelectMultiOption[field]').hasAttribute('disabled')
+    ).toBe(true);
+  });
+});

--- a/src/widgets/value-source-select.tsx
+++ b/src/widgets/value-source-select.tsx
@@ -1,0 +1,174 @@
+import React, { FC, useContext } from 'react';
+import { IBuilderFieldProps } from '../builder';
+import { BuilderContext } from '../builder-context';
+import { Select as DefaultSelect } from '../form/select';
+import { createReplaceNodeAction } from '../history/create-replace-node-action';
+import { findNodeById } from '../history/find-node-by-id';
+import { applyDataUpdate } from '../utils/apply-data-update.util';
+import { createRuleValueForFieldOperator } from '../utils/create-rule-value-for-field-operator.util';
+import { emitBuilderFieldChange } from '../utils/emit-builder-field-change.util';
+import { isNormalizedGroupNode } from '../utils/is-normalized-group-node.util';
+import { QueryRuleValueSource } from '../utils/query-tree';
+import { updateItem } from '../utils/update-item.util';
+
+export interface IValueSourceSelectProps {
+  id: string;
+  field: IBuilderFieldProps;
+  selectedValueSource: QueryRuleValueSource;
+  compatibleFields: IBuilderFieldProps[];
+  fieldComparisonEnabled?: boolean;
+  disabled?: boolean;
+}
+
+export const ValueSourceSelect: FC<IValueSourceSelectProps> = ({
+  id,
+  field,
+  selectedValueSource,
+  compatibleFields,
+  fieldComparisonEnabled = true,
+  disabled = false,
+}) => {
+  const {
+    data,
+    setData,
+    onChange,
+    updateData,
+    dispatchAction,
+    components,
+    strings,
+    readOnly,
+    onFieldChange,
+  } = useContext(BuilderContext);
+  const Select = components.form?.Select || DefaultSelect;
+  const isDisabled = Boolean(readOnly || disabled);
+
+  const handleChange = (nextValueSource: QueryRuleValueSource) => {
+    if (isDisabled) {
+      return;
+    }
+
+    const currentRule = findNodeById(data, id);
+
+    if (!currentRule || isNormalizedGroupNode(currentRule)) {
+      return;
+    }
+
+    if (nextValueSource === 'field' && !fieldComparisonEnabled) {
+      return;
+    }
+
+    const nextRule =
+      nextValueSource === 'field'
+        ? compatibleFields[0]
+          ? {
+              ...currentRule,
+              valueSource: 'field' as const,
+              valueField: compatibleFields[0].field,
+              value: undefined,
+            }
+          : null
+        : {
+            ...currentRule,
+            valueSource: 'value' as const,
+            valueField: undefined,
+            value: createRuleValueForFieldOperator(field, currentRule.operator),
+          };
+
+    if (!nextRule) {
+      return;
+    }
+
+    if (!dispatchAction && setData && onChange) {
+      const nextData = updateItem(data, id, item => {
+        if (isNormalizedGroupNode(item)) {
+          return;
+        }
+
+        item.valueSource = nextRule.valueSource;
+        if (nextRule.valueSource === 'field') {
+          item.valueField = nextRule.valueField;
+          delete item.value;
+        } else {
+          delete item.valueField;
+          item.value = nextRule.value;
+        }
+      });
+
+      applyDataUpdate(data, setData, onChange, () => nextData, updateData);
+      emitBuilderFieldChange(
+        onFieldChange,
+        nextData,
+        id,
+        currentRule.field,
+        currentRule.value,
+        nextRule.value,
+        {
+          previousValueSource: currentRule.valueSource ?? 'value',
+          previousValueField: currentRule.valueField,
+          valueSource: nextRule.valueSource,
+          valueField: nextRule.valueField,
+        }
+      );
+      return;
+    }
+
+    if (!dispatchAction) {
+      return;
+    }
+
+    dispatchAction(createReplaceNodeAction(id, nextRule));
+    emitBuilderFieldChange(
+      onFieldChange,
+      updateItem(data, id, item => {
+        if (isNormalizedGroupNode(item)) {
+          return;
+        }
+
+        item.valueSource = nextRule.valueSource;
+        if (nextRule.valueSource === 'field') {
+          item.valueField = nextRule.valueField;
+          delete item.value;
+        } else {
+          delete item.valueField;
+          item.value = nextRule.value;
+        }
+      }),
+      id,
+      currentRule.field,
+      currentRule.value,
+      nextRule.value,
+      {
+        previousValueSource: currentRule.valueSource ?? 'value',
+        previousValueField: currentRule.valueField,
+        valueSource: nextRule.valueSource,
+        valueField: nextRule.valueField,
+      }
+    );
+  };
+
+  if (!strings.form) {
+    return null;
+  }
+
+  return (
+    <Select
+      id={`query-builder-rule-${id}-value-source`}
+      name={`query-builder-rule-${id}-value-source`}
+      values={[
+        {
+          value: 'value',
+          label: strings.form.compareToValue || 'Value',
+        },
+        {
+          value: 'field',
+          label: strings.form.compareToField || 'Field',
+          disabled: !fieldComparisonEnabled || compatibleFields.length === 0,
+        },
+      ]}
+      selectedValue={selectedValueSource}
+      emptyValue={strings.form.compareToValue}
+      onChange={handleChange}
+      disabled={isDisabled}
+    />
+  );
+};


### PR DESCRIPTION
- Added field-to-field comparison support to the builder, validation, text mode, parsers, and formatters
- Added support for field-comparison metadata, value sources, and value-field rule data
- Added example and demo coverage for field-to-field comparisons
- Documented field-to-field comparisons in the README, Documentation, and API sections
- Added a dedicated Getting Started page for field comparisons
- Restructured Parsing and Formatting docs to present field comparisons separately from general format usage
- Updated the parsing playground data so all formats could be tested without field-to-field comparisons by default
- Reordered Getting Started documentation pages to better match the recommended reading flow