### PR TITLE
feat: Added cookie consent for analytics

### DIFF
--- a/.codex/TASKS.md
+++ b/.codex/TASKS.md
@@ -285,3 +285,32 @@ This backlog is derived from `AGENTS.md`. Keep tasks incremental and update stat
 - Build the example website with the GitHub Pages URL and confirm the generated
   HTML contains no Google Tag Manager markup.
 - Run Prettier on all modified code.
+
+### T005 - Add cookie consent for Google Analytics
+
+**Status:** `[x]` Done
+
+**Goal:** Require an explicit visitor choice before Google Analytics storage is
+enabled on the production website.
+
+**Scope:**
+
+- Add a cookie consent bar using `react-cookie-consent`.
+- Default Google Tag Manager consent to denied before the container loads.
+- Update Google consent state when analytics cookies are accepted or declined.
+- Keep the consent UI and analytics consent utilities focused and isolated.
+
+**Acceptance criteria:**
+
+- New visitors can accept or decline analytics cookies from an accessible consent
+  bar.
+- Analytics storage remains denied until consent is accepted.
+- A saved choice is restored without prompting the visitor on every page load.
+- Google Tag Manager remains restricted to the production website build.
+- The example website build succeeds.
+
+**Verification:**
+
+- Run focused consent tests.
+- Build the example website and inspect the production consent-mode markup.
+- Run Prettier on all modified code.

--- a/example/package.json
+++ b/example/package.json
@@ -29,6 +29,7 @@
     "minisearch": "^7.2.0",
     "prism-react-renderer": "^2.4.1",
     "react": "^19.2.6",
+    "react-cookie-consent": "^10.0.1",
     "react-dom": "^19.2.6",
     "react-hook-form": "7.81.0",
     "react-router-dom": "^7.15.1",

--- a/example/src/components/cookie-consent-banner.styles.ts
+++ b/example/src/components/cookie-consent-banner.styles.ts
@@ -1,0 +1,36 @@
+import type { CSSProperties } from 'react';
+import { siteTheme } from '../constants/site-theme';
+
+export const cookieConsentContainerStyle: CSSProperties = {
+  alignItems: 'center',
+  background: '#0f172a',
+  boxShadow: '0 -12px 36px rgba(15, 23, 42, 0.18)',
+  color: '#f8fafc',
+  gap: '1rem',
+  padding: '0.85rem max(1rem, calc((100vw - 1320px) / 2 + 1.5rem))',
+};
+
+export const cookieConsentContentStyle: CSSProperties = {
+  flex: '1 1 420px',
+  margin: 0,
+};
+
+export const cookieConsentButtonStyle: CSSProperties = {
+  background: siteTheme.primaryLight,
+  border: 0,
+  borderRadius: '999px',
+  color: '#ffffff',
+  cursor: 'pointer',
+  fontFamily: 'inherit',
+  fontSize: '0.95rem',
+  fontWeight: 700,
+  margin: '0.35rem',
+  padding: '0.7rem 1rem',
+};
+
+export const cookieConsentDeclineButtonStyle: CSSProperties = {
+  ...cookieConsentButtonStyle,
+  background: 'transparent',
+  border: '1px solid #94a3b8',
+  color: '#f8fafc',
+};

--- a/example/src/components/cookie-consent-banner.tsx
+++ b/example/src/components/cookie-consent-banner.tsx
@@ -1,0 +1,68 @@
+import * as React from 'react';
+import CookieConsent, { getCookieConsentValue } from 'react-cookie-consent';
+import {
+  GOOGLE_ANALYTICS_CONSENT_COOKIE,
+  GOOGLE_ANALYTICS_CONSENT_DENIED,
+  GOOGLE_ANALYTICS_CONSENT_GRANTED,
+} from '../constants/google-analytics-consent';
+import { isGoogleAnalyticsEnabled } from '../utils/is-google-analytics-enabled.util';
+import { updateGoogleAnalyticsConsent } from '../utils/update-google-analytics-consent.util';
+import {
+  cookieConsentButtonStyle,
+  cookieConsentContainerStyle,
+  cookieConsentContentStyle,
+  cookieConsentDeclineButtonStyle,
+} from './cookie-consent-banner.styles';
+
+const isAnalyticsEnabled = isGoogleAnalyticsEnabled(
+  import.meta.env.VITE_SITE_URL
+);
+
+export const CookieConsentBanner: React.FC = () => {
+  React.useEffect(() => {
+    if (!isAnalyticsEnabled) {
+      return;
+    }
+
+    const savedConsent = getCookieConsentValue(GOOGLE_ANALYTICS_CONSENT_COOKIE);
+
+    if (savedConsent !== undefined) {
+      updateGoogleAnalyticsConsent(
+        savedConsent === GOOGLE_ANALYTICS_CONSENT_GRANTED
+      );
+    }
+  }, []);
+
+  if (!isAnalyticsEnabled) {
+    return null;
+  }
+
+  return (
+    <CookieConsent
+      ariaAcceptLabel="Accept analytics cookies"
+      ariaDeclineLabel="Decline analytics cookies"
+      buttonStyle={cookieConsentButtonStyle}
+      buttonText="Accept analytics"
+      contentStyle={cookieConsentContentStyle}
+      cookieName={GOOGLE_ANALYTICS_CONSENT_COOKIE}
+      cookieValue={GOOGLE_ANALYTICS_CONSENT_GRANTED}
+      customContainerAttributes={{
+        'aria-label': 'Analytics cookie consent',
+        role: 'region',
+      }}
+      declineButtonStyle={cookieConsentDeclineButtonStyle}
+      declineButtonText="Decline"
+      declineCookieValue={GOOGLE_ANALYTICS_CONSENT_DENIED}
+      enableDeclineButton
+      expires={365}
+      location="bottom"
+      onAccept={() => updateGoogleAnalyticsConsent(true)}
+      onDecline={() => updateGoogleAnalyticsConsent(false)}
+      sameSite="strict"
+      style={cookieConsentContainerStyle}
+    >
+      We use optional analytics cookies to understand how the documentation is
+      used and improve it. You can accept or decline them.
+    </CookieConsent>
+  );
+};

