### PR TITLE
feat: Improved MUI adapter density and layout consistency

### DIFF
--- a/.codex/TASKS.md
+++ b/.codex/TASKS.md
@@ -1,4 +1,4 @@
-This backlog is derived from `AGENTS.md`. Keep tasks incremental and update statuses as work lands.
+﻿This backlog is derived from `AGENTS.md`. Keep tasks incremental and update statuses as work lands.
 
 ## Status Legend
 
@@ -314,3 +314,34 @@ enabled on the production website.
 - Run focused consent tests.
 - Build the example website and inspect the production consent-mode markup.
 - Run Prettier on all modified code.
+### T006 - Improve MUI adapter density and isolate demo styles
+
+**Status:** `[x]` Done
+
+**Goal:** Make the MUI adapter use consistent 32px-high controls with 14px typography and prevent the example website's styles from affecting MUI demo components.
+
+**Scope:**
+
+- Use MUI's smallest native variants and enforce a 32px height with 14px typography for single-line adapter inputs, selects, and buttons; align switches within the same control row while preserving MUI's native small geometry.
+- Render the NOT, AND, and OR controls as a small primary MUI toggle button group while preserving independent negation and combinator behavior.
+- Remove adapter sizing overrides that enlarge native small controls.
+- Use integer group-body spacing and vertically center root and nested group-header controls.
+- Isolate MUI demo rendering from inherited example-site typography and control styles.
+- Add focused tests for compact variants, toggle grouping, and interaction behavior.
+
+**Acceptance criteria:**
+
+- MUI adapter single-line form and action controls render at 32px high with 14px typography in both v7 and v9 mappings, while switches retain MUI small-size geometry.
+- NOT, AND, and OR render as small primary MUI toggle buttons in one group.
+- Toggling NOT does not change AND or OR, and changing AND or OR does not change NOT.
+- Disabled and read-only toggle behavior remains intact.
+- Root and nested MUI group headers use consistent integer vertical positioning for their controls.
+- Example-site styles do not override the MUI demo's component baseline.
+- No public Builder or adapter API changes are introduced.
+
+**Verification:**
+
+- Run focused MUI adapter tests.
+- Run lint, library build, and example build.
+- Run Prettier on all modified code and task files.
+- Review the final diff against repository structure and testing rules.

--- a/example/src/components/demo-playground.tsx
+++ b/example/src/components/demo-playground.tsx
@@ -24,6 +24,7 @@ import {
 } from '../constants/demo-data';
 import { siteTheme } from '../constants/site-theme';
 import { BuilderSurface } from './builder-surface';
