### PR TITLE
feat: Added versioned URL and basename helpers

### DIFF
--- a/.codex/TASKS.md
+++ b/.codex/TASKS.md
@@ -807,7 +807,7 @@ sharing only non-content site infrastructure.
 
 ### T013 - Add version-prefix, basename, and URL helpers
 
-**Status:** `[ ]` Not started
+**Status:** `[x]` Done
 
 **Depends on:** T012
 

--- a/example/src/app/router-basename.ts
+++ b/example/src/app/router-basename.ts
@@ -1,4 +1,4 @@
+import { normalizeBasename } from '../shared/versioned-url';
+
 export const routerBasename =
-  import.meta.env.BASE_URL === '/'
-    ? undefined
-    : import.meta.env.BASE_URL.replace(/\/$/, '');
+  normalizeBasename(import.meta.env.BASE_URL) || undefined;

--- a/example/src/shared/versioned-url/index.ts
+++ b/example/src/shared/versioned-url/index.ts
@@ -1,0 +1,7 @@
+export { addVersionPrefix } from './utils/add-version-prefix.util';
+export { normalizeBasename } from './utils/normalize-basename.util';
+export { parseVersionedUrl } from './utils/parse-versioned-url.util';
+export { removeVersionPrefix } from './utils/remove-version-prefix.util';
+export { switchVersionPrefix } from './utils/switch-version-prefix.util';
+export type { SiteVersion } from './types/site-version';
+export type { IVersionedUrl } from './types/versioned-url';

--- a/example/src/shared/versioned-url/types/site-version.ts
+++ b/example/src/shared/versioned-url/types/site-version.ts
@@ -1,0 +1,1 @@
+export type SiteVersion = 'v1' | 'v2';

--- a/example/src/shared/versioned-url/types/versioned-url.ts
+++ b/example/src/shared/versioned-url/types/versioned-url.ts
@@ -1,0 +1,9 @@
+import type { SiteVersion } from './site-version';
+
+export interface IVersionedUrl {
+  basename: string;
+  version: SiteVersion | undefined;
+  pathname: string;
+  search: string;
+  hash: string;
+}

--- a/example/src/shared/versioned-url/utils/add-version-prefix.util.ts
+++ b/example/src/shared/versioned-url/utils/add-version-prefix.util.ts
@@ -1,0 +1,13 @@
+import type { SiteVersion } from '../types/site-version';
+import { formatVersionedUrl } from './format-versioned-url.util';
+import { parseVersionedUrl } from './parse-versioned-url.util';
+
+export const addVersionPrefix = (
+  url: string,
+  version: SiteVersion,
+  basename?: string
+): string => {
+  const parsedUrl = parseVersionedUrl(url, basename);
+
+  return parsedUrl.version ? url : formatVersionedUrl(parsedUrl, version);
+};

--- a/example/src/shared/versioned-url/utils/format-versioned-url.util.ts
+++ b/example/src/shared/versioned-url/utils/format-versioned-url.util.ts
@@ -1,0 +1,14 @@
+import type { SiteVersion } from '../types/site-version';
+import type { IVersionedUrl } from '../types/versioned-url';
+
+export const formatVersionedUrl = (
+  parsedUrl: IVersionedUrl,
+  version: SiteVersion | undefined
+): string => {
+  const versionPrefix = version ? `/${version}` : '';
+  const pathname = parsedUrl.pathname === '/' ? '' : parsedUrl.pathname;
+  const versionedPathname =
+    `${parsedUrl.basename}${versionPrefix}${pathname}` || '/';
+
+  return `${versionedPathname}${parsedUrl.search}${parsedUrl.hash}`;
+};

--- a/example/src/shared/versioned-url/utils/normalize-basename.util.ts
+++ b/example/src/shared/versioned-url/utils/normalize-basename.util.ts
@@ -1,0 +1,7 @@
+export const normalizeBasename = (basename?: string): string => {
+  const withLeadingSlash = basename?.startsWith('/')
+    ? basename
+    : `/${basename ?? ''}`;
+
+  return withLeadingSlash.replace(/\/+$/, '');
+};