--- a/example/src/components/site-shell.tsx
+++ b/example/src/components/site-shell.tsx
@@ -2,10 +2,16 @@ import * as React from 'react';
 import styled, { createGlobalStyle } from 'styled-components';
 import { NavLink, Outlet, useLocation } from 'react-router-dom';
 import { colors } from '../../../src';
-import { GITHUB_URL, NPM_URL, SITE_NAME, TOP_LEVEL_NAV } from '../constants/site-constants';
+import {
+  GITHUB_URL,
+  NPM_URL,
+  SITE_NAME,
+  TOP_LEVEL_NAV,
+} from '../constants/site-constants';
 import { siteTheme } from '../constants/site-theme';
 import { CloseIcon, GithubIcon, MenuIcon, NpmIcon } from './icons';
 import { HeaderSearch } from './header-search';
+import { CookieConsentBanner } from './cookie-consent-banner';
 
 const GlobalStyle = createGlobalStyle`
   :root {
@@ -353,13 +359,15 @@ export const SiteShell: React.FC = () => {
               <ReactText>React</ReactText>
               <QueryBuilderText>Query Builder</QueryBuilderText>
             </BrandText>
-            <VersionBadge aria-label="Documentation version">Docs v1</VersionBadge>
+            <VersionBadge aria-label="Documentation version">
+              Docs v1
+            </VersionBadge>
           </Brand>
 
           <Right>
             <DesktopOnly>
               <Nav>
-                {TOP_LEVEL_NAV.map(item => (
+                {TOP_LEVEL_NAV.map((item) => (
                   <NavItem key={item.to} to={item.to} end={item.to === '/'}>
                     {item.label}
                   </NavItem>
@@ -372,10 +380,20 @@ export const SiteShell: React.FC = () => {
             </DesktopOnly>
 
             <MobileActions>
-              <IconLink href={GITHUB_URL} target="_blank" rel="noopener noreferrer" aria-label="GitHub">
+              <IconLink
+                href={GITHUB_URL}
+                target="_blank"
+                rel="noopener noreferrer"
+                aria-label="GitHub"
+              >
                 <GithubIcon />
               </IconLink>
-              <IconLink href={NPM_URL} target="_blank" rel="noopener noreferrer" aria-label="npm">
+              <IconLink
+                href={NPM_URL}
+                target="_blank"
+                rel="noopener noreferrer"
+                aria-label="npm"
+              >
                 <NpmIcon />
               </IconLink>
               <MobileMenuTrigger
@@ -391,10 +409,20 @@ export const SiteShell: React.FC = () => {
             </MobileActions>
 
             <DesktopOnly>
-              <IconLink href={GITHUB_URL} target="_blank" rel="noopener noreferrer" aria-label="GitHub">
+              <IconLink
+                href={GITHUB_URL}
+                target="_blank"
+                rel="noopener noreferrer"
+                aria-label="GitHub"
+              >
                 <GithubIcon />
               </IconLink>
-              <IconLink href={NPM_URL} target="_blank" rel="noopener noreferrer" aria-label="npm">
+              <IconLink
+                href={NPM_URL}
+                target="_blank"
+                rel="noopener noreferrer"
+                aria-label="npm"
+              >
                 <NpmIcon />
               </IconLink>
             </DesktopOnly>
@@ -408,7 +436,11 @@ export const SiteShell: React.FC = () => {
         $open={mobileMenuOpen}
         onClick={() => setMobileMenuOpen(false)}
       />
-      <MobilePanel id="mobile-site-panel" $open={mobileMenuOpen} aria-hidden={!mobileMenuOpen}>
+      <MobilePanel
+        id="mobile-site-panel"
+        $open={mobileMenuOpen}
+        aria-hidden={!mobileMenuOpen}
+      >
         <MobilePanelContent>
           <MobilePanelHeader>
             <MenuButton
@@ -423,7 +455,7 @@ export const SiteShell: React.FC = () => {
             <HeaderSearch />
           </MobileSearchWrap>
           <MobileNav>
-            {TOP_LEVEL_NAV.map(item => (
+            {TOP_LEVEL_NAV.map((item) => (
               <MobileNavItem key={item.to} to={item.to} end={item.to === '/'}>
                 {item.label}
               </MobileNavItem>
@@ -436,9 +468,10 @@ export const SiteShell: React.FC = () => {
         <Outlet />
       </Main>
       <Footer>
-        &copy; Vojtěch Václav Porteš {year} - All library contents are available under the
-        MIT license.
+        &copy; Vojtěch Václav Porteš {year} - All library contents are available
+        under the MIT license.
       </Footer>
+      <CookieConsentBanner />
     </Page>
   );
 };

--- a/example/src/constants/google-analytics-consent.ts
+++ b/example/src/constants/google-analytics-consent.ts
@@ -1,0 +1,4 @@
+export const GOOGLE_ANALYTICS_CONSENT_COOKIE = 'rqb-analytics-consent';
+export const GOOGLE_ANALYTICS_CONSENT_GRANTED = 'granted';
+export const GOOGLE_ANALYTICS_CONSENT_DENIED = 'denied';
+export const GOOGLE_ANALYTICS_HOSTNAME = 'www.react-query-builder.com';

--- a/example/src/utils/is-google-analytics-enabled.util.test.ts
+++ b/example/src/utils/is-google-analytics-enabled.util.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from 'vitest';
+import { isGoogleAnalyticsEnabled } from './is-google-analytics-enabled.util';
+
+describe('isGoogleAnalyticsEnabled', () => {
+  it('enables analytics only for the production website hostname', () => {
+    expect(
+      isGoogleAnalyticsEnabled('https://www.react-query-builder.com/docs')
+    ).toBe(true);
+    expect(isGoogleAnalyticsEnabled('https://react-query-builder.com')).toBe(
+      false
+    );
+    expect(
+      isGoogleAnalyticsEnabled(
+        'https://vojtechportes.github.io/react-query-builder/'
+      )
+    ).toBe(false);
+  });
+
+  it('disables analytics for missing or invalid URLs', () => {
+    expect(isGoogleAnalyticsEnabled(undefined)).toBe(false);
+    expect(isGoogleAnalyticsEnabled('not a URL')).toBe(false);
+  });
+});

--- a/example/src/utils/is-google-analytics-enabled.util.ts
+++ b/example/src/utils/is-google-analytics-enabled.util.ts
@@ -1,0 +1,11 @@
+import { GOOGLE_ANALYTICS_HOSTNAME } from '../constants/google-analytics-consent';
+
+export const isGoogleAnalyticsEnabled = (
+  siteUrl: string | undefined
+): boolean => {
+  try {
+    return new URL(siteUrl ?? '').hostname === GOOGLE_ANALYTICS_HOSTNAME;
+  } catch {
+    return false;
+  }
+};

--- a/example/src/utils/update-google-analytics-consent.util.test.ts
+++ b/example/src/utils/update-google-analytics-consent.util.test.ts
@@ -1,0 +1,32 @@
+/* @vitest-environment jsdom */
+
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { updateGoogleAnalyticsConsent } from './update-google-analytics-consent.util';
+
+type GoogleTagWindow = Window & {
+  gtag?: ReturnType<typeof vi.fn>;
+};
+
+afterEach(() => {
+  delete (window as GoogleTagWindow).gtag;
+});
+
+describe('updateGoogleAnalyticsConsent', () => {
+  it.each([
+    [true, 'granted'],
+    [false, 'denied'],
+  ] as const)('updates analytics storage to %s', (isGranted, value) => {
+    const gtag = vi.fn();
+    (window as GoogleTagWindow).gtag = gtag;
+
+    updateGoogleAnalyticsConsent(isGranted);
+
+    expect(gtag).toHaveBeenCalledWith('consent', 'update', {
+      analytics_storage: value,
+    });
+  });
+
+  it('does nothing when Google Tag Manager is unavailable', () => {
+    expect(() => updateGoogleAnalyticsConsent(true)).not.toThrow();
+  });
+});

--- a/example/src/utils/update-google-analytics-consent.util.ts
+++ b/example/src/utils/update-google-analytics-consent.util.ts
@@ -1,0 +1,13 @@
+type GoogleTagWindow = Window & {
+  gtag?: (
+    command: 'consent',
+    action: 'update',
+    consent: { analytics_storage: 'denied' | 'granted' }
+  ) => void;
+};
+
+export const updateGoogleAnalyticsConsent = (isGranted: boolean): void => {
+  (window as GoogleTagWindow).gtag?.('consent', 'update', {
+    analytics_storage: isGranted ? 'granted' : 'denied',
+  });
+};

--- a/example/vite-plugins/create-google-tag-manager-plugin.ts
+++ b/example/vite-plugins/create-google-tag-manager-plugin.ts
@@ -3,6 +3,16 @@ import type { Plugin } from 'vite';
 const GOOGLE_TAG_MANAGER_HOSTNAME = 'www.react-query-builder.com';
 const GOOGLE_TAG_MANAGER_ID = 'GTM-WPZDH54F';
 
+const GOOGLE_CONSENT_DEFAULT_SCRIPT = `window.dataLayer=window.dataLayer||[];
+function gtag(){dataLayer.push(arguments);}
+gtag('consent','default',{
+  ad_storage:'denied',
+  analytics_storage:'denied',
+  ad_user_data:'denied',
+  ad_personalization:'denied',
+  wait_for_update:500
+});`;
+
 export const createGoogleTagManagerPlugin = (
   siteUrl: string | undefined
 ): Plugin => {
@@ -26,7 +36,8 @@ export const createGoogleTagManagerPlugin = (
         return [
           {
             tag: 'script',
-            children: `(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+            children: `${GOOGLE_CONSENT_DEFAULT_SCRIPT}
+(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
 new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
 j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
 'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@vojtechportes/react-query-builder",
-  "version": "1.31.0",
+  "version": "1.31.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@vojtechportes/react-query-builder",
-      "version": "1.31.0",
+      "version": "1.31.1",
       "license": "MIT",
       "workspaces": [
         "example"
@@ -128,18 +128,19 @@
         "@mantine/hooks": "^9.2.2",
         "@mui/icons-material": "^9.0.1",
         "@mui/material": "^9.0.1",
-        "@mui/x-data-grid": "^9.9.0",
+        "@mui/x-data-grid": "9.9.0",
         "@radix-ui/react-icons": "^1.3.2",
         "@radix-ui/themes": "^1.1.2",
-        "@tanstack/react-table": "^8.21.3",
-        "ag-grid-community": "^36.0.0",
-        "ag-grid-react": "^36.0.0",
+        "@tanstack/react-table": "8.21.3",
+        "ag-grid-community": "36.0.0",
+        "ag-grid-react": "36.0.0",
         "antd": "^6.0.0",
         "minisearch": "^7.2.0",
         "prism-react-renderer": "^2.4.1",
         "react": "^19.2.6",
+        "react-cookie-consent": "^10.0.1",
         "react-dom": "^19.2.6",
-        "react-hook-form": "^7.81.0",
+        "react-hook-form": "7.81.0",
         "react-router-dom": "^7.15.1",
         "styled-components": "^6.4.2"
       },
@@ -13014,6 +13015,12 @@
         "node": ">=6"
       }
     },
+    "node_modules/js-cookie": {
+      "version": "3.0.8",
+      "resolved": "https://registry.npmjs.org/js-cookie/-/js-cookie-3.0.8.tgz",
+      "integrity": "sha512-yeJd4aNAdYZQjaon2bpD/Gb0B/omw7HQOsynXXcOiWVCacbBcPlgn8S/d1X6blFSaHao7ozqtW7NZW19xpCtIw==",
+      "license": "MIT"
+    },
     "node_modules/js-tokens": {
       "version": "4.0.0",
       "license": "MIT"
@@ -14233,6 +14240,22 @@
       },
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-cookie-consent": {
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/react-cookie-consent/-/react-cookie-consent-10.0.1.tgz",
+      "integrity": "sha512-qgU7Kr+x9/feKZxaIJbMT+R/xD1lnAQy9MzD4yLooVrkhoUR7XFc8Xv8M+GDQYcjoYh6uszslLGo1k+eU2VLtw==",
+      "license": "MIT",
+      "dependencies": {
+        "js-cookie": "^3.0.5"
+      },
+      "engines": {
+        "node": ">=20.16"
+      },
+      "peerDependencies": {
+        "react": ">=18",
+        "react-dom": ">=18"
       }
     },
     "node_modules/react-dom": {


### PR DESCRIPTION
- Added a production-only analytics cookie consent banner
- Defaulted Google Tag Manager consent to denied
- Restored and applied saved analytics consent choices
- Added focused consent tests and backlog tracking