+import { MuiBuilderSurface } from './mui-builder-surface';
 import {
   formatLabels,
   formatBuilderSource,
@@ -302,6 +303,7 @@ export const DemoPlayground: React.FC<IDemoPlaygroundProps> = ({
   const isFluentUiMode = customizationMode === 'fluentui';
   const isRadixMode = customizationMode === 'radix';
   const isBootstrapMode = customizationMode === 'bootstrap';
+  const BuilderDemoSurface = isMuiMode ? MuiBuilderSurface : BuilderSurface;
   const usesAdapterMode =
     isMuiMode ||
     isAntdMode ||
@@ -733,7 +735,7 @@ export const DemoPlayground: React.FC<IDemoPlaygroundProps> = ({
               </BuilderSurface>
             </>
           ) : (
-            <BuilderSurface
+            <BuilderDemoSurface
               className={isBootstrapMode ? bootstrapScopeClassName : undefined}
             >
               {isBootstrapMode ? <style>{scopedBootstrapStyles}</style> : null}
@@ -754,7 +756,7 @@ export const DemoPlayground: React.FC<IDemoPlaygroundProps> = ({
                   <Builder {...builderProps} />
                 </ThemeProvider>
               )}
-            </BuilderSurface>
+            </BuilderDemoSurface>
           )}
         </BuilderCard>
 

--- a/example/src/components/mui-builder-surface.test.tsx
+++ b/example/src/components/mui-builder-surface.test.tsx
@@ -1,0 +1,30 @@
+/* @vitest-environment jsdom */
+
+import * as React from 'react';
+import { act } from 'react';
+import { createRoot } from 'react-dom/client';
+import { expect, it } from 'vitest';
+import { MuiBuilderSurface } from './mui-builder-surface';
+
+(
+  globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT: boolean }
+).IS_REACT_ACT_ENVIRONMENT = true;
+
+it('isolates MUI demo content with a scoped Material UI baseline', () => {
+  const container = document.createElement('div');
+  const root = createRoot(container);
+
+  act(() => {
+    root.render(
+      <MuiBuilderSurface>
+        <button type="button">Action</button>
+      </MuiBuilderSurface>
+    );
+  });
+
+  expect(
+    container.firstElementChild?.classList.contains('MuiScopedCssBaseline-root')
+  ).toBe(true);
+
+  act(() => root.unmount());
+});

--- a/example/src/components/mui-builder-surface.tsx
+++ b/example/src/components/mui-builder-surface.tsx
@@ -1,0 +1,6 @@
+import { ScopedCssBaseline } from '@mui/material';
+import styled from 'styled-components';
+
+export const MuiBuilderSurface = styled(ScopedCssBaseline)`
+  min-width: 0;
+`;

--- a/example/src/pages/recipes-page/components/recipe-builder-surface.tsx
+++ b/example/src/pages/recipes-page/components/recipe-builder-surface.tsx
@@ -1,16 +1,19 @@
 import * as React from 'react';
 import { ThemeProvider } from '../../../../../src/theme-provider/theme-provider';
 import { BuilderSurface } from '../../../components/builder-surface';
+import { MuiBuilderSurface } from '../../../components/mui-builder-surface';
 import { defaultTheme } from '../../../constants/demo-data';
 
 export const RecipeBuilderSurface: React.FC<
   React.PropsWithChildren<{ adapter?: boolean }>
-> = ({ adapter = false, children }) => (
-  <BuilderSurface>
-    {adapter ? (
-      children
-    ) : (
+> = ({ adapter = false, children }) => {
+  if (adapter) {
+    return <MuiBuilderSurface>{children}</MuiBuilderSurface>;
+  }
+
+  return (
+    <BuilderSurface>
       <ThemeProvider colors={defaultTheme.colors}>{children}</ThemeProvider>
-    )}
-  </BuilderSurface>
-);
+    </BuilderSurface>
+  );
+};

--- a/src/mui/shared/components.test.tsx
+++ b/src/mui/shared/components.test.tsx
@@ -1,14 +1,20 @@
 import React from 'react';
 import '@testing-library/jest-dom';
 import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import { Builder, IBuilderFieldProps, IStrings } from '../../index';
+import { BuilderContext, IBuilderContextProps } from '../../builder-context';
+import { strings } from '../../constants/strings';
 import { components as muiV7Components } from '../v7';
 import { components as muiV9Components } from '../v9';
+import { MuiSelect } from './components/mui-select';
+import { MuiSelectMulti } from './components/mui-select-multi';
+import { MuiSwitch } from './components/mui-switch';
 
 const fields: IBuilderFieldProps[] = [
   {
     field: 'status',
-    label: 'Status',
+    label: 'Order manual review threshold requiring attention',
     type: 'TEXT',
     operators: ['EQUAL'],
   },
@@ -29,6 +35,22 @@ const data = [
   },
 ];
 
+const nestedGroupData = [
+  {
+    type: 'GROUP' as const,
+    value: 'AND' as const,
+    isNegated: false,
+    children: [
+      {
+        type: 'GROUP' as const,
+        value: 'OR' as const,
+        isNegated: false,
+        children: [],
+      },
+    ],
+  },
+];
+
 const untranslatedData = [
   {
     type: 'GROUP' as const,
@@ -42,6 +64,8 @@ const untranslatedData = [
   },
 ];
 
+const muiComponentContext = { strings } as IBuilderContextProps;
+
 describe('#mui/components', () => {
   it('renders the builder with the MUI v7 component mapping', () => {
     render(
@@ -53,10 +77,227 @@ describe('#mui/components', () => {
       />
     );
 
-    expect(screen.getByDisplayValue('active')).toBeInTheDocument();
-    expect(screen.getByRole('button', { name: 'Delete' })).toBeInTheDocument();
+    const inputRoot = screen
+      .getByDisplayValue('active')
+      .closest('.MuiInputBase-root');
+    const deleteButton = screen.getByRole('button', { name: 'Delete' });
+
+    expect(inputRoot).toHaveClass('MuiInputBase-sizeSmall');
+    expect(inputRoot).toHaveStyle({ height: '32px' });
+    expect(screen.getByDisplayValue('active')).toHaveStyle({
+      fontSize: '14px',
+    });
+    expect(deleteButton).toHaveClass('MuiButton-sizeSmall');
+    expect(deleteButton).toHaveStyle({ height: '32px', fontSize: '14px' });
   });
 
+  it('uses 32px controls, 14px type, and a primary toggle group', () => {
+    render(
+      <Builder
+        fields={fields}
+        data={data}
+        components={muiV9Components}
+        onChange={jest.fn()}
+      />
+    );
+
+    const inputRoot = screen
+      .getByDisplayValue('active')
+      .closest('.MuiInputBase-root');
+    const selectTrigger = screen.getAllByRole('combobox')[0];
+    const selectRoot = selectTrigger.closest('.MuiInputBase-root');
+    const toggleGroup = screen.getByRole('group');
+    const andToggle = screen.getByRole('button', { name: /and/i });
+
+    expect(inputRoot).toHaveClass('MuiInputBase-sizeSmall');
+    expect(inputRoot).toHaveStyle({ height: '32px' });
+    expect(screen.getByDisplayValue('active')).toHaveStyle({
+      fontSize: '14px',
+    });
+    expect(selectRoot).toHaveStyle({ height: '32px', fontSize: '14px' });
+    expect(selectTrigger).toHaveStyle({
+      display: 'block',
+      overflow: 'hidden',
+      textOverflow: 'ellipsis',
+      whiteSpace: 'nowrap',
+    });
+    expect(screen.getByRole('button', { name: 'Add Rule' })).toHaveClass(
+      'MuiButton-sizeSmall'
+    );
+    expect(screen.getByRole('button', { name: 'Add Rule' })).toHaveStyle({
+      height: '32px',
+      fontSize: '14px',
+    });
+    expect(screen.getByRole('button', { name: 'Delete' })).toHaveClass(
+      'MuiButton-sizeSmall'
+    );
+    expect(toggleGroup).toHaveClass('MuiToggleButtonGroup-root');
+    expect(toggleGroup).toHaveStyle({ height: '32px', fontSize: '14px' });
+    expect(andToggle).toHaveClass(
+      'MuiToggleButton-sizeSmall',
+      'MuiToggleButton-primary'
+    );
+    expect(andToggle).toHaveStyle({ height: '32px', fontSize: '14px' });
+    expect(andToggle).toHaveAttribute('aria-pressed', 'true');
+  });
+
+  it('clips a long single-select label with an ellipsis', () => {
+    render(
+      <BuilderContext.Provider value={muiComponentContext}>
+        <div style={{ width: 160 }}>
+          <MuiSelect
+            values={[
+              {
+                value: 'review',
+                label: 'Order manual review threshold requiring attention',
+              },
+            ]}
+            selectedValue="review"
+            onChange={jest.fn()}
+          />
+        </div>
+      </BuilderContext.Provider>
+    );
+
+    expect(screen.getByRole('combobox')).toHaveStyle({
+      display: 'block',
+      overflow: 'hidden',
+      textOverflow: 'ellipsis',
+      whiteSpace: 'nowrap',
+    });
+  });
+
+  it('truncates multiselect text while reserving room for its badge', () => {
+    const { container } = render(
+      <BuilderContext.Provider value={muiComponentContext}>
+        <div style={{ width: 160 }}>
+          <MuiSelectMulti
+            values={[
+              { value: 'first', label: 'First very long selected option' },
+              { value: 'second', label: 'Second selected option' },
+              { value: 'third', label: 'Third selected option' },
+            ]}
+            selectedValue={['first', 'second', 'third']}
+            onChange={jest.fn()}
+            onDelete={jest.fn()}
+          />
+        </div>
+      </BuilderContext.Provider>
+    );
+
+    const summary = container.querySelector(
+      '.MuiBox-root[data-test="SelectMultiTrigger"]'
+    );
+    const summaryText = summary?.querySelector('.MuiTypography-root');
+    const badge = container.querySelector(
+      '[data-test="SelectMultiSummaryBadge"]'
+    );
+
+    expect(summaryText).toHaveStyle({
+      flex: '1 1 auto',
+      minWidth: '0',
+      overflow: 'hidden',
+      textOverflow: 'ellipsis',
+    });
+    expect(badge).toHaveStyle({ flex: '0 0 32px' });
+    expect(badge?.firstElementChild).not.toBeNull();
+    expect(badge).toHaveTextContent('+2');
+  });
+  it('uses integer vertical positioning for root and nested group headers', () => {
+    const { container } = render(
+      <Builder
+        fields={fields}
+        data={nestedGroupData}
+        components={muiV9Components}
+        onChange={jest.fn()}
+      />
+    );
+
+    const groupBodies = container.querySelectorAll(
+      '[data-test="MuiGroupBody"]'
+    );
+    const groupHeaders = container.querySelectorAll(
+      '[data-test="MuiGroupHeader"]'
+    );
+    const groupHeaderActions = container.querySelectorAll(
+      '[data-test="MuiGroupHeaderActions"]'
+    );
+
+    expect(groupBodies).toHaveLength(2);
+    expect(groupHeaders).toHaveLength(2);
+    expect(groupHeaderActions).toHaveLength(2);
+    groupBodies.forEach((groupBody) => {
+      expect(groupBody).toHaveStyle({ padding: '12px' });
+    });
+    groupHeaders.forEach((groupHeader) => {
+      expect(groupHeader).toHaveStyle({ alignItems: 'center' });
+    });
+    groupHeaderActions.forEach((groupHeaderAction) => {
+      expect(groupHeaderAction).toHaveStyle({ alignItems: 'center' });
+    });
+  });
+
+  it('preserves the native dimensions of the small MUI switch', () => {
+    render(
+      <MuiSwitch switched={false} onChange={jest.fn()} disabled={false} />
+    );
+
+    const switchRoot = screen.getByRole('switch').closest('.MuiSwitch-root');
+
+    expect(switchRoot).toHaveClass('MuiSwitch-root', 'MuiSwitch-sizeSmall');
+    expect(switchRoot).toHaveStyle({ height: '24px', width: '40px' });
+    expect(switchRoot?.querySelector('.MuiSwitch-track')).not.toBeNull();
+    expect(switchRoot?.querySelector('.MuiSwitch-thumb')).not.toBeNull();
+  });
+  it('disables group toggles when the builder is read-only', () => {
+    render(
+      <Builder
+        fields={fields}
+        data={data}
+        components={muiV9Components}
+        readOnly
+        onChange={jest.fn()}
+      />
+    );
+
+    expect(screen.getByRole('button', { name: /not/i })).toBeDisabled();
+    expect(screen.getByRole('button', { name: /and/i })).toBeDisabled();
+    expect(screen.getByRole('button', { name: /or/i })).toBeDisabled();
+  });
+  it('keeps negation independent from the selected combinator', async () => {
+    const user = userEvent.setup();
+    const onChange = jest.fn();
+    const { rerender } = render(
+      <Builder
+        fields={fields}
+        data={data}
+        components={muiV9Components}
+        onChange={onChange}
+      />
+    );
+
+    await user.click(screen.getByRole('button', { name: /or/i }));
+
+    const queryWithOr = onChange.mock.calls.at(-1)?.[0];
+    expect(queryWithOr[0]).toMatchObject({ value: 'OR', isNegated: false });
+
+    rerender(
+      <Builder
+        fields={fields}
+        data={queryWithOr}
+        components={muiV9Components}
+        onChange={onChange}
+      />
+    );
+
+    await user.click(screen.getByRole('button', { name: /not/i }));
+
+    const negatedQueryWithOr = onChange.mock.calls.at(-1)?.[0];
+    expect(negatedQueryWithOr[0]).toMatchObject({
+      value: 'OR',
+      isNegated: true,
+    });
+  });
   it('renders the builder with the MUI v9 component mapping', () => {
     render(
       <Builder
@@ -111,7 +352,9 @@ describe('#mui/components', () => {
       />
     );
 
-    expect(screen.getByRole('textbox')).toHaveClass('builder-text-mode-input-field');
+    expect(screen.getByRole('textbox')).toHaveClass(
+      'builder-text-mode-input-field'
+    );
   });
 
   it('renders the locked text-mode warning with the MUI alert adapter', () => {
@@ -180,8 +423,15 @@ describe('#mui/components', () => {
     expect(
       screen.getByRole('button', { name: 'Protect group' })
     ).toBeInTheDocument();
-    expect(
-      screen.getByRole('button', { name: 'Duplicate rule' })
-    ).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Duplicate rule' })).toHaveStyle({
+      height: '32px',
+      width: '32px',
+      fontSize: '14px',
+    });
+    expect(screen.getByRole('button', { name: 'Protect group' })).toHaveStyle({
+      height: '32px',
+      width: '32px',
+      fontSize: '14px',
+    });
   });
 });

--- a/src/mui/shared/components/mui-add-button.tsx
+++ b/src/mui/shared/components/mui-add-button.tsx
@@ -1,6 +1,7 @@
 import React, { FC } from 'react';
 import { Button } from '@mui/material';
 import { IButtonProps } from '../../../button';
+import { muiControlDensitySx } from '../constants/mui-control-density-sx.constant';
 import { resolveButtonContent } from './button-utils';
 
 export const MuiAddButton: FC<IButtonProps> = (props) => (
@@ -12,7 +13,11 @@ export const MuiAddButton: FC<IButtonProps> = (props) => (
     className={props.className}
     data-test={props['data-test']}
     size="small"
-    sx={{ textTransform: 'uppercase', whiteSpace: 'nowrap', minHeight: '2rem' }}
+    sx={{
+      ...muiControlDensitySx,
+      textTransform: 'uppercase',
+      whiteSpace: 'nowrap',
+    }}
   >
     {resolveButtonContent(props)}
   </Button>

--- a/src/mui/shared/components/mui-clone-button.tsx
+++ b/src/mui/shared/components/mui-clone-button.tsx
@@ -1,6 +1,7 @@
 import React, { FC } from 'react';
 import { IconButton } from '@mui/material';
 import { ICloneButtonProps } from '../../../clone-button';
+import { muiControlDensitySx } from '../constants/mui-control-density-sx.constant';
 import { CloneIcon } from '../icons';
 import { getMuiCloneTitle, useMuiBuilderStrings } from './copy';
 
@@ -24,7 +25,14 @@ export const MuiCloneButton: FC<ICloneButtonProps> = ({
       title={resolvedTitle}
       aria-label={resolvedTitle}
       data-test={dataTest}
-      sx={{ border: 1, borderColor: 'divider', borderRadius: 1 }}
+      sx={{
+        ...muiControlDensitySx,
+        width: muiControlDensitySx.height,
+        minWidth: muiControlDensitySx.height,
+        border: 1,
+        borderColor: 'divider',
+        borderRadius: 1,
+      }}
     >
       <CloneIcon fontSize="small" />
     </IconButton>

--- a/src/mui/shared/components/mui-group-header-controls.tsx
+++ b/src/mui/shared/components/mui-group-header-controls.tsx
@@ -1,0 +1,23 @@
+import React, { FC } from 'react';
+import { ToggleButtonGroup } from '@mui/material';
+import { muiControlDensitySx } from '../constants/mui-control-density-sx.constant';
+
+export interface IMuiGroupHeaderControlsProps {
+  children: React.ReactNode;
+}
+
+export const MuiGroupHeaderControls: FC<IMuiGroupHeaderControlsProps> = ({
+  children,
+}) => {
+  const options =
+    React.isValidElement<{ children?: React.ReactNode }>(children) &&
+    children.type === React.Fragment
+      ? children.props.children
+      : children;
+
+  return (
+    <ToggleButtonGroup color="primary" size="small" sx={muiControlDensitySx}>
+      {options}
+    </ToggleButtonGroup>
+  );
+};

--- a/src/mui/shared/components/mui-group-header-option.tsx
+++ b/src/mui/shared/components/mui-group-header-option.tsx
@@ -1,6 +1,7 @@
 import React, { FC } from 'react';
-import { ButtonBase } from '@mui/material';
+import { ToggleButton } from '@mui/material';
 import { IOptionProps } from '../../../group/option';
+import { muiControlDensitySx } from '../constants/mui-control-density-sx.constant';
 
 export const MuiGroupHeaderOption: FC<IOptionProps> = ({
   children,
@@ -10,27 +11,16 @@ export const MuiGroupHeaderOption: FC<IOptionProps> = ({
   isSelected,
   className,
 }) => (
-  <ButtonBase
+  <ToggleButton
+    value={value}
+    selected={isSelected}
+    disabled={disabled}
     className={className}
-    onClick={() => {
-      if (!disabled) {
-        onClick(value);
-      }
-    }}
-    sx={{
-      px: 1.5,
-      py: 1,
-      minHeight: '2rem',
-      border: 1,
-      borderColor: isSelected ? 'primary.main' : 'grey.500',
-      bgcolor: isSelected ? 'primary.main' : 'grey.500',
-      color: 'primary.contrastText',
-      fontWeight: 700,
-      fontSize: '0.7rem',
-      textTransform: 'uppercase',
-      opacity: disabled ? 0.7 : 1,
-    }}
+    color="primary"
+    size="small"
+    sx={muiControlDensitySx}
+    onClick={() => onClick(value)}
   >
     {children}
-  </ButtonBase>
+  </ToggleButton>
 );

--- a/src/mui/shared/components/mui-group.tsx
+++ b/src/mui/shared/components/mui-group.tsx
@@ -1,6 +1,7 @@
 import React, { FC } from 'react';
 import { Box, Paper } from '@mui/material';
 import { IGroupProps } from '../../../group/group-container';
+import { MuiGroupHeaderControls } from './mui-group-header-controls';
 
 export const MuiGroup: FC<IGroupProps> = ({
   controlsLeft,
@@ -28,11 +29,13 @@ export const MuiGroup: FC<IGroupProps> = ({
       }}
     >
       {dragHandle}
-      <Box sx={{ position: 'relative', p: 1.4 }}>
+      <Box data-test="MuiGroupBody" sx={{ position: 'relative', p: '12px' }}>
         {hasHeader ? (
           <Box
+            data-test="MuiGroupHeader"
             sx={{
               display: 'grid',
+              alignItems: 'center',
               gap: 2,
               gridTemplateColumns: 'minmax(0, 1fr) auto',
               pb: 1,
@@ -45,22 +48,14 @@ export const MuiGroup: FC<IGroupProps> = ({
             }}
           >
             {hasControlsLeft ? (
-              <Box
-                sx={{
-                  display: 'grid',
-                  gridAutoColumns: 'min-content',
-                  gridAutoFlow: 'column',
-                  alignSelf: 'end',
-                  justifySelf: 'start',
-                }}
-              >
-                {controlsLeft}
-              </Box>
+              <MuiGroupHeaderControls>{controlsLeft}</MuiGroupHeaderControls>
             ) : null}
             {hasControlsRight ? (
               <Box
+                data-test="MuiGroupHeaderActions"
                 sx={{
                   display: 'grid',
+                  alignItems: 'center',
                   gridAutoColumns: 'min-content',
                   gridAutoFlow: 'column',
                   gap: 1,

--- a/src/mui/shared/components/mui-input.tsx
+++ b/src/mui/shared/components/mui-input.tsx
@@ -1,6 +1,7 @@
 import React, { FC } from 'react';
 import { TextField } from '@mui/material';
 import { IInputProps } from '../../../form/input';
+import { muiControlDensitySx } from '../constants/mui-control-density-sx.constant';
 
 export const MuiInput: FC<IInputProps> = ({
   type,
@@ -16,12 +17,21 @@ export const MuiInput: FC<IInputProps> = ({
     name={name}
     type={type}
     value={value}
-    onChange={event => onChange(event.target.value)}
+    onChange={(event) => onChange(event.target.value)}
     className={className}
     disabled={disabled}
     size="small"
     fullWidth
     variant="outlined"
     slotProps={{ htmlInput: { 'data-test': 'Input' } }}
+    sx={{
+      '& .MuiInputBase-root': muiControlDensitySx,
+      '& .MuiInputBase-input': {
+        boxSizing: 'border-box',
+        height: '100%',
+        padding: '6px 14px',
+        fontSize: muiControlDensitySx.fontSize,
+      },
+    }}
   />
 );

--- a/src/mui/shared/components/mui-lock-toggle.tsx
+++ b/src/mui/shared/components/mui-lock-toggle.tsx
@@ -5,6 +5,7 @@ import {
   getNextGroupLockState,
   getNextRuleLockState,
 } from '../../../utils/lock-state';
+import { muiControlDensitySx } from '../constants/mui-control-density-sx.constant';
 import { LockStateIcon } from '../icons';
 import { getMuiLockTitle, useMuiBuilderStrings } from './copy';
 
@@ -38,6 +39,9 @@ export const MuiLockToggle: FC<ILockToggleProps> = ({
       aria-label={resolvedTitle}
       data-test={dataTest}
       sx={{
+        ...muiControlDensitySx,
+        width: muiControlDensitySx.height,
+        minWidth: muiControlDensitySx.height,
         border: 1,
         borderColor: state === 'unlocked' ? 'divider' : 'primary.main',
         color: state === 'unlocked' ? 'text.secondary' : 'primary.main',

--- a/src/mui/shared/components/mui-outlined-button.tsx
+++ b/src/mui/shared/components/mui-outlined-button.tsx
@@ -1,6 +1,7 @@
 import React, { FC } from 'react';
 import { Button } from '@mui/material';
 import { IButtonProps } from '../../../button';
+import { muiControlDensitySx } from '../constants/mui-control-density-sx.constant';
 import { resolveButtonContent } from './button-utils';
 
 export const MuiOutlinedButton: FC<IButtonProps> = (props) => (
@@ -12,7 +13,11 @@ export const MuiOutlinedButton: FC<IButtonProps> = (props) => (
     className={props.className}
     data-test={props['data-test']}
     size="small"
-    sx={{ textTransform: 'none', whiteSpace: 'nowrap', minHeight: '2rem' }}
+    sx={{
+      ...muiControlDensitySx,
+      textTransform: 'none',
+      whiteSpace: 'nowrap',
+    }}
   >
     {resolveButtonContent(props)}
   </Button>

--- a/src/mui/shared/components/mui-popover-item.tsx
+++ b/src/mui/shared/components/mui-popover-item.tsx
@@ -1,6 +1,7 @@
 import React, { FC } from 'react';
 import { MenuItem } from '@mui/material';
 import { IPopoverItemProps } from '../../../popover-item';
+import { muiControlDensitySx } from '../constants/mui-control-density-sx.constant';
 
 export const MuiPopoverItem: FC<IPopoverItemProps> = ({
   label,
@@ -9,6 +10,8 @@ export const MuiPopoverItem: FC<IPopoverItemProps> = ({
   'data-test': dataTest,
 }) => (
   <MenuItem
+    dense
+    sx={muiControlDensitySx}
     onClick={(event) =>
       onClick(event as unknown as React.MouseEvent<HTMLButtonElement>)
     }

--- a/src/mui/shared/components/mui-popover.tsx
+++ b/src/mui/shared/components/mui-popover.tsx
@@ -1,6 +1,7 @@
 import React, { FC, useState } from 'react';
 import { Button, Menu } from '@mui/material';
 import { IPopoverProps } from '../../../popover';
+import { muiControlDensitySx } from '../constants/mui-control-density-sx.constant';
 import { menuPaperSx } from './styles';
 
 export const MuiPopover: FC<IPopoverProps> = ({
@@ -21,7 +22,11 @@ export const MuiPopover: FC<IPopoverProps> = ({
         className={className}
         data-test={dataTest}
         size="small"
-        sx={{ textTransform: 'uppercase', whiteSpace: 'nowrap', minHeight: '2rem' }}
+        sx={{
+          ...muiControlDensitySx,
+          textTransform: 'uppercase',
+          whiteSpace: 'nowrap',
+        }}
       >
         {label}
       </Button>
@@ -31,7 +36,7 @@ export const MuiPopover: FC<IPopoverProps> = ({
         onClose={() => setAnchorEl(null)}
         slotProps={{ paper: { sx: menuPaperSx } }}
       >
-        {React.Children.map(children, child => {
+        {React.Children.map(children, (child) => {
           if (!React.isValidElement(child)) {
             return child;
           }

--- a/src/mui/shared/components/mui-remove-button.tsx
+++ b/src/mui/shared/components/mui-remove-button.tsx
@@ -1,6 +1,7 @@
 import React, { FC } from 'react';
 import { Button } from '@mui/material';
 import { IButtonProps } from '../../../button';
+import { muiControlDensitySx } from '../constants/mui-control-density-sx.constant';
 import { resolveButtonContent } from './button-utils';
 
 export const MuiRemoveButton: FC<IButtonProps> = (props) => (
@@ -12,7 +13,11 @@ export const MuiRemoveButton: FC<IButtonProps> = (props) => (
     className={props.className}
     data-test={props['data-test']}
     size="small"
-    sx={{ textTransform: 'uppercase', whiteSpace: 'nowrap', minHeight: '2rem' }}
+    sx={{
+      ...muiControlDensitySx,
+      textTransform: 'uppercase',
+      whiteSpace: 'nowrap',
+    }}
   >
     {resolveButtonContent(props)}
   </Button>

--- a/src/mui/shared/components/mui-select-multi.tsx
+++ b/src/mui/shared/components/mui-select-multi.tsx
@@ -13,6 +13,7 @@ import {
 import type { SelectChangeEvent } from '@mui/material/Select';
 import { ISelectMultiProps } from '../../../form/select-multi';
 import { createSummary } from '../../../widgets/select-multi/utils/create-summary.util';
+import { muiControlDensitySx } from '../constants/mui-control-density-sx.constant';
 import { getMuiSelectPlaceholder, useMuiBuilderStrings } from './copy';
 import { menuPaperSx } from './styles';
 
@@ -41,13 +42,13 @@ export const MuiSelectMulti: FC<ISelectMultiProps> = ({
         : event.target.value;
 
     for (const removedValue of selectedValue.filter(
-      value => !nextValues.includes(value)
+      (value) => !nextValues.includes(value)
     )) {
       onDelete(removedValue);
     }
 
     for (const addedValue of nextValues.filter(
-      value => !selectedValue.includes(value)
+      (value) => !selectedValue.includes(value)
     )) {
       onChange(addedValue);
     }
@@ -72,11 +73,29 @@ export const MuiSelectMulti: FC<ISelectMultiProps> = ({
         value={selectedValue}
         onChange={handleChange}
         input={<OutlinedInput id={id} name={name} />}
+        sx={{
+          ...muiControlDensitySx,
+          '& .MuiSelect-select': {
+            boxSizing: 'border-box',
+            display: 'block',
+            height: '100%',
+            padding: '6px 32px 6px 14px',
+            overflow: 'hidden',
+            fontSize: muiControlDensitySx.fontSize,
+            lineHeight: '20px',
+            textOverflow: 'ellipsis',
+            whiteSpace: 'nowrap',
+          },
+        }}
         displayEmpty
         renderValue={() => {
           if (!summary.text) {
             return (
-              <Typography variant="body2" color="text.secondary">
+              <Typography
+                variant="body2"
+                color="text.secondary"
+                sx={{ fontSize: muiControlDensitySx.fontSize }}
+              >
                 {placeholder}
               </Typography>
             );
@@ -84,11 +103,27 @@ export const MuiSelectMulti: FC<ISelectMultiProps> = ({
 
           return (
             <Box
-              sx={{ display: 'flex', gap: 1, alignItems: 'center' }}
+              sx={{
+                display: 'flex',
+                alignItems: 'center',
+                gap: 1,
+                minWidth: 0,
+                maxWidth: '100%',
+              }}
               title={title}
               data-test="SelectMultiTrigger"
             >
-              <Typography variant="body2" noWrap>
+              <Typography
+                variant="body2"
+                sx={{
+                  flex: '1 1 auto',
+                  minWidth: 0,
+                  overflow: 'hidden',
+                  fontSize: muiControlDensitySx.fontSize,
+                  textOverflow: 'ellipsis',
+                }}
+                noWrap
+              >
                 {summary.text}
               </Typography>
               {summary.hiddenCount > 0 ? (
@@ -96,7 +131,13 @@ export const MuiSelectMulti: FC<ISelectMultiProps> = ({
                   badgeContent={`+${summary.hiddenCount}`}
                   color="primary"
                   data-test="SelectMultiSummaryBadge"
-                />
+                  sx={{
+                    flex: '0 0 32px',
+                    '& .MuiBadge-badge': { right: 12 },
+                  }}
+                >
+                  <Box component="span" sx={{ width: '100%', height: 1 }} />
+                </Badge>
               ) : null}
             </Box>
           );
@@ -109,9 +150,21 @@ export const MuiSelectMulti: FC<ISelectMultiProps> = ({
             key={value}
             value={value}
             data-test={`SelectMultiOption[${value}]`}
+            dense
+            sx={{
+              minHeight: muiControlDensitySx.height,
+              fontSize: muiControlDensitySx.fontSize,
+            }}
           >
-            <Checkbox checked={selectedValue.includes(value)} />
-            <ListItemText primary={label} />
+            <Checkbox size="small" checked={selectedValue.includes(value)} />
+            <ListItemText
+              primary={label}
+              sx={{
+                '& .MuiListItemText-primary': {
+                  fontSize: muiControlDensitySx.fontSize,
+                },
+              }}
+            />
           </MenuItem>
         ))}
       </Select>

--- a/src/mui/shared/components/mui-select.tsx
+++ b/src/mui/shared/components/mui-select.tsx
@@ -8,6 +8,7 @@ import {
 } from '@mui/material';
 import type { SelectChangeEvent } from '@mui/material/Select';
 import { ISelectProps } from '../../../form/select';
+import { muiControlDensitySx } from '../constants/mui-control-density-sx.constant';
 import { getMuiSelectPlaceholder, useMuiBuilderStrings } from './copy';
 import { menuPaperSx } from './styles';
 
@@ -36,21 +37,41 @@ export const MuiSelect: FC<ISelectProps> = ({
     >
       <Select
         value={selectedValue || ''}
+        sx={{
+          ...muiControlDensitySx,
+          '& .MuiSelect-select': {
+            boxSizing: 'border-box',
+            display: 'block',
+            height: '100%',
+            padding: '6px 32px 6px 14px',
+            overflow: 'hidden',
+            fontSize: muiControlDensitySx.fontSize,
+            lineHeight: '20px',
+            textOverflow: 'ellipsis',
+            whiteSpace: 'nowrap',
+          },
+        }}
         displayEmpty
         input={<OutlinedInput id={id} name={name} />}
         onChange={(event: SelectChangeEvent<string>) =>
           onChange(event.target.value)
         }
-        renderValue={selected => {
+        renderValue={(selected) => {
           if (!selected) {
             return (
-              <Typography variant="body2" color="text.secondary">
+              <Typography
+                variant="body2"
+                color="text.secondary"
+                sx={{ fontSize: muiControlDensitySx.fontSize }}
+              >
                 {placeholder}
               </Typography>
             );
           }
 
-          return values.find(({ value }) => value === selected)?.label || selected;
+          return (
+            values.find(({ value }) => value === selected)?.label || selected
+          );
         }}
         inputProps={{ 'data-test': 'SelectTrigger' }}
         MenuProps={{ slotProps: { paper: { sx: menuPaperSx } } }}
@@ -60,6 +81,11 @@ export const MuiSelect: FC<ISelectProps> = ({
             key={value}
             value={value}
             data-test={`SelectOption[${value}]`}
+            dense
+            sx={{
+              minHeight: muiControlDensitySx.height,
+              fontSize: muiControlDensitySx.fontSize,
+            }}
           >
             {label}
           </MenuItem>

--- a/src/mui/shared/components/mui-text-mode-input.tsx
+++ b/src/mui/shared/components/mui-text-mode-input.tsx
@@ -1,6 +1,7 @@
 import React, { FC, useState } from 'react';
 import { alpha, styled } from '@mui/material/styles';
 import { ITextModeInputProps } from '../../../builder/text-mode/types/text-mode-input-props';
+import { muiControlDensitySx } from '../constants/mui-control-density-sx.constant';
 
 const Root = styled('div')(({ theme }) => ({
   position: 'relative',
@@ -33,6 +34,7 @@ const Textarea = styled('textarea')({
   resize: 'vertical',
   background: 'transparent',
   outline: 'none',
+  fontSize: muiControlDensitySx.fontSize,
 });
 
 export const MuiTextModeInput: FC<ITextModeInputProps> = ({
@@ -55,7 +57,7 @@ export const MuiTextModeInput: FC<ITextModeInputProps> = ({
     >
       <Textarea
         value={value}
-        onChange={event => onChange(event.target.value)}
+        onChange={(event) => onChange(event.target.value)}
         onFocus={() => setIsFocused(true)}
         onBlur={() => setIsFocused(false)}
         className={inputClassName}

--- a/src/mui/shared/components/mui-text.tsx
+++ b/src/mui/shared/components/mui-text.tsx
@@ -1,5 +1,6 @@
 import React, { FC, PropsWithChildren } from 'react';
 import { Box } from '@mui/material';
+import { muiControlDensitySx } from '../constants/mui-control-density-sx.constant';
 
 export const MuiText: FC<PropsWithChildren> = ({ children }) => (
   <Box
@@ -9,11 +10,12 @@ export const MuiText: FC<PropsWithChildren> = ({ children }) => (
       display: 'inline-flex',
       alignItems: 'center',
       minWidth: 160,
-      minHeight: '2rem',
+      height: muiControlDensitySx.height,
+      minHeight: muiControlDensitySx.minHeight,
       px: 1.5,
-      py: 1,
+      py: 0.5,
       color: 'text.primary',
-      fontSize: '0.8rem',
+      fontSize: muiControlDensitySx.fontSize,
       lineHeight: 1.3,
       border: 1,
       borderColor: 'grey.500',

--- a/src/mui/shared/constants/mui-control-density-sx.constant.ts
+++ b/src/mui/shared/constants/mui-control-density-sx.constant.ts
@@ -1,0 +1,7 @@
+import type { SxProps, Theme } from '@mui/material';
+
+export const muiControlDensitySx = {
+  height: 32,
+  minHeight: 32,
+  fontSize: '14px',
+} satisfies SxProps<Theme>;


### PR DESCRIPTION
- Standardized MUI inputs, buttons, and button groups at 32px with 14px typography
- Added a compact primary toggle button group
- Preserved the native small MUI Switch geometry
- Truncated overflowing select and multiselect labels
- Aligned root and nested group-header controls using integer spacing
- Isolated MUI demo components from external styles
- Added density, overflow, switch, nested layout, interaction, and style-isolation tests