--- a/example/src/shared/versioned-url/utils/parse-versioned-url.util.ts
+++ b/example/src/shared/versioned-url/utils/parse-versioned-url.util.ts
@@ -1,0 +1,40 @@
+import type { IVersionedUrl } from '../types/versioned-url';
+import { normalizeBasename } from './normalize-basename.util';
+
+export const parseVersionedUrl = (
+  url: string,
+  basename?: string
+): IVersionedUrl => {
+  const hashIndex = url.indexOf('#');
+  const hash = hashIndex === -1 ? '' : url.slice(hashIndex);
+  const urlWithoutHash = hashIndex === -1 ? url : url.slice(0, hashIndex);
+  const searchIndex = urlWithoutHash.indexOf('?');
+  const search = searchIndex === -1 ? '' : urlWithoutHash.slice(searchIndex);
+  const rawPathname =
+    searchIndex === -1 ? urlWithoutHash : urlWithoutHash.slice(0, searchIndex);
+  const absolutePathname = rawPathname.startsWith('/')
+    ? rawPathname
+    : `/${rawPathname}`;
+  const normalizedPathname = absolutePathname || '/';
+  const normalizedBasename = normalizeBasename(basename);
+  const isWithinBasename =
+    normalizedBasename !== '' &&
+    (normalizedPathname === normalizedBasename ||
+      normalizedPathname.startsWith(`${normalizedBasename}/`));
+  const pathAfterBasename = isWithinBasename
+    ? normalizedPathname.slice(normalizedBasename.length) || '/'
+    : normalizedPathname;
+  const versionMatch = pathAfterBasename.match(/^\/(v1|v2)(?=\/|$)/);
+  const version = versionMatch?.[1] as IVersionedUrl['version'];
+  const pathname = versionMatch
+    ? pathAfterBasename.slice(versionMatch[0].length) || '/'
+    : pathAfterBasename;
+
+  return {
+    basename: normalizedBasename,
+    version,
+    pathname,
+    search,
+    hash,
+  };
+};

--- a/example/src/shared/versioned-url/utils/remove-version-prefix.util.ts
+++ b/example/src/shared/versioned-url/utils/remove-version-prefix.util.ts
@@ -1,0 +1,8 @@
+import { formatVersionedUrl } from './format-versioned-url.util';
+import { parseVersionedUrl } from './parse-versioned-url.util';
+
+export const removeVersionPrefix = (url: string, basename?: string): string => {
+  const parsedUrl = parseVersionedUrl(url, basename);
+
+  return parsedUrl.version ? formatVersionedUrl(parsedUrl, undefined) : url;
+};

--- a/example/src/shared/versioned-url/utils/switch-version-prefix.util.ts
+++ b/example/src/shared/versioned-url/utils/switch-version-prefix.util.ts
@@ -1,0 +1,15 @@
+import type { SiteVersion } from '../types/site-version';
+import { formatVersionedUrl } from './format-versioned-url.util';
+import { parseVersionedUrl } from './parse-versioned-url.util';
+
+export const switchVersionPrefix = (
+  url: string,
+  version: SiteVersion,
+  basename?: string
+): string => {
+  const parsedUrl = parseVersionedUrl(url, basename);
+
+  return parsedUrl.version === version
+    ? url
+    : formatVersionedUrl(parsedUrl, version);
+};

--- a/example/src/shared/versioned-url/versioned-url.test.ts
+++ b/example/src/shared/versioned-url/versioned-url.test.ts
@@ -1,0 +1,203 @@
+import { describe, expect, it } from 'vitest';
+import { addVersionPrefix } from './utils/add-version-prefix.util';
+import { normalizeBasename } from './utils/normalize-basename.util';
+import { parseVersionedUrl } from './utils/parse-versioned-url.util';
+import { removeVersionPrefix } from './utils/remove-version-prefix.util';
+import { switchVersionPrefix } from './utils/switch-version-prefix.util';
+
+describe('versioned URL helpers', () => {
+  it.each([
+    {
+      label: 'an unversioned production root',
+      url: '/',
+      basename: undefined,
+      expected: {
+        basename: '',
+        version: undefined,
+        pathname: '/',
+        search: '',
+        hash: '',
+      },
+    },
+    {
+      label: 'a version root without a trailing slash',
+      url: '/v1',
+      basename: '/',
+      expected: {
+        basename: '',
+        version: 'v1',
+        pathname: '/',
+        search: '',
+        hash: '',
+      },
+    },
+    {
+      label: 'a version root with a trailing slash',
+      url: '/v2/',
+      basename: undefined,
+      expected: {
+        basename: '',
+        version: 'v2',
+        pathname: '/',
+        search: '',
+        hash: '',
+      },
+    },
+    {
+      label: 'a deep repository URL',
+      url: '/react-query-builder/v1/documentation/usage',
+      basename: '/react-query-builder/',
+      expected: {
+        basename: '/react-query-builder',
+        version: 'v1',
+        pathname: '/documentation/usage',
+        search: '',
+        hash: '',
+      },
+    },
+    {
+      label: 'an unknown route with an encoded suffix',
+      url: '/repo/v2/unknown/deep?filter=a%2Fb&filter=c#rule%201',
+      basename: 'repo',
+      expected: {
+        basename: '/repo',
+        version: 'v2',
+        pathname: '/unknown/deep',
+        search: '?filter=a%2Fb&filter=c',
+        hash: '#rule%201',
+      },
+    },
+    {
+      label: 'a path outside the configured basename',
+      url: '/other/v1/docs?preview=#heading',
+      basename: '/repo',
+      expected: {
+        basename: '/repo',
+        version: undefined,
+        pathname: '/other/v1/docs',
+        search: '?preview=',
+        hash: '#heading',
+      },
+    },
+    {
+      label: 'a basename lookalike',
+      url: '/react-query-builderish/v1/docs',
+      basename: '/react-query-builder',
+      expected: {
+        basename: '/react-query-builder',
+        version: undefined,
+        pathname: '/react-query-builderish/v1/docs',
+        search: '',
+        hash: '',
+      },
+    },
+    {
+      label: 'a prefix lookalike',
+      url: '/repo/v10/docs?next=/v1#v2',
+      basename: '/repo',
+      expected: {
+        basename: '/repo',
+        version: undefined,
+        pathname: '/v10/docs',
+        search: '?next=/v1',
+        hash: '#v2',
+      },
+    },
+  ])('parses $label', ({ url, basename, expected }) => {
+    expect(parseVersionedUrl(url, basename)).toEqual(expected);
+  });
+
+  it.each([
+    ['/', 'v1', undefined, '/v1'],
+    ['/documentation/usage', 'v2', '/', '/v2/documentation/usage'],
+    [
+      '/documentation/usage?tab=api',
+      'v2',
+      '/',
+      '/v2/documentation/usage?tab=api',
+    ],
+    [
+      '/react-query-builder/unknown/deep?draft=&draft=2#results',
+      'v1',
+      '/react-query-builder/',
+      '/react-query-builder/v1/unknown/deep?draft=&draft=2#results',
+    ],
+    ['/v1/docs?version=/v2#v1', 'v1', undefined, '/v1/docs?version=/v2#v1'],
+    ['/v1/docs', 'v2', undefined, '/v1/docs'],
+  ] as const)(
+    'adds a prefix to %s for %s with basename %s',
+    (url, version, basename, expected) => {
+      expect(addVersionPrefix(url, version, basename)).toBe(expected);
+    }
+  );
+
+  it.each([
+    ['/v1', undefined, '/'],
+    ['/v2/', '/', '/'],
+    [
+      '/v1/documentation/usage?tab=api#example',
+      undefined,
+      '/documentation/usage?tab=api#example',
+    ],
+    [
+      '/react-query-builder/v2/unknown/deep?value=a%2Fb#result',
+      '/react-query-builder/',
+      '/react-query-builder/unknown/deep?value=a%2Fb#result',
+    ],
+    [
+      '/other/v1/docs?tab=api#heading',
+      '/repo',
+      '/other/v1/docs?tab=api#heading',
+    ],
+    [
+      '/v1-docs/usage?version=/v1#v2',
+      undefined,
+      '/v1-docs/usage?version=/v1#v2',
+    ],
+  ] as const)(
+    'removes a prefix from %s with basename %s',
+    (url, basename, expected) => {
+      expect(removeVersionPrefix(url, basename)).toBe(expected);
+    }
+  );
+
+  it.each([
+    ['/v1', 'v2', undefined, '/v2'],
+    ['/v2/', 'v1', '/', '/v1'],
+    [
+      '/v1/documentation/usage?tab=api#example',
+      'v2',
+      undefined,
+      '/v2/documentation/usage?tab=api#example',
+    ],
+    [
+      '/react-query-builder/v2/unknown/deep?value=a%2Fb#result',
+      'v1',
+      '/react-query-builder/',
+      '/react-query-builder/v1/unknown/deep?value=a%2Fb#result',
+    ],
+    [
+      '/unknown/deep?draft=#result',
+      'v2',
+      undefined,
+      '/v2/unknown/deep?draft=#result',
+    ],
+    ['/v1/docs#heading', 'v2', undefined, '/v2/docs#heading'],
+    ['/v2/docs?version=/v1#v2', 'v2', undefined, '/v2/docs?version=/v1#v2'],
+  ] as const)(
+    'switches %s to %s with basename %s',
+    (url, version, basename, expected) => {
+      expect(switchVersionPrefix(url, version, basename)).toBe(expected);
+    }
+  );
+
+  it.each([
+    [undefined, ''],
+    ['', ''],
+    ['/', ''],
+    ['/react-query-builder/', '/react-query-builder'],
+    ['organization/repository///', '/organization/repository'],
+  ])('normalizes basename %s', (basename, expected) => {
+    expect(normalizeBasename(basename)).toBe(expected);
+  });
+});


### PR DESCRIPTION
- Added URL parsing and version prefix add, remove, and switch utilities
- Preserved query strings, hashes, unknown paths, and deployment basenames
- Added table-driven URL coverage for v1 and v2
- Centralized router basename normalization and marked T013 as done