### PR TITLE
feat: Froze the version-owned v1 documentation tree

### DIFF
--- a/.codex/TASKS.md
+++ b/.codex/TASKS.md
@@ -878,7 +878,7 @@ sharing only non-content site infrastructure.
 
 ### T016 - Freeze the version-owned v1 Documentation tree
 
-**Status:** `[ ]` Not started
+**Status:** `[x]` Done
 
 **Depends on:** T013
 

--- a/example/config/versioned-site/import-boundaries.test.ts
+++ b/example/config/versioned-site/import-boundaries.test.ts
@@ -22,7 +22,7 @@ describe('versioned site import boundaries', () => {
     expect(violations).toEqual([]);
   });
 
-  it('keeps v1 Home and Demo imports out of transitional legacy content', () => {
+  it('keeps v1-owned content out of transitional legacy implementations', () => {
     const v1Root = resolve(sourceRoot, 'v1');
     const forbiddenLegacyRoots = [
       resolve(sourceRoot, 'pages/home-page'),
@@ -37,6 +37,15 @@ describe('versioned site import boundaries', () => {
       resolve(sourceRoot, 'constants/locale-strings'),
       resolve(sourceRoot, 'utils/builder-source'),
       resolve(sourceRoot, 'utils/query-formatters'),
+      resolve(sourceRoot, 'pages/documentation-page'),
+      resolve(sourceRoot, 'components/imperative-field-options-demo'),
+      resolve(sourceRoot, 'components/shared-field-options-demo'),
+      resolve(sourceRoot, 'components/parsing-sandbox'),
+      resolve(sourceRoot, 'components/load-imperative-field-options-demo'),
+      resolve(sourceRoot, 'components/load-shared-field-options-demo'),
+      resolve(sourceRoot, 'components/load-parsing-sandbox'),
+      resolve(sourceRoot, 'components/utils/wait-for-timeout.util'),
+      resolve(sourceRoot, 'constants/related-recipes-by-path'),
     ];
     const violations = collectSourceImports(v1Root).flatMap(
       ({ importer, source }) => {

--- a/example/src/app/app-routes.tsx
+++ b/example/src/app/app-routes.tsx
@@ -3,7 +3,6 @@ import { Navigate, Route, Routes } from 'react-router-dom';
 import { SiteShell } from '../components/site-shell';
 import { canonicalSeoPages } from '../constants/seo-pages';
 import { ApiPage } from '../pages/api-page/api-page';
-import { DocumentationPage } from '../pages/documentation-page/documentation-page';
 import { RecipesPage } from '../pages/recipes-page/recipes-page';
 import type { IAppContentPages } from './types/app-content-pages';
 
@@ -35,12 +34,13 @@ const redirects = [
 
 export const AppRoutes: React.FC<IAppContentPages> = ({
   demoPage,
+  documentationPage,
   homePage,
 }) => {
   const pageElements = {
     API: <ApiPage />,
     Demo: demoPage,
-    Documentation: <DocumentationPage />,
+    Documentation: documentationPage,
     Home: homePage,
     Recipes: <RecipesPage />,
   };

--- a/example/src/app/app.tsx
+++ b/example/src/app/app.tsx
@@ -4,8 +4,16 @@ import type { IAppContentPages } from './types/app-content-pages';
 import { AppRoutes } from './app-routes';
 import { routerBasename } from './router-basename';
 
-export const App: React.FC<IAppContentPages> = ({ demoPage, homePage }) => (
+export const App: React.FC<IAppContentPages> = ({
+  demoPage,
+  documentationPage,
+  homePage,
+}) => (
   <BrowserRouter basename={routerBasename}>
-    <AppRoutes demoPage={demoPage} homePage={homePage} />
+    <AppRoutes
+      demoPage={demoPage}
+      documentationPage={documentationPage}
+      homePage={homePage}
+    />
   </BrowserRouter>
 );

--- a/example/src/app/types/app-content-pages.ts
+++ b/example/src/app/types/app-content-pages.ts
@@ -2,5 +2,6 @@ import type * as React from 'react';
 
 export interface IAppContentPages {
   demoPage: React.ReactElement;
+  documentationPage: React.ReactElement;
   homePage: React.ReactElement;
 }

--- a/example/src/entry-server.tsx
+++ b/example/src/entry-server.tsx
@@ -6,6 +6,7 @@ import { AppRoutes } from './app/app-routes';
 import { routerBasename } from './app/router-basename';
 import { DemoPage } from './pages/demo-page/demo-page';
 import { HomePage } from './pages/home-page/home-page';
+import { DocumentationPage } from './pages/documentation-page/documentation-page';
 
 export interface IRenderedPage {
   html: string;
@@ -20,7 +21,11 @@ export const renderPage = (pathname: string): IRenderedPage => {
     const html = renderToString(
       sheet.collectStyles(
         <StaticRouter basename={routerBasename} location={location}>
-          <AppRoutes demoPage={<DemoPage />} homePage={<HomePage />} />
+          <AppRoutes
+            demoPage={<DemoPage />}
+            documentationPage={<DocumentationPage />}
+            homePage={<HomePage />}
+          />
         </StaticRouter>
       )
     );

--- a/example/src/main.tsx
+++ b/example/src/main.tsx
@@ -3,6 +3,7 @@ import { hydrateRoot } from 'react-dom/client';
 import { App } from './app/app';
 import { DemoPage } from './pages/demo-page/demo-page';
 import { HomePage } from './pages/home-page/home-page';
+import { DocumentationPage } from './pages/documentation-page/documentation-page';
 import { reportRecoverableError } from './report-recoverable-error';
 
 const rootElement = document.getElementById('root');
@@ -13,7 +14,11 @@ if (!rootElement) {
 
 hydrateRoot(
   rootElement,
-  <App demoPage={<DemoPage />} homePage={<HomePage />} />,
+  <App
+    demoPage={<DemoPage />}
+    documentationPage={<DocumentationPage />}
+    homePage={<HomePage />}
+  />,
   {
     onRecoverableError: reportRecoverableError,
   }

--- a/example/src/v1/entry-client.tsx
+++ b/example/src/v1/entry-client.tsx
@@ -3,5 +3,12 @@ import { App } from '../app/app';
 import { hydrateApp } from '../shared/client/hydrate-app.util';
 import { DemoPage } from './pages/demo-page/demo-page';
 import { HomePage } from './pages/home-page/home-page';
+import { DocumentationPage } from './pages/documentation-page/documentation-page';
 
-hydrateApp(<App demoPage={<DemoPage />} homePage={<HomePage />} />);
+hydrateApp(
+  <App
+    demoPage={<DemoPage />}
+    documentationPage={<DocumentationPage />}
+    homePage={<HomePage />}
+  />
+);

--- a/example/src/v1/entry-server.test.tsx
+++ b/example/src/v1/entry-server.test.tsx
@@ -1,7 +1,8 @@
 import { describe, expect, it } from 'vitest';
+import { documentationBaseline } from './pages/documentation-page/constants/documentation-baseline';
 import { renderPage } from './entry-server';
 
-describe('v1 Home and Demo SSR', () => {
+describe('v1 version-owned SSR', () => {
   it('renders the frozen Home copy with styled-components output', () => {
     const page = renderPage('/');
 
@@ -26,5 +27,22 @@ describe('v1 Home and Demo SSR', () => {
       'Loading the interactive query builder playground...'
     );
     expect(page.styles).toContain('data-styled="true"');
+  });
+
+  it.each(documentationBaseline)(
+    'renders the frozen Documentation content for $path',
+    ({ path, title }) => {
+      const page = renderPage(path);
+
+      expect(page.html).toContain(`>${title}</h1>`);
+      expect(page.styles).toContain('data-styled="true"');
+    }
+  );
+
+  it('preserves the parsing sandbox client-only boundary', () => {
+    const page = renderPage('/documentation/parsing-and-formatting');
+
+    expect(page.html).toContain('data-client-only-placeholder="true"');
+    expect(page.html).toContain('Loading the interactive parsing sandbox...');
   });
 });

--- a/example/src/v1/entry-server.tsx
+++ b/example/src/v1/entry-server.tsx
@@ -4,10 +4,15 @@ import { routerBasename } from '../app/router-basename';
 import { renderApp } from '../shared/ssr/render-app.util';
 import { DemoPage } from './pages/demo-page/demo-page';
 import { HomePage } from './pages/home-page/home-page';
+import { DocumentationPage } from './pages/documentation-page/documentation-page';
 
 export const renderPage = (pathname: string) =>
   renderApp(
     pathname,
     routerBasename,
-    <AppRoutes demoPage={<DemoPage />} homePage={<HomePage />} />
+    <AppRoutes
+      demoPage={<DemoPage />}
+      documentationPage={<DocumentationPage />}
+      homePage={<HomePage />}
+    />
   );

--- a/example/src/v1/pages/documentation-page/components/imperative-field-options-demo.tsx
+++ b/example/src/v1/pages/documentation-page/components/imperative-field-options-demo.tsx
@@ -1,0 +1,138 @@
+import * as React from 'react';
+import styled from 'styled-components';
+import {
+  Builder,
+  useBuilderRef,
+  type DenormalizedQuery,
+  type IBuilderFieldProps,
+} from '@vojtechportes/react-query-builder';
+import { waitForTimeout } from '../utils/wait-for-timeout.util';
+
+const DemoCard = styled.div`
+  display: grid;
+  gap: 1rem;
+  padding: 1rem;
+  border: 1px solid #dbe4f0;
+  border-radius: 18px;
+  background: linear-gradient(180deg, #ffffff 0%, #f8fbff 100%);
+`;
+
+const fields: IBuilderFieldProps[] = [
+  {
+    field: 'COUNTRY',
+    label: 'Country',
+    type: 'LIST',
+    operators: ['EQUAL'],
+    value: [
+      { value: 'CZ', label: 'Czech Republic' },
+      { value: 'SK', label: 'Slovakia' },
+      { value: 'DE', label: 'Germany' },
+    ],
+  },
+  {
+    field: 'CITY',
+    label: 'City',
+    type: 'LIST',
+    operators: ['EQUAL'],
+    value: [],
+  },
+];
+
+const initialData: DenormalizedQuery = [
+  {
+    type: 'GROUP',
+    value: 'AND',
+    isNegated: false,
+    children: [
+      {
+        type: 'GROUP',
+        value: 'AND',
+        isNegated: false,
+        children: [
+          {
+            field: 'COUNTRY',
+            operator: 'EQUAL',
+            value: 'CZ',
+          },
+          {
+            field: 'CITY',
+            operator: 'EQUAL',
+            value: 'PRG',
+          },
+        ],
+      },
+      {
+        type: 'GROUP',
+        value: 'AND',
+        isNegated: false,
+        children: [
+          {
+            field: 'COUNTRY',
+            operator: 'EQUAL',
+            value: 'SK',
+          },
+          {
+            field: 'CITY',
+            operator: 'EQUAL',
+            value: 'BTS',
+          },
+        ],
+      },
+    ],
+  },
+];
+
+const cityOptionsByCountry: Record<string, { value: string; label: string }[]> =
+  {
+    CZ: [
+      { value: 'PRG', label: 'Prague' },
+      { value: 'BRN', label: 'Brno' },
+      { value: 'OSR', label: 'Ostrava' },
+    ],
+    SK: [
+      { value: 'BTS', label: 'Bratislava' },
+      { value: 'KSC', label: 'Kosice' },
+      { value: 'ZIL', label: 'Zilina' },
+    ],
+    DE: [
+      { value: 'BER', label: 'Berlin' },
+      { value: 'MUC', label: 'Munich' },
+      { value: 'HAM', label: 'Hamburg' },
+    ],
+  };
+
+export const ImperativeFieldOptionsDemo: React.FC = () => {
+  const [data, setData] = React.useState<DenormalizedQuery>(initialData);
+  const builderRef = useBuilderRef();
+  React.useEffect(() => {
+    return builderRef.bindRuleOptions('CITY', {
+      dependencies: ['COUNTRY'],
+      resolve: async ({ dependencies, signal }) => {
+        const countryValue = dependencies.COUNTRY?.value;
+
+        if (typeof countryValue !== 'string') {
+          return [];
+        }
+
+        await waitForTimeout(550, signal);
+        return cityOptionsByCountry[countryValue] ?? [];
+      },
+      onOptionsResolved: ({ ruleId }) => {
+        builderRef.reconcileRuleValueWithOptions(ruleId, {
+          strategy: 'clear-if-missing',
+        });
+      },
+    });
+  }, [builderRef]);
+
+  return (
+    <DemoCard>
+      <Builder
+        ref={builderRef}
+        fields={fields}
+        data={data}
+        onChange={setData}
+      />
+    </DemoCard>
+  );
+};

--- a/example/src/v1/pages/documentation-page/components/parsing-sandbox.tsx
+++ b/example/src/v1/pages/documentation-page/components/parsing-sandbox.tsx
@@ -1,0 +1,253 @@
+import * as React from 'react';
+import styled from 'styled-components';
+import {
+  Builder,
+  type DenormalizedQuery,
+  type IBuilderFieldProps,
+} from '@vojtechportes/react-query-builder';
+import { ThemeProvider } from '@vojtechportes/react-query-builder';
+import { parseQuery } from '@vojtechportes/react-query-builder/parseQuery';
+import { AlertBox } from '../../../../components/alert-box';
+import { CodeBlock } from '../../../../components/code-block';
+import { defaultTheme } from '../../demo-page/constants/default-theme';
+import { demoFields } from '../../demo-page/constants/demo-fields';
+import { supportedFormats } from '../../demo-page/constants/supported-formats';
+import type { SupportedQueryFormat } from '../../demo-page/types/supported-query-format';
+import { formatQueryText } from '../../demo-page/utils/format-query-text.util';
+import { inferCodeLanguage } from '../../demo-page/utils/infer-code-language.util';
+import { parsingSandboxInitialQueryTree } from '../constants/parsing-sandbox-initial-query-tree';
+import { siteTheme } from '../../../../constants/site-theme';
+
+const Root = styled.section`
+  display: grid;
+  gap: 1.25rem;
+  min-width: 0;
+  padding: 1.5rem;
+  border: 1px solid #dbe4f0;
+  border-radius: 16px;
+  background: linear-gradient(180deg, #ffffff 0%, #f8fbff 100%);
+
+  @media (max-width: 540px) {
+    padding: 1.25rem;
+  }
+`;
+
+const Header = styled.div`
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  min-width: 0;
+`;
+
+const Title = styled.h3`
+  margin: 0;
+  font-size: 1.2rem;
+`;
+
+const SelectRow = styled.div`
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+  min-width: 0;
+`;
+
+const Select = styled.select`
+  min-width: 170px;
+  padding: 0.8rem 2.4rem 0.8rem 0.95rem;
+  border: 1px solid #dbe4f0;
+  border-radius: 16px;
+  background: #fff;
+  color: #0f172a;
+  font-size: 0.98rem;
+  appearance: none;
+  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='12' height='12' viewBox='0 0 12 12' fill='none'%3E%3Cpath d='M2.5 4.5L6 8L9.5 4.5' stroke='%230f172a' stroke-width='1.5' stroke-linecap='round' stroke-linejoin='round'/%3E%3C/svg%3E");
+  background-repeat: no-repeat;
+  background-position: right 0.95rem center;
+
+  &:focus {
+    outline: none;
+    border-color: ${siteTheme.primaryLight};
+    box-shadow: 0 0 0 3px ${siteTheme.primaryGlow};
+  }
+`;
+
+const Textarea = styled.textarea`
+  width: 100%;
+  max-width: 100%;
+  min-height: 220px;
+  padding: 1rem;
+  border: 1px solid #dbe4f0;
+  border-radius: 16px;
+  resize: vertical;
+  background: #fff;
+  color: #0f172a;
+  line-height: 1.6;
+`;
+
+const BuilderCard = styled.div`
+  min-width: 0;
+  padding: 1.25rem;
+  border: 1px solid #dbe4f0;
+  border-radius: 16px;
+  background: #fff;
+`;
+
+const BuilderScrollArea = styled.div`
+  overflow-x: auto;
+  overflow-y: hidden;
+  padding-bottom: 0.35rem;
+`;
+
+const BuilderViewport = styled.div`
+  display: inline-block;
+  font-family: Arial, sans-serif;
+  font-size: 16px;
+  line-height: normal;
+`;
+
+const formatExample = (
+  query: DenormalizedQuery,
+  format: SupportedQueryFormat
+) => formatQueryText(query, format, demoFields);
+
+export const ParsingSandbox: React.FC = () => {
+  const [inputFormat, setInputFormat] =
+    React.useState<SupportedQueryFormat>('SQL');
+  const [outputFormat, setOutputFormat] =
+    React.useState<SupportedQueryFormat>('Mongo');
+  const [builderData, setBuilderData] = React.useState<DenormalizedQuery>(
+    parsingSandboxInitialQueryTree
+  );
+  const [builderFields, setBuilderFields] =
+    React.useState<IBuilderFieldProps[]>(demoFields);
+  const [inputText, setInputText] = React.useState(() =>
+    formatExample(parsingSandboxInitialQueryTree, 'SQL')
+  );
+  const [inputError, setInputError] = React.useState<string | null>(null);
+  const [outputError, setOutputError] = React.useState<string | null>(null);
+
+  const outputState = React.useMemo(() => {
+    try {
+      return {
+        text: formatQueryText(builderData, outputFormat, builderFields),
+        error: null,
+      };
+    } catch (error) {
+      return {
+        text: '',
+        error:
+          error instanceof Error ? error.message : 'Unknown formatting error.',
+      };
+    }
+  }, [builderData, builderFields, outputFormat]);
+
+  React.useEffect(() => {
+    setOutputError(outputState.error);
+  }, [outputState.error]);
+
+  const applyParse = React.useCallback(
+    (value: string, format: SupportedQueryFormat) => {
+      setInputText(value);
+
+      try {
+        const parsed = parseQuery(value, format);
+        setBuilderData(parsed.data);
+        setBuilderFields(parsed.fields.length > 0 ? parsed.fields : demoFields);
+        setInputError(null);
+      } catch (error) {
+        setInputError(
+          error instanceof Error ? error.message : 'Unknown parsing error.'
+        );
+      }
+    },
+    []
+  );
+
+  return (
+    <Root>
+      <Header>
+        <div>
+          <Title>Parsing and formatting sandbox</Title>
+          <p>
+            Switch formats, paste an expression, and watch the generated builder
+            and reformatted output update in one place.
+          </p>
+        </div>
+
+        <SelectRow>
+          <Select
+            value={inputFormat}
+            onChange={(event) => {
+              const nextFormat = event.target.value as SupportedQueryFormat;
+              setInputFormat(nextFormat);
+              const nextText = formatExample(builderData, nextFormat);
+              setInputText(nextText);
+              setInputError(null);
+            }}
+          >
+            {supportedFormats.map((format) => (
+              <option key={format} value={format}>
+                Input: {format}
+              </option>
+            ))}
+          </Select>
+
+          <Select
+            value={outputFormat}
+            onChange={(event) =>
+              setOutputFormat(event.target.value as SupportedQueryFormat)
+            }
+          >
+            {supportedFormats.map((format) => (
+              <option key={format} value={format}>
+                Output: {format}
+              </option>
+            ))}
+          </Select>
+        </SelectRow>
+      </Header>
+
+      <Textarea
+        value={inputText}
+        onChange={(event) => applyParse(event.target.value, inputFormat)}
+      />
+
+      {inputError ? (
+        <AlertBox title="Parse error" variant="warning">
+          {inputError}
+        </AlertBox>
+      ) : null}
+
+      <BuilderCard>
+        <BuilderScrollArea>
+          <BuilderViewport>
+            <ThemeProvider colors={defaultTheme.colors}>
+              <Builder
+                data={builderData}
+                fields={builderFields}
+                groupTypes="both"
+                singleRootGroup
+                showValidation
+                onChange={setBuilderData}
+              />
+            </ThemeProvider>
+          </BuilderViewport>
+        </BuilderScrollArea>
+      </BuilderCard>
+
+      {outputError ? (
+        <AlertBox title="Format error" variant="warning">
+          {outputError}
+        </AlertBox>
+      ) : (
+        <CodeBlock
+          code={outputState.text}
+          language={inferCodeLanguage(outputFormat)}
+          label={`${outputFormat} output`}
+        />
+      )}
+    </Root>
+  );
+};

--- a/example/src/v1/pages/documentation-page/components/shared-field-options-demo.tsx
+++ b/example/src/v1/pages/documentation-page/components/shared-field-options-demo.tsx
@@ -1,0 +1,162 @@
+import * as React from 'react';
+import styled from 'styled-components';
+import {
+  Builder,
+  useBuilderRef,
+  type DenormalizedQuery,
+  type IBuilderFieldOptionState,
+  type IBuilderFieldProps,
+} from '@vojtechportes/react-query-builder';
+
+const DemoCard = styled.div`
+  display: grid;
+  gap: 1rem;
+  padding: 1rem;
+  border: 1px solid #dbe4f0;
+  border-radius: 18px;
+  background: linear-gradient(180deg, #ffffff 0%, #f8fbff 100%);
+`;
+
+const Toolbar = styled.div`
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+  align-items: center;
+  justify-content: space-between;
+`;
+
+const SmallButton = styled.button`
+  padding: 0.6rem 0.9rem;
+  border: 1px solid #cbd5e1;
+  border-radius: 999px;
+  background: #fff;
+  color: #0f172a;
+  cursor: pointer;
+
+  &:hover {
+    border-color: #93c5fd;
+    background: #eff6ff;
+  }
+`;
+
+const StatusRow = styled.div`
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+  font-size: 0.95rem;
+  color: #334155;
+`;
+
+const fields: IBuilderFieldProps[] = [
+  {
+    field: 'CITY',
+    label: 'City',
+    type: 'LIST',
+    operators: ['EQUAL'],
+    value: [
+      { value: 'PRG', label: 'Prague' },
+      { value: 'BTS', label: 'Bratislava' },
+    ],
+  },
+];
+
+const initialData: DenormalizedQuery = [
+  {
+    type: 'GROUP',
+    value: 'AND',
+    isNegated: false,
+    children: [
+      {
+        field: 'CITY',
+        operator: 'EQUAL',
+        value: 'PRG',
+      },
+      {
+        field: 'CITY',
+        operator: 'EQUAL',
+        value: 'BTS',
+      },
+    ],
+  },
+];
+
+export const SharedFieldOptionsDemo: React.FC = () => {
+  const [data, setData] = React.useState<DenormalizedQuery>(initialData);
+  const [cityOptionState, setCityOptionState] =
+    React.useState<IBuilderFieldOptionState>({
+      options: Array.isArray(fields[0].value) ? fields[0].value : [],
+      status: 'idle',
+    });
+  const builderRef = useBuilderRef();
+
+  React.useEffect(
+    () => builderRef.subscribeToFieldOptionState('CITY', setCityOptionState),
+    [builderRef]
+  );
+
+  const loadSharedOptions = React.useCallback(
+    (mode: 'default' | 'czech' | 'slovak' | 'german') => {
+      builderRef.current?.setFieldOptionsStatus('CITY', 'loading');
+
+      window.setTimeout(() => {
+        if (mode === 'czech') {
+          builderRef.current?.setFieldOptions('CITY', [
+            { value: 'PRG', label: 'Prague' },
+            { value: 'BRN', label: 'Brno' },
+            { value: 'OSR', label: 'Ostrava' },
+          ]);
+          return;
+        }
+
+        if (mode === 'slovak') {
+          builderRef.current?.setFieldOptions('CITY', [
+            { value: 'BTS', label: 'Bratislava' },
+            { value: 'KSC', label: 'Kosice' },
+            { value: 'ZIL', label: 'Zilina' },
+          ]);
+          return;
+        }
+
+        if (mode === 'german') {
+          builderRef.current?.setFieldOptions('CITY', [
+            { value: 'BER', label: 'Berlin' },
+            { value: 'MUC', label: 'Munich' },
+            { value: 'HAM', label: 'Hamburg' },
+          ]);
+          return;
+        }
+
+        builderRef.current?.invalidateFieldOptions('CITY');
+      }, 500);
+    },
+    [builderRef]
+  );
+  return (
+    <DemoCard>
+      <Toolbar>
+        <SmallButton type="button" onClick={() => loadSharedOptions('czech')}>
+          Load Czech cities
+        </SmallButton>
+        <SmallButton type="button" onClick={() => loadSharedOptions('slovak')}>
+          Load Slovak cities
+        </SmallButton>
+        <SmallButton type="button" onClick={() => loadSharedOptions('german')}>
+          Load German cities
+        </SmallButton>
+        <SmallButton type="button" onClick={() => loadSharedOptions('default')}>
+          Reset to field.value
+        </SmallButton>
+      </Toolbar>
+      <StatusRow>
+        <span>Field state: {cityOptionState.status}</span>
+        <span>Shared options: {cityOptionState.options.length}</span>
+      </StatusRow>
+      <Builder
+        ref={builderRef}
+        fields={fields}
+        data={data}
+        onChange={setData}
+      />
+    </DemoCard>
+  );
+};

--- a/example/src/v1/pages/documentation-page/constants/documentation-baseline.ts
+++ b/example/src/v1/pages/documentation-page/constants/documentation-baseline.ts
@@ -1,0 +1,140 @@
+export const documentationBaseline = [
+  {
+    path: '/documentation',
+    title: 'Documentation Overview',
+    contentHash:
+      'e0c673c5c2a60ff73de78b2ac97b249a4311669b1522dd8b7706c9f74ea1ffa9',
+  },
+  {
+    path: '/documentation/installation',
+    title: 'Installation',
+    contentHash:
+      'e0385ad2c7ce036afbf95470e5627f1573553a63d0a5bfc3ef7467e1d38975a2',
+  },
+  {
+    path: '/documentation/usage',
+    title: 'Usage',
+    contentHash:
+      '764fd4078f038a9d1cb5c0835a99d652f53cc3a18094b28e8606015577897d74',
+  },
+  {
+    path: '/documentation/builder-behavior',
+    title: 'Builder Behavior',
+    contentHash:
+      'c2bb396032346ebbcfa6ed1c6e0beb7099e1f88d087246f26f5b50c085f7561e',
+  },
+  {
+    path: '/documentation/builder-ref',
+    title: 'Builder Ref',
+    contentHash:
+      'a70765ebd3d09c74aeb8351ad5cc6c4cae0327e2386230b4ef7bfa143fbd4617',
+  },
+  {
+    path: '/documentation/field-comparisons',
+    title: 'Field Comparisons',
+    contentHash:
+      '410d28b3955d51ad0ad0df72e18280d378ed97e8a340fa8e525129e76f310788',
+  },
+  {
+    path: '/documentation/dynamic-field-options',
+    title: 'Dynamic Field Options',
+    contentHash:
+      '29528dee02cb21bcdabebbd8344706087bb0f25d7635b752ca4f75b6955bd58e',
+  },
+  {
+    path: '/documentation/validation',
+    title: 'Validation',
+    contentHash:
+      '630b117a9d402d25c5d128ee3ec8fa6d839d6b32043384a922f124f44a8ec7f2',
+  },
+  {
+    path: '/documentation/history',
+    title: 'Undo and Redo',
+    contentHash:
+      'ee78f399929c36c9f266f354c6e57e11c3682d0e7b01ec662cc890f80afefcf3',
+  },
+  {
+    path: '/documentation/locking-and-read-only',
+    title: 'Locking and Read-only',
+    contentHash:
+      '12ce1ecf0bad544558206d4c76c3de13b4c34be03541a87efb75e94310cfeadd',
+  },
+  {
+    path: '/documentation/parsing-and-formatting',
+    title: 'Overview',
+    contentHash:
+      '0b57e0266e2066de98cedb214072ff27b6ee157a35e03a889a9797717b5f4783',
+  },
+  {
+    path: '/documentation/parsing-and-formatting/supported-formats',
+    title: 'Supported Formats',
+    contentHash:
+      '8bfa7855bc503b2eee4b48533b9ce5cb1ce1a669198a57dbfb6c1c18b01689b1',
+  },
+  {
+    path: '/documentation/text-mode',
+    title: 'Text Mode',
+    contentHash:
+      '961a240ccec92394dd30b92bf1f72ca352fbbcd328143d8b0eae532fe003cce1',
+  },
+  {
+    path: '/documentation/components',
+    title: 'Components',
+    contentHash:
+      '03899815efa95fb6ec42356df1610cbb2a74d040901d223089441338926ae550',
+  },
+  {
+    path: '/documentation/adapters',
+    title: 'Adapters',
+    contentHash:
+      '623743d4ecbfc64411b4227e477638944843b18a25b4b1a86394b5814c63252f',
+  },
+  {
+    path: '/documentation/adapters/mui',
+    title: 'MUI',
+    contentHash:
+      '551a2029e27410e98ac5d36998f2def51f9a82094a1c005126dd222e15e14cc8',
+  },
+  {
+    path: '/documentation/adapters/antd',
+    title: 'ANTD',
+    contentHash:
+      '55c9b1b47f48aa2e783dcb327e6498b3e6b7742f1fa05a940f7c7bf296dfd6bb',
+  },
+  {
+    path: '/documentation/adapters/fluentui',
+    title: 'Fluent UI',
+    contentHash:
+      '76664ff1e9ee04935ca58f7255881ea6db80088af37bacd2b855f7a30418c25e',
+  },
+  {
+    path: '/documentation/adapters/mantine',
+    title: 'Mantine',
+    contentHash:
+      'a868177d59eb4efba6e7d67c3041524a464adf5fd4b4afc4ce000ce1def02b5d',
+  },
+  {
+    path: '/documentation/adapters/bootstrap',
+    title: 'Bootstrap',
+    contentHash:
+      '4beca84339cbe889e8b545fac29b402dc4bd2f3c803550e2b77232441c94c2cb',
+  },
+  {
+    path: '/documentation/adapters/radix',
+    title: 'Radix',
+    contentHash:
+      '8c0055ec6bddb17983d3c2eeb16b22fca9aa20aff1b88b83b3848ca3e3a103b1',
+  },
+  {
+    path: '/documentation/theming',
+    title: 'Theming',
+    contentHash:
+      '9e2fa30cbec8402749d1989bfb149ac3f51e81c92fc3df1d9ca3341ec373d277',
+  },
+  {
+    path: '/documentation/localization',
+    title: 'Localization',
+    contentHash:
+      '0d75a7ba7623017766f09a994f7b59a0fae5a96d3906c025f7354f775680a46e',
+  },
+] as const;

--- a/example/src/v1/pages/documentation-page/constants/documentation-groups.ts
+++ b/example/src/v1/pages/documentation-page/constants/documentation-groups.ts
@@ -1,0 +1,31 @@
+import type { IDocumentationGroup } from '../types/documentation-group';
+import { documentationPages } from './documentation-pages';
+
+export const documentationGroups: IDocumentationGroup[] = [
+  {
+    key: 'getting-started',
+    title: 'Getting Started',
+    pages: documentationPages.filter(
+      (page) => page.sectionKey === 'getting-started'
+    ),
+  },
+  {
+    key: 'parsing',
+    title: 'Parsing and Formatting',
+    pages: documentationPages.filter((page) => page.sectionKey === 'parsing'),
+  },
+  {
+    key: 'customization',
+    title: 'Customization',
+    pages: documentationPages.filter(
+      (page) => page.sectionKey === 'customization'
+    ),
+  },
+  {
+    key: 'single-localization',
+    title: 'Localization',
+    pages: documentationPages.filter(
+      (page) => page.sectionKey === 'single-localization'
+    ),
+  },
+];

--- a/example/src/v1/pages/documentation-page/constants/documentation-pages.ts
+++ b/example/src/v1/pages/documentation-page/constants/documentation-pages.ts
@@ -1,0 +1,50 @@
+import { overviewDocumentationPage } from '../pages/overview.documentation-page';
+import { installationDocumentationPage } from '../pages/installation.documentation-page';
+import { usageDocumentationPage } from '../pages/usage.documentation-page';
+import { builderBehaviorDocumentationPage } from '../pages/builder-behavior.documentation-page';
+import { builderRefDocumentationPage } from '../pages/builder-ref.documentation-page';
+import { fieldComparisonsDocumentationPage } from '../pages/field-comparisons.documentation-page';
+import { dynamicFieldOptionsDocumentationPage } from '../pages/dynamic-field-options.documentation-page';
+import { validationDocumentationPage } from '../pages/validation.documentation-page';
+import { historyDocumentationPage } from '../pages/history.documentation-page';
+import { lockingAndReadOnlyDocumentationPage } from '../pages/locking-and-read-only.documentation-page';
+import { parsingAndFormattingDocumentationPage } from '../pages/parsing-and-formatting.documentation-page';
+import { parsingAndFormattingSupportedFormatsDocumentationPage } from '../pages/parsing-and-formatting-supported-formats.documentation-page';
+import { textModeDocumentationPage } from '../pages/text-mode.documentation-page';
+import { componentsDocumentationPage } from '../pages/components.documentation-page';
+import { adaptersDocumentationPage } from '../pages/adapters.documentation-page';
+import { adaptersMuiDocumentationPage } from '../pages/adapters-mui.documentation-page';
+import { adaptersAntdDocumentationPage } from '../pages/adapters-antd.documentation-page';
+import { adaptersFluentuiDocumentationPage } from '../pages/adapters-fluentui.documentation-page';
+import { adaptersMantineDocumentationPage } from '../pages/adapters-mantine.documentation-page';
+import { adaptersBootstrapDocumentationPage } from '../pages/adapters-bootstrap.documentation-page';
+import { adaptersRadixDocumentationPage } from '../pages/adapters-radix.documentation-page';
+import { themingDocumentationPage } from '../pages/theming.documentation-page';
+import { localizationDocumentationPage } from '../pages/localization.documentation-page';
+import type { IDocumentationPage } from '../types/documentation-page';
+
+export const documentationPages: IDocumentationPage[] = [
+  overviewDocumentationPage,
+  installationDocumentationPage,
+  usageDocumentationPage,
+  builderBehaviorDocumentationPage,
+  builderRefDocumentationPage,
+  fieldComparisonsDocumentationPage,
+  dynamicFieldOptionsDocumentationPage,
+  validationDocumentationPage,
+  historyDocumentationPage,
+  lockingAndReadOnlyDocumentationPage,
+  parsingAndFormattingDocumentationPage,
+  parsingAndFormattingSupportedFormatsDocumentationPage,
+  textModeDocumentationPage,
+  componentsDocumentationPage,
+  adaptersDocumentationPage,
+  adaptersMuiDocumentationPage,
+  adaptersAntdDocumentationPage,
+  adaptersFluentuiDocumentationPage,
+  adaptersMantineDocumentationPage,
+  adaptersBootstrapDocumentationPage,
+  adaptersRadixDocumentationPage,
+  themingDocumentationPage,
+  localizationDocumentationPage,
+];

--- a/example/src/v1/pages/documentation-page/constants/parsing-sandbox-initial-query-tree.ts
+++ b/example/src/v1/pages/documentation-page/constants/parsing-sandbox-initial-query-tree.ts
@@ -1,0 +1,48 @@
+import type { DenormalizedQuery } from '@vojtechportes/react-query-builder';
+
+export const parsingSandboxInitialQueryTree: DenormalizedQuery = [
+  {
+    type: 'GROUP',
+    value: 'AND',
+    isNegated: false,
+    children: [
+      {
+        field: 'CUSTOMER_COUNTRY',
+        operator: 'EQUAL',
+        value: 'CZ',
+      },
+      {
+        type: 'GROUP',
+        value: 'OR',
+        isNegated: false,
+        children: [
+          {
+            field: 'CUSTOMER_CITY',
+            operator: 'EQUAL',
+            value: 'Prague',
+          },
+          {
+            field: 'ORDER_TOTAL',
+            operator: 'BETWEEN',
+            value: [2500, 12000],
+          },
+        ],
+      },
+      {
+        field: 'IS_VAT_PAYER',
+        operator: 'EQUAL',
+        value: true,
+      },
+      {
+        field: 'CUSTOMER_SEGMENTS',
+        operator: 'ALL_IN',
+        value: ['B2B', 'Priority'],
+      },
+      {
+        field: 'ORDER_CREATED_AT',
+        operator: 'LARGER_EQUAL',
+        value: '2025-01-01',
+      },
+    ],
+  },
+];

--- a/example/src/v1/pages/documentation-page/constants/related-recipes-by-path.ts
+++ b/example/src/v1/pages/documentation-page/constants/related-recipes-by-path.ts
@@ -1,0 +1,76 @@
+export const relatedRecipesByPath: Record<
+  string,
+  { path: string; label: string }[]
+> = {
+  '/documentation/dynamic-field-options': [
+    {
+      path: '/recipes/dynamic-operators-by-field-type',
+      label: 'Dynamic operators by field type',
+    },
+  ],
+  '/documentation/validation': [
+    {
+      path: '/recipes/save-load-filter-presets',
+      label: 'Save and validate filter presets',
+    },
+    { path: '/recipes/server-side-filtering', label: 'Server-side filtering' },
+    {
+      path: '/recipes/ai-assisted-filter-creation',
+      label: 'AI-assisted filter creation',
+    },
+  ],
+  '/documentation/history': [
+    {
+      path: '/recipes/persist-filters-in-url',
+      label: 'Persist filters in URL state',
+    },
+    {
+      path: '/recipes/save-load-filter-presets',
+      label: 'Save and load filter presets',
+    },
+  ],
+  '/documentation/locking-and-read-only': [
+    {
+      path: '/recipes/server-side-filtering',
+      label: 'Enforce filters on the server',
+    },
+    {
+      path: '/recipes/ai-assisted-filter-creation',
+      label: 'Review AI-generated draft filters',
+    },
+  ],
+  '/documentation/parsing-and-formatting/supported-formats': [
+    {
+      path: '/recipes/sql-where-to-react-query-builder',
+      label: 'Import a SQL WHERE clause',
+    },
+    {
+      path: '/recipes/export-to-mongodb-query',
+      label: 'Export a MongoDB query',
+    },
+    {
+      path: '/recipes/export-to-prisma-where-clause',
+      label: 'Export a Prisma where clause',
+    },
+  ],
+  '/documentation/components': [
+    {
+      path: '/recipes/ag-grid-query-builder',
+      label: 'AG Grid external filter panel',
+    },
+    {
+      path: '/recipes/tanstack-table-filtering',
+      label: 'TanStack Table filtering',
+    },
+    {
+      path: '/recipes/react-hook-form-query-builder',
+      label: 'React Hook Form integration',
+    },
+  ],
+  '/documentation/adapters/mui': [
+    {
+      path: '/recipes/mui-datagrid-advanced-filtering',
+      label: 'MUI DataGrid advanced filtering',
+    },
+  ],
+};

--- a/example/src/v1/pages/documentation-page/documentation-content.test.tsx
+++ b/example/src/v1/pages/documentation-page/documentation-content.test.tsx
@@ -1,0 +1,67 @@
+import * as React from 'react';
+import { renderToStaticMarkup } from 'react-dom/server';
+import { StaticRouter } from 'react-router-dom';
+import { describe, expect, it } from 'vitest';
+import { documentationBaseline } from './constants/documentation-baseline';
+import { documentationPages } from './constants/documentation-pages';
+import { findDocumentationPage } from './utils/find-documentation-page.util';
+import { hashDocumentationContent } from './utils/hash-documentation-content.util';
+
+describe('v1 Documentation content', () => {
+  it('preserves the complete ordered route and title registry', () => {
+    expect(
+      documentationPages.map(({ path, title }) => ({ path, title }))
+    ).toEqual(
+      documentationBaseline.map(({ path, title }) => ({ path, title }))
+    );
+  });
+
+  it('preserves the normalized raw content for every route', async () => {
+    for (const { path, contentHash } of documentationBaseline) {
+      const page = findDocumentationPage(path);
+      const content = renderToStaticMarkup(
+        <StaticRouter location={path}>{page.content}</StaticRouter>
+      ).replace(/ class="[^"]*"/g, '');
+
+      await expect(hashDocumentationContent(content)).resolves.toBe(
+        contentHash
+      );
+    }
+  });
+
+  it('normalizes trailing slashes and preserves the overview fallback', () => {
+    expect(
+      findDocumentationPage('/documentation/dynamic-field-options/').path
+    ).toBe('/documentation/dynamic-field-options');
+    expect(findDocumentationPage('/documentation/unknown').path).toBe(
+      '/documentation'
+    );
+  });
+
+  it.each([
+    [
+      '/documentation/installation',
+      'npm install @vojtechportes/react-query-builder',
+    ],
+    ['/documentation/parsing-and-formatting/supported-formats', 'formatQuery'],
+    ['/documentation/parsing-and-formatting/supported-formats', 'parseQuery'],
+    ['/documentation/text-mode', '@vojtechportes/react-query-builder/monaco'],
+    [
+      '/documentation/adapters/mui',
+      '@vojtechportes/react-query-builder/mui/v9',
+    ],
+    ['/documentation/theming', 'ThemeProvider'],
+    [
+      '/documentation/localization',
+      '@vojtechportes/react-query-builder/locale/fr-FR',
+    ],
+  ])('preserves the frozen %s code sample', (path, sample) => {
+    const content = renderToStaticMarkup(
+      <StaticRouter location={path}>
+        {findDocumentationPage(path).content}
+      </StaticRouter>
+    );
+
+    expect(content).toContain(sample);
+  });
+});

--- a/example/src/v1/pages/documentation-page/documentation-loaders.test.ts
+++ b/example/src/v1/pages/documentation-page/documentation-loaders.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from 'vitest';
+import { ImperativeFieldOptionsDemo } from './components/imperative-field-options-demo';
+import { ParsingSandbox } from './components/parsing-sandbox';
+import { SharedFieldOptionsDemo } from './components/shared-field-options-demo';
+import { loadImperativeFieldOptionsDemo } from './utils/load-imperative-field-options-demo.util';
+import { loadParsingSandbox } from './utils/load-parsing-sandbox.util';
+import { loadSharedFieldOptionsDemo } from './utils/load-shared-field-options-demo.util';
+
+describe('v1 Documentation lazy loaders', () => {
+  it('loads the v1-owned interactive documentation components', async () => {
+    await expect(loadImperativeFieldOptionsDemo()).resolves.toEqual({
+      default: ImperativeFieldOptionsDemo,
+    });
+    await expect(loadSharedFieldOptionsDemo()).resolves.toEqual({
+      default: SharedFieldOptionsDemo,
+    });
+    await expect(loadParsingSandbox()).resolves.toEqual({
+      default: ParsingSandbox,
+    });
+  });
+});

--- a/example/src/v1/pages/documentation-page/documentation-page.tsx
+++ b/example/src/v1/pages/documentation-page/documentation-page.tsx
@@ -1,0 +1,74 @@
+import * as React from 'react';
+import { useLocation } from 'react-router-dom';
+import styled from 'styled-components';
+import { ClientOnly } from '../../../components/client-only';
+import { ContentArticle } from '../../../components/content-article';
+import { DocumentationSidebar } from '../../../components/documentation-sidebar';
+import { RelatedRecipes } from '../../../components/related-recipes';
+import { findSeoPage } from '../../../constants/seo-pages';
+import { usePageMetadata } from '../../../hooks/use-page-metadata';
+import { documentationGroups } from './constants/documentation-groups';
+import { documentationPages } from './constants/documentation-pages';
+import { relatedRecipesByPath } from './constants/related-recipes-by-path';
+import { findDocumentationPage } from './utils/find-documentation-page.util';
+import { loadParsingSandbox } from './utils/load-parsing-sandbox.util';
+
+const Layout = styled.div`
+  display: grid;
+  grid-template-columns: 280px minmax(0, 1fr);
+  gap: 1.5rem;
+
+  @media (max-width: 1080px) {
+    grid-template-columns: 1fr;
+  }
+`;
+
+const SectionLabel = styled.span`
+  font-size: 0.8rem;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: #64748b;
+`;
+
+const Title = styled.h1`
+  margin: 0;
+  margin-bottom: 1rem;
+  font-size: clamp(2rem, 4vw, 3rem);
+`;
+
+const Summary = styled.p`
+  font-size: 1.05rem;
+  margin-top: 0.55rem;
+`;
+
+export const DocumentationPage: React.FC = () => {
+  const location = useLocation();
+  const page = findDocumentationPage(location.pathname);
+  const seoPage = findSeoPage(page.path);
+
+  usePageMetadata(seoPage.title, seoPage.description, seoPage);
+
+  return (
+    <Layout>
+      <DocumentationSidebar
+        title="Documentation"
+        overviewPage={documentationPages[0]}
+        groups={documentationGroups}
+      />
+      <ContentArticle>
+        <SectionLabel>{page.sectionTitle}</SectionLabel>
+        <Title>{page.title}</Title>
+        {page.summary ? <Summary>{page.summary}</Summary> : null}
+        {page.content}
+        <RelatedRecipes links={relatedRecipesByPath[page.path]} />
+        {page.path === '/documentation/parsing-and-formatting' ? (
+          <ClientOnly
+            loader={loadParsingSandbox}
+            label="Loading the interactive parsing sandbox..."
+            minHeight="20rem"
+          />
+        ) : null}
+      </ContentArticle>
+    </Layout>
+  );
+};

--- a/example/src/v1/pages/documentation-page/pages/adapters-antd.documentation-page.tsx
+++ b/example/src/v1/pages/documentation-page/pages/adapters-antd.documentation-page.tsx
@@ -1,0 +1,122 @@
+import * as React from 'react';
+import { AlertBox } from '../../../../components/alert-box';
+import { CodeBlock } from '../../../../components/code-block';
+import {
+  InlineCode,
+  List,
+  SectionTitle,
+  TextLink,
+} from '../../../../components/docs-primitives';
+import type { IDocumentationPage } from '../types/documentation-page';
+
+const antdSnippet = `import {
+  Builder,
+  type DenormalizedQuery,
+} from '@vojtechportes/react-query-builder';
+import { components } from '@vojtechportes/react-query-builder/antd/v6';
+
+export const MyAntdBuilder = () => {
+  const [data, setData] = useState<DenormalizedQuery>(initialData);
+
+  return (
+    <Builder
+      data={data}
+      fields={fields}
+      components={components}
+      onChange={setData}
+    />
+  );
+};`;
+
+const antdAdaptersInstallSnippet = `npm install antd@^6.0.0 @ant-design/icons@^6.0.0`;
+
+const antdCreateComponentsSnippet = `import {
+  Builder,
+  type DenormalizedQuery,
+} from '@vojtechportes/react-query-builder';
+import {
+  createAntdComponents,
+  components as antdComponents,
+} from '@vojtechportes/react-query-builder/antd/v6';
+
+const components = createAntdComponents(antdComponents, {
+  form: {
+    Input: MyInput,
+  },
+  Add: MyAddButton,
+});
+
+export const MyAntdBuilder = () => {
+  const [data, setData] = useState<DenormalizedQuery>(initialData);
+
+  return (
+    <Builder
+      data={data}
+      fields={fields}
+      components={components}
+      onChange={setData}
+    />
+  );
+};`;
+
+export const adaptersAntdDocumentationPage: IDocumentationPage = {
+  path: '/documentation/adapters/antd',
+  title: 'ANTD',
+  depth: 1,
+  sectionKey: 'customization',
+  sectionTitle: 'Customization',
+  summary: '',
+  description:
+    'Documentation for the Ant Design adapter, including antd/v6, legacy antd/v5 support, installation, and component merging.',
+  searchText:
+    'ANTD adapter ant design antd v6 antd v5 adapter install createAntdComponents components',
+  content: (
+    <>
+      <p>
+        Use the ANTD adapter when your application uses Ant Design and you want
+        the builder controls to match the surrounding system components.
+      </p>
+      <SectionTitle>Available entrypoints</SectionTitle>
+      <List>
+        <li>
+          <InlineCode>@vojtechportes/react-query-builder/antd/v6</InlineCode> is
+          the recommended entrypoint for new Ant Design projects and is
+          available in the demo.
+        </li>
+        <li>
+          <InlineCode>@vojtechportes/react-query-builder/antd/v5</InlineCode> is
+          available for applications that are still on Ant Design 5.
+        </li>
+      </List>
+      <SectionTitle>Installing ANTD</SectionTitle>
+      <p>
+        Install the Ant Design peer dependencies that match the adapter version
+        you want to use. For new setups, prefer <InlineCode>antd/v6</InlineCode>
+        .
+      </p>
+      <CodeBlock
+        code={antdAdaptersInstallSnippet}
+        language="bash"
+        label="ANTD v6 peers"
+      />
+      <SectionTitle>Using ANTD v6</SectionTitle>
+      <CodeBlock code={antdSnippet} language="tsx" label="ANTD v6 adapter" />
+      <SectionTitle>Supporting ANTD v5</SectionTitle>
+      <p>
+        If your application is still on Ant Design 5, switch the import path to{' '}
+        <InlineCode>@vojtechportes/react-query-builder/antd/v5</InlineCode>.
+      </p>
+      <SectionTitle>Extending the ANTD adapter</SectionTitle>
+      <CodeBlock
+        code={antdCreateComponentsSnippet}
+        language="tsx"
+        label="Merging ANTD defaults"
+      />
+      <AlertBox title="Related docs" variant="info">
+        <TextLink to="/documentation/adapters">Adapters</TextLink>,{' '}
+        <TextLink to="/documentation/components">Components</TextLink>, and{' '}
+        <TextLink to="/api/adapters/antd">ANTD adapter API</TextLink>.
+      </AlertBox>
+    </>
+  ),
+};

--- a/example/src/v1/pages/documentation-page/pages/adapters-bootstrap.documentation-page.tsx
+++ b/example/src/v1/pages/documentation-page/pages/adapters-bootstrap.documentation-page.tsx
@@ -1,0 +1,130 @@
+import * as React from 'react';
+import { AlertBox } from '../../../../components/alert-box';
+import { CodeBlock } from '../../../../components/code-block';
+import {
+  InlineCode,
+  List,
+  SectionTitle,
+  TextLink,
+} from '../../../../components/docs-primitives';
+import type { IDocumentationPage } from '../types/documentation-page';
+
+const bootstrapSnippet = `import {
+  Builder,
+  type DenormalizedQuery,
+} from '@vojtechportes/react-query-builder';
+import 'bootstrap/dist/css/bootstrap.min.css';
+import 'bootstrap-icons/font/bootstrap-icons.css';
+import { components } from '@vojtechportes/react-query-builder/bootstrap/v5';
+
+export const MyBootstrapBuilder = () => {
+  const [data, setData] = useState<DenormalizedQuery>(initialData);
+
+  return (
+    <Builder
+      data={data}
+      fields={fields}
+      components={components}
+      onChange={setData}
+    />
+  );
+};`;
+
+const bootstrapAdaptersInstallSnippet = `npm install bootstrap@^5.0.0 bootstrap-icons@^1.13.1`;
+
+const bootstrapCreateComponentsSnippet = `import {
+  Builder,
+  type DenormalizedQuery,
+} from '@vojtechportes/react-query-builder';
+import 'bootstrap/dist/css/bootstrap.min.css';
+import 'bootstrap-icons/font/bootstrap-icons.css';
+import {
+  createBootstrapComponents,
+  components as bootstrapComponents,
+} from '@vojtechportes/react-query-builder/bootstrap/v5';
+
+const components = createBootstrapComponents(bootstrapComponents, {
+  form: {
+    Input: MyInput,
+  },
+  Add: MyAddButton,
+});
+
+export const MyBootstrapBuilder = () => {
+  const [data, setData] = useState<DenormalizedQuery>(initialData);
+
+  return (
+    <Builder
+      data={data}
+      fields={fields}
+      components={components}
+      onChange={setData}
+    />
+  );
+};`;
+
+export const adaptersBootstrapDocumentationPage: IDocumentationPage = {
+  path: '/documentation/adapters/bootstrap',
+  title: 'Bootstrap',
+  depth: 1,
+  sectionKey: 'customization',
+  sectionTitle: 'Customization',
+  summary: '',
+  description:
+    'Documentation for the Bootstrap adapter, including bootstrap/v5 installation, stylesheet setup, usage, and component merging.',
+  searchText:
+    'Bootstrap adapter bootstrap v5 adapter install stylesheet createBootstrapComponents components',
+  content: (
+    <>
+      <p>
+        Use the Bootstrap adapter when your application already ships Bootstrap
+        5 styles and you want the builder controls mapped to Bootstrap-flavored
+        UI.
+      </p>
+      <SectionTitle>Available entrypoint</SectionTitle>
+      <List>
+        <li>
+          <InlineCode>
+            @vojtechportes/react-query-builder/bootstrap/v5
+          </InlineCode>{' '}
+          is the Bootstrap 5 adapter and is available in the demo.
+        </li>
+      </List>
+      <SectionTitle>Installing Bootstrap</SectionTitle>
+      <p>
+        Install Bootstrap and import its stylesheet before rendering the
+        adapter.
+      </p>
+      <CodeBlock
+        code={bootstrapAdaptersInstallSnippet}
+        language="bash"
+        label="Bootstrap 5 peer"
+      />
+      <AlertBox title="Stylesheet required" variant="info">
+        Import <InlineCode>bootstrap/dist/css/bootstrap.min.css</InlineCode> in
+        your application entrypoint or the specific subtree where the adapter is
+        rendered. Also import{' '}
+        <InlineCode>bootstrap-icons/font/bootstrap-icons.css</InlineCode> so the
+        adapter icon buttons render with the official Bootstrap Icons package.
+        Without these stylesheets, the adapter falls back to unstyled HTML.
+      </AlertBox>
+      <SectionTitle>Using Bootstrap v5</SectionTitle>
+      <CodeBlock
+        code={bootstrapSnippet}
+        language="tsx"
+        label="Bootstrap v5 adapter"
+      />
+      <SectionTitle>Extending the Bootstrap adapter</SectionTitle>
+      <CodeBlock
+        code={bootstrapCreateComponentsSnippet}
+        language="tsx"
+        label="Merging Bootstrap defaults"
+      />
+      <AlertBox title="Related docs" variant="info">
+        <TextLink to="/documentation/adapters">Adapters</TextLink>,{' '}
+        <TextLink to="/documentation/components">Components</TextLink>, and{' '}
+        <TextLink to="/api/adapters/bootstrap">Bootstrap adapter API</TextLink>.
+      </AlertBox>
+    </>
+  ),
+};

--- a/example/src/v1/pages/documentation-page/pages/adapters-fluentui.documentation-page.tsx
+++ b/example/src/v1/pages/documentation-page/pages/adapters-fluentui.documentation-page.tsx
@@ -1,0 +1,117 @@
+import * as React from 'react';
+import { AlertBox } from '../../../../components/alert-box';
+import { CodeBlock } from '../../../../components/code-block';
+import {
+  InlineCode,
+  List,
+  SectionTitle,
+  TextLink,
+} from '../../../../components/docs-primitives';
+import type { IDocumentationPage } from '../types/documentation-page';
+
+const fluentUiSnippet = `import {
+  Builder,
+  type DenormalizedQuery,
+} from '@vojtechportes/react-query-builder';
+import { components } from '@vojtechportes/react-query-builder/fluentui/v8';
+
+export const MyFluentUiBuilder = () => {
+  const [data, setData] = useState<DenormalizedQuery>(initialData);
+
+  return (
+    <Builder
+      data={data}
+      fields={fields}
+      components={components}
+      onChange={setData}
+    />
+  );
+};`;
+
+const fluentUiAdaptersInstallSnippet = `npm install @fluentui/react@^8.125.6`;
+
+const fluentUiCreateComponentsSnippet = `import {
+  Builder,
+  type DenormalizedQuery,
+} from '@vojtechportes/react-query-builder';
+import {
+  createFluentUiComponents,
+  components as fluentUiComponents,
+} from '@vojtechportes/react-query-builder/fluentui/v8';
+
+const components = createFluentUiComponents(fluentUiComponents, {
+  form: {
+    Input: MyInput,
+  },
+  Add: MyAddButton,
+});
+
+export const MyFluentUiBuilder = () => {
+  const [data, setData] = useState<DenormalizedQuery>(initialData);
+
+  return (
+    <Builder
+      data={data}
+      fields={fields}
+      components={components}
+      onChange={setData}
+    />
+  );
+};`;
+
+export const adaptersFluentuiDocumentationPage: IDocumentationPage = {
+  path: '/documentation/adapters/fluentui',
+  title: 'Fluent UI',
+  depth: 1,
+  sectionKey: 'customization',
+  sectionTitle: 'Customization',
+  summary: '',
+  description:
+    'Documentation for the Fluent UI adapter, including fluentui/v8 installation, usage, and component merging.',
+  searchText:
+    'Fluent UI adapter fluentui v8 adapter install createFluentUiComponents components',
+  content: (
+    <>
+      <p>
+        Use the Fluent UI adapter when your application is built on Fluent UI
+        React 8 and you want builder controls mapped to that component set.
+      </p>
+      <SectionTitle>Available entrypoint</SectionTitle>
+      <List>
+        <li>
+          <InlineCode>
+            @vojtechportes/react-query-builder/fluentui/v8
+          </InlineCode>{' '}
+          targets <InlineCode>@fluentui/react</InlineCode> 8.x and is available
+          in the demo.
+        </li>
+      </List>
+      <SectionTitle>Installing Fluent UI</SectionTitle>
+      <p>
+        Install the matching Fluent UI peer dependency before using the adapter.
+      </p>
+      <CodeBlock
+        code={fluentUiAdaptersInstallSnippet}
+        language="bash"
+        label="Fluent UI v8 peers"
+      />
+      <SectionTitle>Using Fluent UI v8</SectionTitle>
+      <CodeBlock
+        code={fluentUiSnippet}
+        language="tsx"
+        label="Fluent UI v8 adapter"
+      />
+      <SectionTitle>Extending the Fluent UI adapter</SectionTitle>
+      <CodeBlock
+        code={fluentUiCreateComponentsSnippet}
+        language="tsx"
+        label="Merging Fluent UI defaults"
+      />
+      <AlertBox title="Related docs" variant="info">
+        <TextLink to="/documentation/adapters">Adapters</TextLink>,{' '}
+        <TextLink to="/documentation/components">Components</TextLink>, and{' '}
+        <TextLink to="/api/adapters/fluentui">Fluent UI adapter API</TextLink>.
+      </AlertBox>
+    </>
+  ),
+};

--- a/example/src/v1/pages/documentation-page/pages/adapters-mantine.documentation-page.tsx
+++ b/example/src/v1/pages/documentation-page/pages/adapters-mantine.documentation-page.tsx
@@ -1,0 +1,143 @@
+import * as React from 'react';
+import { AlertBox } from '../../../../components/alert-box';
+import { CodeBlock } from '../../../../components/code-block';
+import {
+  InlineCode,
+  List,
+  SectionTitle,
+  TextLink,
+} from '../../../../components/docs-primitives';
+import type { IDocumentationPage } from '../types/documentation-page';
+
+const mantineSnippet = `import {
+  Builder,
+  type DenormalizedQuery,
+} from '@vojtechportes/react-query-builder';
+import '@mantine/core/styles.css';
+import { MantineProvider } from '@mantine/core';
+import { components } from '@vojtechportes/react-query-builder/mantine/v9';
+
+export const MyMantineBuilder = () => {
+  const [data, setData] = useState<DenormalizedQuery>(initialData);
+
+  return (
+    <MantineProvider>
+      <Builder
+        data={data}
+        fields={fields}
+        components={components}
+        onChange={setData}
+      />
+    </MantineProvider>
+  );
+};`;
+
+const mantineAdaptersInstallSnippet = `npm install @mantine/core@^9.0.0 @mantine/hooks@^9.0.0 react@^19.2.0 react-dom@^19.2.0`;
+
+const mantineCreateComponentsSnippet = `import {
+  Builder,
+  type DenormalizedQuery,
+} from '@vojtechportes/react-query-builder';
+import '@mantine/core/styles.css';
+import { MantineProvider } from '@mantine/core';
+import {
+  createMantineComponents,
+  components as mantineComponents,
+} from '@vojtechportes/react-query-builder/mantine/v9';
+
+const components = createMantineComponents(mantineComponents, {
+  form: {
+    Input: MyInput,
+  },
+  Add: MyAddButton,
+});
+
+export const MyMantineBuilder = () => {
+  const [data, setData] = useState<DenormalizedQuery>(initialData);
+
+  return (
+    <MantineProvider>
+      <Builder
+        data={data}
+        fields={fields}
+        components={components}
+        onChange={setData}
+      />
+    </MantineProvider>
+  );
+};`;
+
+export const adaptersMantineDocumentationPage: IDocumentationPage = {
+  path: '/documentation/adapters/mantine',
+  title: 'Mantine',
+  depth: 1,
+  sectionKey: 'customization',
+  sectionTitle: 'Customization',
+  summary: '',
+  description:
+    'Documentation for the Mantine adapter, including mantine/v9, legacy mantine/v8 support, installation, provider setup, and component merging.',
+  searchText:
+    'Mantine adapter mantine v9 mantine v8 adapter install MantineProvider createMantineComponents components',
+  content: (
+    <>
+      <p>
+        Use the Mantine adapter when your application already uses Mantine and
+        you want the builder controls to inherit that component language.
+      </p>
+      <SectionTitle>Available entrypoints</SectionTitle>
+      <List>
+        <li>
+          <InlineCode>@vojtechportes/react-query-builder/mantine/v9</InlineCode>{' '}
+          is the recommended entrypoint for new Mantine projects and the one
+          used in the demo.
+        </li>
+        <li>
+          <InlineCode>@vojtechportes/react-query-builder/mantine/v8</InlineCode>{' '}
+          is available for applications that are still on Mantine 8.
+        </li>
+      </List>
+      <SectionTitle>Installing Mantine</SectionTitle>
+      <p>
+        Install the Mantine peer dependencies that match the adapter version you
+        want to use. For new setups, prefer <InlineCode>mantine/v9</InlineCode>.
+      </p>
+      <CodeBlock
+        code={mantineAdaptersInstallSnippet}
+        language="bash"
+        label="Mantine v9 peers"
+      />
+      <AlertBox title="React version note" variant="info">
+        Mantine 9 requires React 19. The library website runs on React 19 so it
+        can exercise <InlineCode>mantine/v9</InlineCode> directly, while the
+        library package itself keeps broad React 18 and 19 peer compatibility.
+      </AlertBox>
+      <AlertBox title="Stylesheet required" variant="info">
+        Import <InlineCode>@mantine/core/styles.css</InlineCode> once in your
+        application entrypoint. Without it, Mantine components render without
+        their expected styling.
+      </AlertBox>
+      <SectionTitle>Using Mantine v9</SectionTitle>
+      <CodeBlock
+        code={mantineSnippet}
+        language="tsx"
+        label="Mantine v9 adapter"
+      />
+      <SectionTitle>Supporting Mantine v8</SectionTitle>
+      <p>
+        If your application is still on Mantine 8, switch the import path to{' '}
+        <InlineCode>@vojtechportes/react-query-builder/mantine/v8</InlineCode>.
+      </p>
+      <SectionTitle>Extending the Mantine adapter</SectionTitle>
+      <CodeBlock
+        code={mantineCreateComponentsSnippet}
+        language="tsx"
+        label="Merging Mantine defaults"
+      />
+      <AlertBox title="Related docs" variant="info">
+        <TextLink to="/documentation/adapters">Adapters</TextLink>,{' '}
+        <TextLink to="/documentation/components">Components</TextLink>, and{' '}
+        <TextLink to="/api/adapters/mantine">Mantine adapter API</TextLink>.
+      </AlertBox>
+    </>
+  ),
+};

--- a/example/src/v1/pages/documentation-page/pages/adapters-mui.documentation-page.tsx
+++ b/example/src/v1/pages/documentation-page/pages/adapters-mui.documentation-page.tsx
@@ -1,0 +1,139 @@
+import * as React from 'react';
+import { AlertBox } from '../../../../components/alert-box';
+import { CodeBlock } from '../../../../components/code-block';
+import {
+  InlineCode,
+  List,
+  SectionTitle,
+  TextLink,
+} from '../../../../components/docs-primitives';
+import type { IDocumentationPage } from '../types/documentation-page';
+
+const muiSnippet = `import {
+  Builder,
+  type DenormalizedQuery,
+} from '@vojtechportes/react-query-builder';
+import { components } from '@vojtechportes/react-query-builder/mui/v9';
+
+export const MyMuiBuilder = () => {
+  const [data, setData] = useState<DenormalizedQuery>(initialData);
+
+  return (
+    <Builder
+      data={data}
+      fields={fields}
+      components={components}
+      onChange={setData}
+    />
+  );
+};`;
+
+const muiOverrideSnippet = `import {
+  components as muiComponents,
+  MuiSelect,
+} from '@vojtechportes/react-query-builder/mui/v7';
+
+const components = {
+  ...muiComponents,
+  form: {
+    ...muiComponents.form,
+    Select: MuiSelect,
+  },
+};`;
+
+const adaptersInstallSnippet = `npm install @mui/material@^9.0.1 @mui/icons-material@^9.0.1 @emotion/react @emotion/styled`;
+
+const muiCreateComponentsSnippet = `import {
+  Builder,
+  type DenormalizedQuery,
+} from '@vojtechportes/react-query-builder';
+import {
+  createMuiComponents,
+  components as muiComponents,
+  MuiSelect,
+} from '@vojtechportes/react-query-builder/mui/v9';
+
+const components = createMuiComponents(muiComponents, {
+  form: {
+    Select: MuiSelect,
+  },
+});
+
+export const MyMuiBuilder = () => {
+  const [data, setData] = useState<DenormalizedQuery>(initialData);
+
+  return (
+    <Builder
+      data={data}
+      fields={fields}
+      components={components}
+      onChange={setData}
+    />
+  );
+};`;
+
+export const adaptersMuiDocumentationPage: IDocumentationPage = {
+  path: '/documentation/adapters/mui',
+  title: 'MUI',
+  depth: 1,
+  sectionKey: 'customization',
+  sectionTitle: 'Customization',
+  summary: '',
+  description:
+    'Documentation for the Material UI adapter, including mui/v9, legacy mui/v7 support, installation, and component merging.',
+  searchText:
+    'MUI adapter material ui mui v9 mui v7 adapter install createMuiComponents components',
+  content: (
+    <>
+      <p>
+        Use the MUI adapter when your application already uses Material UI and
+        you want the builder to inherit that component language.
+      </p>
+      <SectionTitle>Available entrypoints</SectionTitle>
+      <List>
+        <li>
+          <InlineCode>@vojtechportes/react-query-builder/mui/v9</InlineCode> is
+          the recommended entrypoint for new Material UI projects and the one
+          used in the demo.
+        </li>
+        <li>
+          <InlineCode>@vojtechportes/react-query-builder/mui/v7</InlineCode> is
+          available for applications that are still on Material UI 7.
+        </li>
+      </List>
+      <SectionTitle>Installing MUI</SectionTitle>
+      <p>
+        Install the MUI peer dependencies that match the adapter version you
+        want to use. For new setups, prefer <InlineCode>mui/v9</InlineCode>.
+      </p>
+      <CodeBlock
+        code={adaptersInstallSnippet}
+        language="bash"
+        label="MUI v9 peers"
+      />
+      <SectionTitle>Using MUI v9</SectionTitle>
+      <CodeBlock code={muiSnippet} language="tsx" label="MUI v9 adapter" />
+      <SectionTitle>Supporting MUI v7</SectionTitle>
+      <p>
+        If your application is still on Material UI 7, switch the import path to{' '}
+        <InlineCode>@vojtechportes/react-query-builder/mui/v7</InlineCode>.
+      </p>
+      <CodeBlock
+        code={muiOverrideSnippet}
+        language="tsx"
+        label="Starting from the MUI v7 mapping"
+      />
+      <SectionTitle>Extending the MUI adapter</SectionTitle>
+      <CodeBlock
+        code={muiCreateComponentsSnippet}
+        language="tsx"
+        label="Merging MUI defaults"
+      />
+      <AlertBox title="Related docs" variant="info">
+        <TextLink to="/documentation/adapters">Adapters</TextLink>,{' '}
+        <TextLink to="/documentation/components">Components</TextLink>, and{' '}
+        <TextLink to="/api/adapters/mui">MUI adapter API</TextLink>.
+      </AlertBox>
+    </>
+  ),
+};

--- a/example/src/v1/pages/documentation-page/pages/adapters-radix.documentation-page.tsx
+++ b/example/src/v1/pages/documentation-page/pages/adapters-radix.documentation-page.tsx
@@ -1,0 +1,135 @@
+import * as React from 'react';
+import { AlertBox } from '../../../../components/alert-box';
+import { CodeBlock } from '../../../../components/code-block';
+import {
+  InlineCode,
+  List,
+  SectionTitle,
+  TextLink,
+} from '../../../../components/docs-primitives';
+import type { IDocumentationPage } from '../types/documentation-page';
+
+const radixSnippet = `import {
+  Builder,
+  type DenormalizedQuery,
+} from '@vojtechportes/react-query-builder';
+import '@radix-ui/themes/styles.css';
+import { Theme } from '@radix-ui/themes';
+import { components } from '@vojtechportes/react-query-builder/radix/v1';
+
+export const MyRadixBuilder = () => {
+  const [data, setData] = useState<DenormalizedQuery>(initialData);
+
+  return (
+    <Theme>
+      <Builder
+        data={data}
+        fields={fields}
+        components={components}
+        onChange={setData}
+      />
+    </Theme>
+  );
+};`;
+
+const radixAdaptersInstallSnippet = `npm install @radix-ui/themes@^1.1.2 @radix-ui/react-icons@^1.3.2`;
+
+const radixCreateComponentsSnippet = `import {
+  Builder,
+  type DenormalizedQuery,
+} from '@vojtechportes/react-query-builder';
+import '@radix-ui/themes/styles.css';
+import { Theme } from '@radix-ui/themes';
+import {
+  createRadixComponents,
+  components as radixComponents,
+} from '@vojtechportes/react-query-builder/radix/v1';
+
+const components = createRadixComponents(radixComponents, {
+  form: {
+    Input: MyInput,
+  },
+  Add: MyAddButton,
+});
+
+export const MyRadixBuilder = () => {
+  const [data, setData] = useState<DenormalizedQuery>(initialData);
+
+  return (
+    <Theme>
+      <Builder
+        data={data}
+        fields={fields}
+        components={components}
+        onChange={setData}
+      />
+    </Theme>
+  );
+};`;
+
+export const adaptersRadixDocumentationPage: IDocumentationPage = {
+  path: '/documentation/adapters/radix',
+  title: 'Radix',
+  depth: 1,
+  sectionKey: 'customization',
+  sectionTitle: 'Customization',
+  summary: '',
+  description:
+    'Documentation for the Radix Themes adapter, including radix/v1 installation, provider setup, usage, and component merging.',
+  searchText:
+    'Radix adapter radix themes radix v1 adapter install Theme createRadixComponents components',
+  content: (
+    <>
+      <p>
+        Use the Radix adapter when your application uses Radix Themes and you
+        want the builder controls to align with that design system.
+      </p>
+      <SectionTitle>Available entrypoint</SectionTitle>
+      <List>
+        <li>
+          <InlineCode>@vojtechportes/react-query-builder/radix/v1</InlineCode>{' '}
+          targets <InlineCode>@radix-ui/themes</InlineCode> 1.x and is available
+          in the demo.
+        </li>
+      </List>
+      <SectionTitle>Installing Radix Themes</SectionTitle>
+      <p>
+        Install the Radix Themes peer dependency and the Radix icons package
+        before using the adapter.
+      </p>
+      <CodeBlock
+        code={radixAdaptersInstallSnippet}
+        language="bash"
+        label="Radix Themes v1 peer"
+      />
+      <AlertBox title="Icons package required" variant="info">
+        The Radix adapter renders icons from{' '}
+        <InlineCode>@radix-ui/react-icons</InlineCode>, so applications using
+        the adapter should install that package alongside{' '}
+        <InlineCode>@radix-ui/themes</InlineCode>.
+      </AlertBox>
+      <AlertBox title="Stylesheet required" variant="info">
+        Import <InlineCode>@radix-ui/themes/styles.css</InlineCode> once in your
+        application entrypoint so Radix Themes components render with the
+        expected styling.
+      </AlertBox>
+      <AlertBox title="Provider required" variant="info">
+        Render the builder inside <InlineCode>Theme</InlineCode> so Radix Themes
+        tokens and component styles are available to the adapter.
+      </AlertBox>
+      <SectionTitle>Using Radix v1</SectionTitle>
+      <CodeBlock code={radixSnippet} language="tsx" label="Radix v1 adapter" />
+      <SectionTitle>Extending the Radix adapter</SectionTitle>
+      <CodeBlock
+        code={radixCreateComponentsSnippet}
+        language="tsx"
+        label="Merging Radix defaults"
+      />
+      <AlertBox title="Related docs" variant="info">
+        <TextLink to="/documentation/adapters">Adapters</TextLink>,{' '}
+        <TextLink to="/documentation/components">Components</TextLink>, and{' '}
+        <TextLink to="/api/adapters/radix">Radix adapter API</TextLink>.
+      </AlertBox>
+    </>
+  ),
+};

--- a/example/src/v1/pages/documentation-page/pages/adapters.documentation-page.tsx
+++ b/example/src/v1/pages/documentation-page/pages/adapters.documentation-page.tsx
@@ -1,0 +1,143 @@
+import * as React from 'react';
+import { AlertBox } from '../../../../components/alert-box';
+import { CodeBlock } from '../../../../components/code-block';
+import {
+  InlineCode,
+  List,
+  SectionTitle,
+  TextLink,
+} from '../../../../components/docs-primitives';
+import type { IDocumentationPage } from '../types/documentation-page';
+
+const muiCreateComponentsSnippet = `import {
+  Builder,
+  type DenormalizedQuery,
+} from '@vojtechportes/react-query-builder';
+import {
+  createMuiComponents,
+  components as muiComponents,
+  MuiSelect,
+} from '@vojtechportes/react-query-builder/mui/v9';
+
+const components = createMuiComponents(muiComponents, {
+  form: {
+    Select: MuiSelect,
+  },
+});
+
+export const MyMuiBuilder = () => {
+  const [data, setData] = useState<DenormalizedQuery>(initialData);
+
+  return (
+    <Builder
+      data={data}
+      fields={fields}
+      components={components}
+      onChange={setData}
+    />
+  );
+};`;
+
+export const adaptersDocumentationPage: IDocumentationPage = {
+  path: '/documentation/adapters',
+  title: 'Adapters',
+  sectionKey: 'customization',
+  sectionTitle: 'Customization',
+  summary: '',
+  description:
+    'Documentation overview for packaged UI adapters, versioned entrypoints, adapter-specific subpages, and shared customization patterns.',
+  searchText:
+    'Adapters customization mui material ui antd ant design bootstrap mantine fluent ui versioned adapter entrypoints adapter overview create components pages ready made overrides',
+  content: (
+    <>
+      <p>
+        Adapters provide pre-mapped <InlineCode>components</InlineCode> objects
+        for UI libraries so you do not need to implement every override in{' '}
+        <TextLink to="/documentation/components">Components</TextLink> yourself.
+      </p>
+      <SectionTitle>Adapter guides</SectionTitle>
+      <List>
+        <li>
+          <TextLink to="/documentation/adapters/mui">MUI</TextLink> covers{' '}
+          <InlineCode>mui/v9</InlineCode>, legacy{' '}
+          <InlineCode>mui/v7</InlineCode>, install steps, and merge patterns.
+        </li>
+        <li>
+          <TextLink to="/documentation/adapters/antd">ANTD</TextLink> covers{' '}
+          <InlineCode>antd/v6</InlineCode>, legacy{' '}
+          <InlineCode>antd/v5</InlineCode>, install steps, and merge patterns.
+        </li>
+        <li>
+          <TextLink to="/documentation/adapters/fluentui">Fluent UI</TextLink>{' '}
+          covers <InlineCode>fluentui/v8</InlineCode>, install steps, and merge
+          patterns.
+        </li>
+        <li>
+          <TextLink to="/documentation/adapters/mantine">Mantine</TextLink>{' '}
+          covers <InlineCode>mantine/v9</InlineCode>, legacy{' '}
+          <InlineCode>mantine/v8</InlineCode>, install steps, provider usage,
+          and merge patterns.
+        </li>
+        <li>
+          <TextLink to="/documentation/adapters/bootstrap">Bootstrap</TextLink>{' '}
+          covers <InlineCode>bootstrap/v5</InlineCode>, stylesheet setup, and
+          merge patterns.
+        </li>
+        <li>
+          <TextLink to="/documentation/adapters/radix">Radix</TextLink> covers{' '}
+          <InlineCode>radix/v1</InlineCode>, stylesheet and provider setup, and
+          merge patterns.
+        </li>
+      </List>
+      <SectionTitle>Extending an adapter</SectionTitle>
+      <List>
+        <li>
+          Start with the exported adapter <InlineCode>components</InlineCode>{' '}
+          object.
+        </li>
+        <li>
+          Override only the pieces you want to replace, such as a single select
+          or button component.
+        </li>
+        <li>
+          This keeps your app aligned with future adapter updates while still
+          allowing local customization.
+        </li>
+      </List>
+      <CodeBlock
+        code={muiCreateComponentsSnippet}
+        language="tsx"
+        label="Merging adapter defaults"
+      />
+      <SectionTitle>Shared behavior</SectionTitle>
+      <List>
+        <li>
+          Adapters are versioned entrypoints so the package can support multiple
+          major UI-library versions in parallel.
+        </li>
+        <li>
+          Each adapter exports a ready-to-pass{' '}
+          <InlineCode>components</InlineCode> object plus a merge helper that
+          preserves nested <InlineCode>form</InlineCode> overrides.
+        </li>
+        <li>
+          Choose the adapter subpage that matches your UI library for exact
+          installation commands and code samples.
+        </li>
+      </List>
+      <AlertBox title="Monaco text mode" variant="info">
+        When you want Monaco text mode together with MUI, ANTD, Bootstrap,
+        Mantine, Fluent UI, or Radix, compose the adapter{' '}
+        <InlineCode>components</InlineCode> object with{' '}
+        <InlineCode>createMonacoComponents(...)</InlineCode>. See{' '}
+        <TextLink to="/documentation/text-mode">Text Mode</TextLink> for
+        examples.
+      </AlertBox>
+      <AlertBox title="Related docs" variant="info">
+        <TextLink to="/documentation/components">Components</TextLink>,{' '}
+        <TextLink to="/documentation/theming">Theming</TextLink>, and{' '}
+        <TextLink to="/api/adapters">Adapters API</TextLink>.
+      </AlertBox>
+    </>
+  ),
+};

--- a/example/src/v1/pages/documentation-page/pages/builder-behavior.documentation-page.tsx
+++ b/example/src/v1/pages/documentation-page/pages/builder-behavior.documentation-page.tsx
@@ -1,0 +1,217 @@
+import * as React from 'react';
+import { AlertBox } from '../../../../components/alert-box';
+import { CodeBlock } from '../../../../components/code-block';
+import {
+  InlineCode,
+  List,
+  SectionTitle,
+  TextLink,
+} from '../../../../components/docs-primitives';
+import type { IDocumentationPage } from '../types/documentation-page';
+
+const builderBehaviorSnippet = `<Builder
+  fields={fields}
+  data={data}
+  lockable
+  readOnlyProtectsDelete
+  cloneable
+  draggable
+  allowGroupNegation={false}
+  newNodePlacement="prepend"
+  singleRootGroup={false}
+  groupTypes="both"
+  onChange={setData}
+/>;
+
+// lockable:
+// Renders built-in lock controls for rules and groups and writes the resulting
+// lock state back into the emitted query via rule/group readOnly values.
+//
+// readOnlyProtectsDelete:
+// Prevents deleting parent groups when that delete would indirectly remove
+// read-only protected descendants. Defaults to true.
+//
+// cloneable:
+// Renders built-in clone controls for rules and groups and inserts the cloned
+// node directly below the original node.
+//
+// draggable:
+// Enables drag-and-drop for editable rules and groups.
+//
+// allowGroupNegation={false}:
+// Hides the group-level NOT toggle and rejects NOT (...) groups in text mode
+// while still allowing operator-level negation such as NOT IN or IS NOT NULL.
+//
+// newNodePlacement="prepend":
+// Inserts newly added rules and groups at the beginning of their parent instead
+// of appending them to the end. The default is "append".
+//
+// singleRootGroup={false}:
+// Allows multiple root-level nodes instead of wrapping everything into one root group.
+//
+// groupTypes="both":
+// Lets users choose between groups with AND/OR/NOT controls and groups without modifiers.`;
+
+export const builderBehaviorDocumentationPage: IDocumentationPage = {
+  path: '/documentation/builder-behavior',
+  title: 'Builder Behavior',
+  sectionKey: 'getting-started',
+  sectionTitle: 'Getting Started',
+  summary: '',
+  description:
+    'Documentation for clone controls, drag-and-drop, insertion placement, root-group behavior, and group mode configuration.',
+  searchText:
+    'builder behavior cloneable clone controls draggable drag and drop allowGroupNegation group negation not groups readOnlyProtectsDelete newNodePlacement append prepend singleRootGroup groupTypes with modifiers without modifiers both root group',
+  content: (
+    <>
+      <p>
+        A few builder props shape the overall editing model more than the field
+        or query data itself. These are worth deciding early because they affect
+        how users add, move, and organize rules.
+      </p>
+      <CodeBlock
+        code={builderBehaviorSnippet}
+        language="tsx"
+        label="Builder behavior"
+      />
+      <SectionTitle>cloneable</SectionTitle>
+      <List>
+        <li>
+          Defaults to <InlineCode>false</InlineCode> and renders built-in clone
+          controls for rules and groups.
+        </li>
+        <li>
+          The clone button appears immediately to the left of the lock button
+          when both controls are enabled.
+        </li>
+        <li>Cloning a rule inserts a duplicate directly below that rule.</li>
+        <li>
+          Cloning a group duplicates the entire subtree and inserts the clone
+          directly below that group.
+        </li>
+        <li>
+          When <InlineCode>singleRootGroup</InlineCode> is enabled, the
+          synthetic root group does not expose a clone control.
+        </li>
+      </List>
+      <SectionTitle>draggable</SectionTitle>
+      <List>
+        <li>
+          Use <InlineCode>lockable</InlineCode> to expose lock controls directly
+          in the UI.
+        </li>
+        <li>
+          Enables drag-and-drop reordering and movement for editable rules and
+          groups.
+        </li>
+        <li>Read-only rules and groups are excluded from dragging.</li>
+        <li>
+          When the entire builder is read-only, drag-and-drop is disabled as
+          well.
+        </li>
+        <li>
+          Empty groups expose a dedicated drop zone so items can be moved into
+          them.
+        </li>
+      </List>
+      <SectionTitle>readOnlyProtectsDelete</SectionTitle>
+      <List>
+        <li>
+          Defaults to <InlineCode>true</InlineCode>.
+        </li>
+        <li>
+          When enabled, deleting a group is blocked if that would indirectly
+          remove read-only protected descendants.
+        </li>
+        <li>
+          Set it to <InlineCode>false</InlineCode> when your product wants only
+          directly protected nodes to be non-deletable, while still allowing
+          parent-group deletes around them.
+        </li>
+      </List>
+      <SectionTitle>singleRootGroup</SectionTitle>
+      <List>
+        <li>
+          Defaults to <InlineCode>true</InlineCode>, which means the builder
+          maintains a single root group around the visible tree.
+        </li>
+        <li>
+          The root group cannot be deleted while{' '}
+          <InlineCode>singleRootGroup</InlineCode> is enabled.
+        </li>
+        <li>
+          Set it to <InlineCode>false</InlineCode> when your application wants
+          multiple top-level nodes instead of one wrapped root group.
+        </li>
+      </List>
+      <SectionTitle>newNodePlacement</SectionTitle>
+      <List>
+        <li>
+          Defaults to <InlineCode>'append'</InlineCode>, which inserts newly
+          added rules and groups at the end of their parent.
+        </li>
+        <li>
+          Set it to <InlineCode>'prepend'</InlineCode> to insert new rules and
+          groups at the beginning of their parent instead.
+        </li>
+        <li>
+          This affects built-in Add Rule and Add Group controls, root-level add
+          controls, and imperative ref methods when no explicit index is
+          provided.
+        </li>
+        <li>
+          It does not change cloning or drag-and-drop behavior, since those
+          actions already use explicit target positions.
+        </li>
+      </List>
+      <SectionTitle>groupTypes</SectionTitle>
+      <List>
+        <li>
+          <InlineCode>with-modifiers</InlineCode> shows group controls such as{' '}
+          <InlineCode>AND</InlineCode>, <InlineCode>OR</InlineCode>, and
+          negation.
+        </li>
+        <li>
+          <InlineCode>without-modifiers</InlineCode> creates structural groups
+          that do not render combinator or negation controls.
+        </li>
+        <li>
+          <InlineCode>both</InlineCode> lets users choose which group kind to
+          insert when adding a new group.
+        </li>
+      </List>
+      <SectionTitle>allowGroupNegation</SectionTitle>
+      <List>
+        <li>
+          Set <InlineCode>allowGroupNegation={false}</InlineCode> when you want
+          groups to keep combinators like <InlineCode>AND</InlineCode> and{' '}
+          <InlineCode>OR</InlineCode> but remove the group-level{' '}
+          <InlineCode>NOT</InlineCode> option.
+        </li>
+        <li>
+          This is narrower than <InlineCode>groupTypes</InlineCode>: it only
+          disables negating whole groups and does not affect whether groups
+          render combinator controls.
+        </li>
+        <li>
+          Operator-level negation still works normally, including{' '}
+          <InlineCode>NOT IN</InlineCode>, <InlineCode>NOT LIKE</InlineCode>,{' '}
+          <InlineCode>IS NOT NULL</InlineCode>, and{' '}
+          <InlineCode>NOT BETWEEN</InlineCode>.
+        </li>
+        <li>
+          When disabled, incoming negated groups are normalized to non-negated
+          form so the builder output stays consistent with the visible UI.
+        </li>
+      </List>
+      <AlertBox title="Related docs" variant="info">
+        <TextLink to="/documentation/history">Undo and Redo</TextLink>,{' '}
+        <TextLink to="/documentation/builder-ref">Builder Ref</TextLink>,{' '}
+        <TextLink to="/documentation/locking-and-read-only">
+          Locking and Read-only
+        </TextLink>{' '}
+        and <TextLink to="/api/builder">Builder</TextLink>.
+      </AlertBox>
+    </>
+  ),
+};

--- a/example/src/v1/pages/documentation-page/pages/builder-ref.documentation-page.tsx
+++ b/example/src/v1/pages/documentation-page/pages/builder-ref.documentation-page.tsx
@@ -1,0 +1,289 @@
+import * as React from 'react';
+import { AlertBox } from '../../../../components/alert-box';
+import { CodeBlock } from '../../../../components/code-block';
+import {
+  InlineCode,
+  List,
+  SectionTitle,
+  TextLink,
+} from '../../../../components/docs-primitives';
+import type { IDocumentationPage } from '../types/documentation-page';
+
+const builderRefBasicSnippet = `import React, { useState } from 'react';
+import {
+  Builder,
+  useBuilderRef,
+  type DenormalizedQuery,
+  type IBuilderFieldProps,
+} from '@vojtechportes/react-query-builder';
+
+const fields: IBuilderFieldProps[] = [
+  {
+    field: 'STATUS',
+    label: 'Status',
+    type: 'LIST',
+    operators: ['EQUAL', 'NOT_EQUAL'],
+    value: [
+      { value: 'ACTIVE', label: 'Active' },
+      { value: 'ARCHIVED', label: 'Archived' },
+    ],
+  },
+];
+
+const initialData: DenormalizedQuery = [
+  {
+    type: 'GROUP',
+    value: 'AND',
+    isNegated: false,
+    children: [
+      {
+        field: 'STATUS',
+        operator: 'EQUAL',
+        value: 'ACTIVE',
+      },
+    ],
+  },
+];
+
+export const BuilderRefExample = () => {
+  const [data, setData] = useState<DenormalizedQuery>(initialData);
+  const builderRef = useBuilderRef();
+
+  return (
+    <>
+      <button
+        type="button"
+        onClick={() => {
+          const rootGroupId = builderRef.current
+            ?.getNodes()
+            .find(node => 'type' in node)?.id;
+
+          if (!rootGroupId) {
+            return;
+          }
+
+          builderRef.current?.addRule(
+            {
+              field: 'STATUS',
+              operator: 'NOT_EQUAL',
+              value: 'ARCHIVED',
+            },
+            rootGroupId
+          );
+        }}
+      >
+        Add rule
+      </button>
+      <Builder ref={builderRef} fields={fields} data={data} onChange={setData} />
+    </>
+  );
+};`;
+
+const builderRefMutationSnippet = `const builderRef = useBuilderRef();
+
+builderRef.current?.cloneNode(nodeId);
+builderRef.current?.moveNode(nodeId, 0, targetGroupId);
+
+builderRef.current?.setNodeLock(nodeId, 'self');
+builderRef.current?.unlockNode(nodeId);
+
+builderRef.current?.replaceNode(nodeId, nextNode);
+builderRef.current?.updateNode(nodeId, node => ({
+  ...node,
+  readOnly: true,
+}));`;
+
+const builderRefFieldOptionsSnippet = `builderRef.current?.isFieldInUse('CITY');
+
+builderRef.current?.getFieldOptionState('CITY');
+
+builderRef.current?.setFieldOptionsStatus('CITY', 'loading');
+builderRef.current?.setFieldOptions('CITY', [
+  { value: 'PRG', label: 'Prague' },
+  { value: 'BRN', label: 'Brno' },
+]);
+
+builderRef.current?.invalidateFieldOptions('CITY');
+builderRef.current?.reloadFieldOptions('CITY');
+builderRef.current?.clearFieldOptions('CITY');`;
+
+const builderRefHistorySnippet = `const builderRef = useBuilderRef();
+
+const history = builderRef.current?.getHistory();
+
+builderRef.current?.undo();
+builderRef.current?.redo();
+
+builderRef.current?.setHistory({
+  past: [],
+  future: [],
+});`;
+
+const builderRefReadSnippet = `const builderRef = useBuilderRef();
+
+const allNodes = builderRef.current?.getNodes();
+const singleNode = builderRef.current?.getNodeById(nodeId);
+const denormalizedData = builderRef.current?.getData();
+const isCityInUse = builderRef.current?.isFieldInUse('CITY');
+const cityOptionState = builderRef.current?.getFieldOptionState('CITY');`;
+
+export const builderRefDocumentationPage: IDocumentationPage = {
+  path: '/documentation/builder-ref',
+  title: 'Builder Ref',
+  sectionKey: 'getting-started',
+  sectionTitle: 'Getting Started',
+  summary: '',
+  description:
+    'Documentation for the imperative builderRef API exposed through useBuilderRef, including reads, mutations, and history access.',
+  searchText:
+    'builderRef useBuilderRef forwardRef imperative api clone lock unlock delete update replace insert add move getNodeById getNodes getData getHistory setHistory undo redo',
+  content: (
+    <>
+      <p>
+        Use <InlineCode>useBuilderRef()</InlineCode> with the{' '}
+        <TextLink to="/api/builder">Builder</TextLink> ref to access internal
+        node actions and history from custom toolbars, menus, keyboard
+        shortcuts, or surrounding workflow logic.
+      </p>
+      <CodeBlock
+        code={builderRefBasicSnippet}
+        language="tsx"
+        label="Basic builderRef setup"
+      />
+      <SectionTitle>When to use it</SectionTitle>
+      <List>
+        <li>
+          Trigger builder changes from controls rendered outside the builder.
+        </li>
+        <li>Implement keyboard shortcuts for clone, delete, undo, or redo.</li>
+        <li>
+          Insert preconfigured rules or groups from business-specific UI flows.
+        </li>
+        <li>
+          Inspect normalized nodes or history without reimplementing builder
+          internals.
+        </li>
+      </List>
+      <SectionTitle>Read methods</SectionTitle>
+      <CodeBlock
+        code={builderRefReadSnippet}
+        language="tsx"
+        label="Reading builder state"
+      />
+      <List>
+        <li>
+          <InlineCode>getNodeById(id)</InlineCode> returns one normalized node
+          by id.
+        </li>
+        <li>
+          <InlineCode>getNodes()</InlineCode> returns the current normalized
+          node array.
+        </li>
+        <li>
+          <InlineCode>getData()</InlineCode> returns the denormalized public
+          query shape.
+        </li>
+        <li>
+          <InlineCode>isFieldInUse(field)</InlineCode> tells you whether a field
+          is currently present in the query.
+        </li>
+        <li>
+          <InlineCode>getFieldOptionState(field)</InlineCode> returns runtime
+          options and the current option status for that field.
+        </li>
+      </List>
+      <SectionTitle>Mutation methods</SectionTitle>
+      <CodeBlock
+        code={builderRefMutationSnippet}
+        language="tsx"
+        label="Mutating nodes"
+      />
+      <List>
+        <li>
+          <InlineCode>cloneNode</InlineCode>,{' '}
+          <InlineCode>deleteNode</InlineCode>, and{' '}
+          <InlineCode>moveNode</InlineCode> follow the same behavior as the
+          built-in UI controls.
+        </li>
+        <li>
+          <InlineCode>addNode</InlineCode>, <InlineCode>addGroup</InlineCode>,{' '}
+          <InlineCode>addRule</InlineCode>, and{' '}
+          <InlineCode>insertNodes</InlineCode> let you build structure
+          imperatively.
+        </li>
+        <li>
+          <InlineCode>replaceNode</InlineCode> swaps a node directly, while{' '}
+          <InlineCode>updateNode</InlineCode> is useful when you want the next
+          value to depend on the current node.
+        </li>
+        <li>
+          <InlineCode>setNodeLock</InlineCode>,{' '}
+          <InlineCode>lockNode</InlineCode>, and{' '}
+          <InlineCode>unlockNode</InlineCode> write the same read-only states as
+          the lock UI.
+        </li>
+      </List>
+      <SectionTitle>Dynamic field options</SectionTitle>
+      <CodeBlock
+        code={builderRefFieldOptionsSnippet}
+        language="tsx"
+        label="Managing field options"
+      />
+      <List>
+        <li>
+          <InlineCode>setFieldOptionsStatus(field, status)</InlineCode> lets
+          surrounding app code reflect loading, success, idle, or error state.
+        </li>
+        <li>
+          <InlineCode>setFieldOptions(field, options)</InlineCode> replaces the
+          runtime option set without changing the original{' '}
+          <InlineCode>fields</InlineCode> array.
+        </li>
+        <li>
+          <InlineCode>invalidateFieldOptions(field)</InlineCode> drops runtime
+          options and falls back to the static options defined in{' '}
+          <InlineCode>field.value</InlineCode>.
+        </li>
+        <li>
+          <InlineCode>clearFieldOptions(field)</InlineCode> removes the runtime
+          state entirely, which is useful when a dependent field leaves scope.
+        </li>
+      </List>
+      <SectionTitle>History methods</SectionTitle>
+      <CodeBlock
+        code={builderRefHistorySnippet}
+        language="tsx"
+        label="History access"
+      />
+      <List>
+        <li>
+          <InlineCode>undo()</InlineCode> and <InlineCode>redo()</InlineCode>{' '}
+          use the same history engine as the built-in controls.
+        </li>
+        <li>
+          <InlineCode>getHistory()</InlineCode> returns the current{' '}
+          <InlineCode>past</InlineCode> and <InlineCode>future</InlineCode>{' '}
+          stacks.
+        </li>
+        <li>
+          <InlineCode>setHistory()</InlineCode> lets you replace or clear the
+          internal history state.
+        </li>
+      </List>
+      <AlertBox title="Data shapes" variant="info">
+        Most imperative methods use normalized nodes because that matches the
+        internal builder engine. Use <InlineCode>getData()</InlineCode> when you
+        need the public denormalized query shape.
+      </AlertBox>
+      <AlertBox title="API reference" variant="info">
+        <TextLink to="/api/builder-ref">Builder Ref</TextLink>,{' '}
+        <TextLink to="/api/builder">Builder</TextLink>,{' '}
+        <TextLink to="/api/data">Data</TextLink>, and{' '}
+        <TextLink to="/documentation/dynamic-field-options">
+          Dynamic Field Options
+        </TextLink>
+        .
+      </AlertBox>
+    </>
+  ),
+};

--- a/example/src/v1/pages/documentation-page/pages/components.documentation-page.tsx
+++ b/example/src/v1/pages/documentation-page/pages/components.documentation-page.tsx
@@ -1,0 +1,129 @@
+import * as React from 'react';
+import { AlertBox } from '../../../../components/alert-box';
+import { CodeBlock } from '../../../../components/code-block';
+import {
+  InlineCode,
+  List,
+  SectionTitle,
+  TextLink,
+} from '../../../../components/docs-primitives';
+import type { IDocumentationPage } from '../types/documentation-page';
+
+const componentsSnippet = `const components = {
+  Add: MyAddButton,
+  Remove: MyRemoveButton,
+  form: {
+    Input: MyInput,
+    Select: MySelect,
+  },
+};
+
+<Builder
+  data={data}
+  fields={fields}
+  components={components}
+  onChange={setData}
+/>;`;
+
+export const componentsDocumentationPage: IDocumentationPage = {
+  path: '/documentation/components',
+  title: 'Components',
+  sectionKey: 'customization',
+  sectionTitle: 'Customization',
+  summary: '',
+  description:
+    'Documentation for replacing built-in builder controls and containers with custom components.',
+  searchText:
+    'Components component overrides custom controls custom renderers builder customization add remove select input group rule responsive responsiveness compact layout multiselect summary',
+  content: (
+    <>
+      <p>
+        Replace built-in controls and containers through the{' '}
+        <InlineCode>components</InlineCode> prop.
+      </p>
+      <CodeBlock
+        code={componentsSnippet}
+        language="tsx"
+        label="Component overrides"
+      />
+      <SectionTitle>Override contracts</SectionTitle>
+      <List>
+        <li>
+          Form controls should behave like controlled inputs. They receive the
+          current value plus change handlers and disabled state.
+        </li>
+        <li>
+          <InlineCode>Rule</InlineCode> and <InlineCode>Group</InlineCode> are
+          layout containers. They receive already-prepared children and control
+          regions rather than raw builder state.
+        </li>
+        <li>
+          <InlineCode>DropZone</InlineCode> and{' '}
+          <InlineCode>EmptyGroupDropZone</InlineCode> are drag-and-drop render
+          hooks. They receive ids, indices, parent ids, drag state, and active
+          state.
+        </li>
+        <li>
+          Button-like overrides such as <InlineCode>Add</InlineCode>,{' '}
+          <InlineCode>Remove</InlineCode>, <InlineCode>Popover</InlineCode>, and{' '}
+          <InlineCode>PopoverItem</InlineCode> should preserve click semantics
+          and remain accessible.
+        </li>
+        <li>
+          <InlineCode>HistoryControls</InlineCode> receives built-in undo and
+          redo button nodes plus history state and handlers, so custom layouts
+          can reuse the default controls instead of recreating them.
+        </li>
+        <li>
+          <InlineCode>TextModeEditor</InlineCode> replaces the whole text-mode
+          editor surface. This is the correct override point for Monaco or other
+          advanced editors.
+        </li>
+        <li>
+          <InlineCode>TextModeInput</InlineCode> replaces only the input control
+          used by the built-in text editor. It is useful when you want the
+          built-in overlay editor behavior but need a UI-library-specific input
+          shell.
+        </li>
+        <li>
+          <InlineCode>TextModeToggleContent</InlineCode>,{' '}
+          <InlineCode>OutlinedButton</InlineCode>, and{' '}
+          <InlineCode>Alert</InlineCode> let you align text-mode controls and
+          warnings with your design system.
+        </li>
+      </List>
+      <SectionTitle>Responsive behavior</SectionTitle>
+      <List>
+        <li>
+          The built-in <InlineCode>Rule</InlineCode> and{' '}
+          <InlineCode>Group</InlineCode> components include a compact responsive
+          layout for medium-width screens.
+        </li>
+        <li>
+          Multi-select controls use a summarized closed state so selected values
+          do not overflow the available rule width.
+        </li>
+        <li>
+          Responsive behavior is automatic when you use the default components.
+        </li>
+        <li>
+          If you replace <InlineCode>components.Rule</InlineCode> or{' '}
+          <InlineCode>components.Group</InlineCode>, your custom layout is
+          responsible for its own responsive behavior.
+        </li>
+      </List>
+      <AlertBox title="Adapter packages" variant="info">
+        If you want ready-made component mappings instead of wiring every
+        override by hand, see{' '}
+        <TextLink to="/documentation/adapters">Adapters</TextLink>.
+      </AlertBox>
+      <AlertBox title="Related docs" variant="info">
+        <TextLink to="/documentation/text-mode">Text Mode</TextLink> covers the
+        built-in SQL editor and the optional Monaco editor integration.
+      </AlertBox>
+      <AlertBox title="API reference" variant="info">
+        <TextLink to="/api/components">Components</TextLink>.
+      </AlertBox>
+    </>
+  ),
+};

--- a/example/src/v1/pages/documentation-page/pages/dynamic-field-options.documentation-page.tsx
+++ b/example/src/v1/pages/documentation-page/pages/dynamic-field-options.documentation-page.tsx
@@ -1,0 +1,484 @@
+import * as React from 'react';
+import { AlertBox } from '../../../../components/alert-box';
+import { CodeBlock } from '../../../../components/code-block';
+import { ClientOnly } from '../../../../components/client-only';
+import { loadImperativeFieldOptionsDemo } from '../utils/load-imperative-field-options-demo.util';
+import { loadSharedFieldOptionsDemo } from '../utils/load-shared-field-options-demo.util';
+import {
+  InlineCode,
+  List,
+  SectionTitle,
+  TextLink,
+} from '../../../../components/docs-primitives';
+import type { IDocumentationPage } from '../types/documentation-page';
+
+const dynamicFieldOptionsSnippet = `import React, { useCallback, useEffect, useState } from 'react';
+import {
+  Builder,
+  useBuilderRef,
+  type DenormalizedQuery,
+  type IBuilderFieldOptionState,
+  type IBuilderFieldProps,
+} from '@vojtechportes/react-query-builder';
+
+const fields: IBuilderFieldProps[] = [
+  {
+    field: 'CITY',
+    label: 'City',
+    type: 'LIST',
+    operators: ['EQUAL'],
+    value: [
+      { value: 'PRG', label: 'Prague' },
+      { value: 'BTS', label: 'Bratislava' },
+    ],
+  },
+];
+
+export const SharedFieldOptionsExample = () => {
+  const [data, setData] = useState<DenormalizedQuery>([
+    {
+      type: 'GROUP',
+      value: 'AND',
+      isNegated: false,
+      children: [
+        { field: 'CITY', operator: 'EQUAL', value: 'PRG' },
+        { field: 'CITY', operator: 'EQUAL', value: 'BTS' },
+      ],
+    },
+  ]);
+  const [cityOptionState, setCityOptionState] = useState<IBuilderFieldOptionState>({
+    options: fields[0].value ?? [],
+    status: 'idle',
+  });
+  const builderRef = useBuilderRef();
+
+  useEffect(() => builderRef.subscribeToFieldOptionState('CITY', setCityOptionState), [
+    builderRef,
+  ]);
+
+  const loadSharedCities = useCallback((scope: 'CZ' | 'SK' | 'DE') => {
+    builderRef.current?.setFieldOptionsStatus('CITY', 'loading');
+
+    window.setTimeout(() => {
+      if (scope === 'CZ') {
+        builderRef.current?.setFieldOptions('CITY', [
+          { value: 'PRG', label: 'Prague' },
+          { value: 'BRN', label: 'Brno' },
+          { value: 'OSR', label: 'Ostrava' },
+        ]);
+        return;
+      }
+
+      if (scope === 'SK') {
+        builderRef.current?.setFieldOptions('CITY', [
+          { value: 'BTS', label: 'Bratislava' },
+          { value: 'KSC', label: 'Kosice' },
+          { value: 'ZIL', label: 'Zilina' },
+        ]);
+        return;
+      }
+
+      builderRef.current?.setFieldOptions(
+        'CITY',
+        [
+          { value: 'BER', label: 'Berlin' },
+          { value: 'MUC', label: 'Munich' },
+          { value: 'HAM', label: 'Hamburg' },
+        ]
+      );
+    }, 500);
+  }, [builderRef]);
+
+  return (
+    <>
+      <button type="button" onClick={() => loadSharedCities('CZ')}>
+        Load Czech cities
+      </button>
+      <p>
+        Field state: {cityOptionState.status} ({cityOptionState.options.length} options)
+      </p>
+      <Builder ref={builderRef} fields={fields} data={data} onChange={setData} />
+    </>
+  );
+};`;
+
+const dynamicFieldOptionsReloadSnippet = `const builderRef = useBuilderRef();
+
+<Builder
+  ref={builderRef}
+  fields={fields}
+  data={data}
+  onFieldOptionsReload={(field) => {
+    if (field === 'CITY') {
+      loadSharedCities('CZ');
+    }
+  }}
+  onChange={setData}
+/>;
+
+builderRef.current?.reloadFieldOptions('CITY');`;
+
+const dynamicRuleOptionsSnippet = `import React, { useEffect, useState } from 'react';
+import {
+  Builder,
+  useBuilderRef,
+  type DenormalizedQuery,
+  type IBuilderFieldProps,
+} from '@vojtechportes/react-query-builder';
+
+const fields: IBuilderFieldProps[] = [
+  {
+    field: 'COUNTRY',
+    label: 'Country',
+    type: 'LIST',
+    operators: ['EQUAL'],
+    value: [
+      { value: 'CZ', label: 'Czech Republic' },
+      { value: 'SK', label: 'Slovakia' },
+      { value: 'DE', label: 'Germany' },
+    ],
+  },
+  {
+    field: 'CITY',
+    label: 'City',
+    type: 'LIST',
+    operators: ['EQUAL'],
+    value: [],
+  },
+];
+
+const initialData: DenormalizedQuery = [
+  {
+    type: 'GROUP',
+    value: 'AND',
+    isNegated: false,
+    children: [
+      {
+        type: 'GROUP',
+        value: 'AND',
+        isNegated: false,
+        children: [
+          { field: 'COUNTRY', operator: 'EQUAL', value: 'CZ' },
+          { field: 'CITY', operator: 'EQUAL', value: 'PRG' },
+        ],
+      },
+      {
+        type: 'GROUP',
+        value: 'AND',
+        isNegated: false,
+        children: [
+          { field: 'COUNTRY', operator: 'EQUAL', value: 'SK' },
+          { field: 'CITY', operator: 'EQUAL', value: 'BTS' },
+        ],
+      },
+    ],
+  },
+];
+
+export const RuleScopedOptionsExample = () => {
+  const [data, setData] = useState<DenormalizedQuery>(initialData);
+  const builderRef = useBuilderRef();
+
+  useEffect(() => {
+    return builderRef.bindRuleOptions('CITY', {
+      dependencies: ['COUNTRY'],
+      resolve: async ({ dependencies, signal }) => {
+        const countryValue = dependencies.COUNTRY?.value;
+
+        if (typeof countryValue !== 'string') {
+          return [];
+        }
+
+        const response = await fetch(
+          \`/api/cities?country=\${countryValue}\`,
+          { signal }
+        );
+        const cities = await response.json();
+
+        return cities.data.map(
+          (city: { code: string; name: string }) => ({
+            value: city.code,
+            label: city.name,
+          })
+        );
+      },
+      onOptionsResolved: ({ ruleId }) => {
+        builderRef.reconcileRuleValueWithOptions(ruleId, {
+          strategy: 'clear-if-missing',
+        });
+      },
+    });
+  }, [builderRef]);
+
+  return (
+    <Builder
+      ref={builderRef}
+      fields={fields}
+      data={data}
+      onChange={setData}
+    />
+  );
+};`;
+
+const dynamicFieldOptionsReactQuerySnippet = `import React, { useEffect, useState } from 'react';
+import { useQueries } from '@tanstack/react-query';
+import {
+  Builder,
+  useBuilderRef,
+  useBuilderRuleDependencies,
+  type DenormalizedQuery,
+  type IBuilderFieldProps,
+} from '@vojtechportes/react-query-builder';
+
+const fields: IBuilderFieldProps[] = [
+  {
+    field: 'COUNTRY',
+    label: 'Country',
+    type: 'LIST',
+    operators: ['EQUAL'],
+    value: [
+      { value: 'CZ', label: 'Czech Republic' },
+      { value: 'SK', label: 'Slovakia' },
+    ],
+  },
+  {
+    field: 'CITY',
+    label: 'City',
+    type: 'LIST',
+    operators: ['EQUAL'],
+    value: [],
+  },
+];
+
+export const ReactQueryOptionsExample = () => {
+  const [data, setData] = useState<DenormalizedQuery>(initialData);
+  const builderRef = useBuilderRef();
+  const cityEntries = useBuilderRuleDependencies(
+    builderRef,
+    'CITY',
+    ['COUNTRY']
+  );
+
+  const cityQueries = useQueries({
+    queries: cityEntries.map((entry) => {
+      const countryValue = entry.dependencies.COUNTRY?.value;
+      const country =
+        typeof countryValue === 'string' ? countryValue : undefined;
+
+      return {
+        queryKey: ['cities', entry.ruleId, country],
+        queryFn: () => loadCities(country as string),
+        enabled: Boolean(country),
+      };
+    }),
+  });
+
+  useEffect(() => {
+    cityEntries.forEach((entry, index) => {
+      const countryValue = entry.dependencies.COUNTRY?.value;
+      const query = cityQueries[index];
+
+      if (!builderRef.current || !query) {
+        return;
+      }
+
+      if (typeof countryValue !== 'string') {
+        builderRef.current.clearRuleOptions(entry.ruleId);
+        return;
+      }
+
+      if (query.status === 'pending') {
+        builderRef.current.setRuleOptionsStatus(entry.ruleId, 'loading');
+        return;
+      }
+
+      if (query.status === 'error') {
+        builderRef.current.setRuleOptionsStatus(entry.ruleId, 'error');
+        return;
+      }
+
+      builderRef.current.setRuleOptions(
+        entry.ruleId,
+        query.data.data.map(({ code, city }) => ({
+          value: code,
+          label: city,
+        }))
+      );
+      builderRef.current.reconcileRuleValueWithOptions(entry.ruleId, {
+        strategy: 'clear-if-missing',
+      });
+    });
+  }, [builderRef, cityEntries, cityQueries]);
+
+  return (
+    <Builder
+      ref={builderRef}
+      fields={fields}
+      data={data}
+      onChange={setData}
+    />
+  );
+};`;
+
+export const dynamicFieldOptionsDocumentationPage: IDocumentationPage = {
+  path: '/documentation/dynamic-field-options',
+  title: 'Dynamic Field Options',
+  sectionKey: 'getting-started',
+  sectionTitle: 'Getting Started',
+  summary: '',
+  description:
+    'Documentation for field-scoped and rule-scoped imperative list options, including shared-option and dependency-aware live demos plus a TanStack React Query example.',
+  searchText:
+    'dynamic field options builderRef subscribe subscribeToRuleDependencies useBuilderRuleDependencies setFieldOptions setRuleOptions getNearestField invalidateFieldOptions invalidateRuleOptions clearFieldOptions clearRuleOptions getFieldOptionState getRuleOptionState onFieldChange onRuleOptionsReload tanstack react-query async select options live demo',
+  content: (
+    <>
+      <p>
+        Keep the <InlineCode>fields</InlineCode> array stable and push runtime
+        options through <InlineCode>builderRef</InlineCode>. The important
+        choice is scope: field-level APIs are for shared options, while
+        rule-level APIs are for dependency-aware options.
+      </p>
+      <SectionTitle>Choose The Scope</SectionTitle>
+      <List>
+        <li>
+          <InlineCode>field.value</InlineCode> still defines the initial static
+          option set and remains the backwards-compatible fallback.
+        </li>
+        <li>
+          Field-level methods such as{' '}
+          <InlineCode>setFieldOptions(field, options)</InlineCode> are for
+          dynamic data where every rule of the same field should share the same
+          option set.
+        </li>
+        <li>
+          Rule-level methods such as{' '}
+          <InlineCode>setRuleOptions(ruleId, options)</InlineCode> are for
+          internal or external dependencies where each rule instance may need
+          different options.
+        </li>
+        <li>
+          <InlineCode>
+            getNearestField(currentNodeId, targetFieldName)
+          </InlineCode>{' '}
+          helps dependent rules resolve the closest matching context, such as
+          the nearest country for a city rule.
+        </li>
+        <li>
+          <InlineCode>builderRef.bindRuleOptions(field, config)</InlineCode> is
+          the simplest way to hydrate dependency-aware options and keep them in
+          sync with the nearest matching rules.
+        </li>
+        <li>
+          <InlineCode>
+            builderRef.subscribeToRuleDependencies(field, dependencyFields,
+            listener)
+          </InlineCode>{' '}
+          stays available when you want to own the orchestration yourself.
+        </li>
+        <li>
+          <InlineCode>
+            useBuilderRuleDependencies(builderRef, field, dependencyFields)
+          </InlineCode>{' '}
+          is the easiest React entrypoint when you want to feed dependency-aware
+          rules into <InlineCode>useQueries()</InlineCode> or other hook-based
+          data layers.
+        </li>
+        <li>
+          <InlineCode>builderRef.subscribeToFieldOptionState(...)</InlineCode>{' '}
+          and{' '}
+          <InlineCode>builderRef.subscribeToRuleOptionState(...)</InlineCode>{' '}
+          let external UI react to loading and success state when you need it.
+        </li>
+        <li>
+          <InlineCode>onFieldChange</InlineCode> is useful for targeted reactive
+          reloads when one dependency should refresh only a subset of rules.
+        </li>
+      </List>
+      <SectionTitle>Field-Level API</SectionTitle>
+      <p>
+        Use the field-level imperative API when all rules of a field should
+        share one runtime option set. This is a good fit for globally shared
+        dynamic data such as statuses, assignees, or categories.
+      </p>
+      <CodeBlock
+        code={dynamicFieldOptionsSnippet}
+        language="tsx"
+        label="Shared field options"
+      />
+      <CodeBlock
+        code={dynamicFieldOptionsReloadSnippet}
+        language="tsx"
+        label="Field-level reload flow"
+      />
+      <p>
+        In this example both <InlineCode>CITY</InlineCode> rules update together
+        because the runtime options are stored at field scope.
+      </p>
+      <p>
+        The live example exposes that field-scoped state through{' '}
+        <InlineCode>
+          builderRef.subscribeToFieldOptionState('CITY', listener)
+        </InlineCode>
+        .
+      </p>
+      <ClientOnly
+        loader={loadSharedFieldOptionsDemo}
+        label="Loading the shared field-options demo..."
+        minHeight="18rem"
+      />
+      <SectionTitle>Rule-Level API</SectionTitle>
+      <p>
+        Use the rule-level imperative API when options depend on other rules or
+        on surrounding app state. This is the right fit for repeated
+        dependencies such as <InlineCode>COUNTRY -&gt; CITY</InlineCode> in
+        multiple groups.
+      </p>
+      <CodeBlock
+        code={dynamicRuleOptionsSnippet}
+        language="tsx"
+        label="Dependency-aware rule options"
+      />
+      <p>
+        This example binds each <InlineCode>CITY</InlineCode> rule to the
+        nearest <InlineCode>COUNTRY</InlineCode> rule. Initial hydration and
+        later dependency changes are handled by{' '}
+        <InlineCode>builderRef.bindRuleOptions(...)</InlineCode>.
+      </p>
+      <p>
+        The extra{' '}
+        <InlineCode>builderRef.reconcileRuleValueWithOptions(...)</InlineCode>{' '}
+        call is optional and useful when you want strict select semantics, such
+        as clearing a now-invalid city after the nearest country changes.
+      </p>
+      <ClientOnly
+        loader={loadImperativeFieldOptionsDemo}
+        label="Loading the imperative field-options demo..."
+        minHeight="18rem"
+      />
+      <SectionTitle>TanStack React Query Example</SectionTitle>
+      <p>
+        If your app already uses TanStack React Query, keep caching there and
+        use the builder only for rule lookup and option storage. For
+        dependency-heavy cases,{' '}
+        <InlineCode>useBuilderRuleDependencies(...)</InlineCode> fits naturally
+        with <InlineCode>useQueries(...)</InlineCode>.
+      </p>
+      <CodeBlock
+        code={dynamicFieldOptionsReactQuerySnippet}
+        language="tsx"
+        label="Rule-level React Query integration"
+      />
+      <p>
+        The reconciliation call in the success branch is optional. Keep it when
+        you want strict select semantics and remove it when the selected value
+        may stay valid even if the currently loaded option slice does not
+        include it yet.
+      </p>
+      <AlertBox title="API reference" variant="info">
+        <TextLink to="/api/builder-ref">Builder Ref</TextLink>,{' '}
+        <TextLink to="/api/builder">Builder</TextLink>, and{' '}
+        <TextLink to="/api/fields">Fields</TextLink>.
+      </AlertBox>
+    </>
+  ),
+};

--- a/example/src/v1/pages/documentation-page/pages/field-comparisons.documentation-page.tsx
+++ b/example/src/v1/pages/documentation-page/pages/field-comparisons.documentation-page.tsx
@@ -1,0 +1,150 @@
+import * as React from 'react';
+import { AlertBox } from '../../../../components/alert-box';
+import { CodeBlock } from '../../../../components/code-block';
+import {
+  InlineCode,
+  List,
+  SectionTitle,
+  TextLink,
+} from '../../../../components/docs-primitives';
+import type { IDocumentationPage } from '../types/documentation-page';
+
+const fieldComparisonSnippet = `import React, { useState } from 'react';
+import {
+  Builder,
+  type DenormalizedQuery,
+  type IBuilderFieldProps,
+} from '@vojtechportes/react-query-builder';
+
+const fields: IBuilderFieldProps[] = [
+  {
+    field: 'ORDER_TOTAL',
+    label: 'Order total',
+    type: 'NUMBER',
+    operators: ['LARGER_EQUAL'],
+    fieldComparison: {
+      type: 'number',
+      comparableFields: ['ORDER_APPROVAL_LIMIT'],
+    },
+  },
+  {
+    field: 'ORDER_APPROVAL_LIMIT',
+    label: 'Approval limit',
+    type: 'NUMBER',
+    operators: ['LARGER_EQUAL'],
+  },
+  {
+    field: 'CUSTOMER_COUNTRY',
+    label: 'Customer country',
+    type: 'LIST',
+    operators: ['EQUAL'],
+    value: [
+      { value: 'CZ', label: 'Czech Republic' },
+      { value: 'SK', label: 'Slovakia' },
+    ],
+    fieldComparison: {
+      type: 'string',
+      comparableFields: ['DELIVERY_COUNTRY_CODE'],
+    },
+  },
+  {
+    field: 'DELIVERY_COUNTRY_CODE',
+    label: 'Delivery country code',
+    type: 'TEXT',
+    operators: ['EQUAL'],
+  },
+];
+
+const initialData: DenormalizedQuery = [
+  {
+    type: 'GROUP',
+    value: 'AND',
+    isNegated: false,
+    children: [
+      {
+        field: 'ORDER_TOTAL',
+        operator: 'LARGER_EQUAL',
+        valueSource: 'field',
+        valueField: 'ORDER_APPROVAL_LIMIT',
+      },
+      {
+        field: 'CUSTOMER_COUNTRY',
+        operator: 'EQUAL',
+        valueSource: 'field',
+        valueField: 'DELIVERY_COUNTRY_CODE',
+      },
+    ],
+  },
+];
+
+export const FieldComparisonBuilder = () => {
+  const [data, setData] = useState(initialData);
+
+  return (
+    <Builder
+      allowFieldComparisons
+      fields={fields}
+      data={data}
+      onChange={setData}
+    />
+  );
+};`;
+
+export const fieldComparisonsDocumentationPage: IDocumentationPage = {
+  path: '/documentation/field-comparisons',
+  title: 'Field Comparisons',
+  sectionKey: 'getting-started',
+  sectionTitle: 'Getting Started',
+  summary: '',
+  description:
+    'Enable rules that compare one field against another field, including configuration, data shape, and format support.',
+  searchText:
+    'field comparisons field-to-field allowFieldComparisons valueSource valueField comparableFields fieldComparison formatQuery parseQuery',
+  content: (
+    <>
+      <p>
+        Enable <InlineCode>allowFieldComparisons</InlineCode> on{' '}
+        <TextLink to="/api/builder">Builder</TextLink> when a rule should be
+        able to compare against another field instead of a literal value.
+      </p>
+      <CodeBlock
+        code={fieldComparisonSnippet}
+        language="tsx"
+        label="Enable field comparisons"
+      />
+      <SectionTitle>How It Works</SectionTitle>
+      <List>
+        <li>
+          <InlineCode>valueSource: 'field'</InlineCode> plus{' '}
+          <InlineCode>valueField</InlineCode> stores the selected comparison
+          field in query data.
+        </li>
+        <li>
+          <InlineCode>fieldComparison.type</InlineCode> lets semantically
+          compatible fields compare even when their builder UI types differ,
+          such as <InlineCode>LIST</InlineCode> to <InlineCode>TEXT</InlineCode>
+          .
+        </li>
+        <li>
+          <InlineCode>fieldComparison.comparableFields</InlineCode> narrows the
+          right-hand-side selector to an explicit allowlist owned by the source
+          field.
+        </li>
+      </List>
+      <AlertBox title="API reference" variant="info">
+        <TextLink to="/api/builder">Builder</TextLink>,{' '}
+        <TextLink to="/api/fields">Fields</TextLink>,{' '}
+        <TextLink to="/api/data">Data</TextLink>,{' '}
+        <TextLink to="/api/format-query">formatQuery</TextLink>, and{' '}
+        <TextLink to="/api/parse-query">parseQuery</TextLink>.
+      </AlertBox>
+      <AlertBox title="Parsing and formatting" variant="tip">
+        Native field-to-field formatting and parsing examples are documented in{' '}
+        <TextLink to="/documentation/parsing-and-formatting/supported-formats">
+          Supported Formats
+        </TextLink>
+        .
+      </AlertBox>
+    </>
+  ),
+};

--- a/example/src/v1/pages/documentation-page/pages/history.documentation-page.tsx
+++ b/example/src/v1/pages/documentation-page/pages/history.documentation-page.tsx
@@ -1,0 +1,187 @@
+import * as React from 'react';
+import { AlertBox } from '../../../../components/alert-box';
+import { CodeBlock } from '../../../../components/code-block';
+import {
+  InlineCode,
+  List,
+  SectionTitle,
+  TextLink,
+} from '../../../../components/docs-primitives';
+import type { IDocumentationPage } from '../types/documentation-page';
+
+const historySnippet = `import React, { useState } from 'react';
+import {
+  Builder,
+  type DenormalizedQuery,
+  type IBuilderStateChange,
+} from '@vojtechportes/react-query-builder';
+
+export const MyBuilder = () => {
+  const [data, setData] = useState<DenormalizedQuery>(initialData);
+  const [historyState, setHistoryState] = useState({
+    canUndo: false,
+    canRedo: false,
+  });
+
+  const handleStateChange = (state: IBuilderStateChange) => {
+    setHistoryState({
+      canUndo: state.canUndo,
+      canRedo: state.canRedo,
+    });
+  };
+
+  return (
+    <>
+      <Builder
+        fields={fields}
+        data={data}
+        draggable
+        cloneable
+        history={{ maxEntries: 30, controls: true }}
+        onStateChange={handleStateChange}
+        onChange={setData}
+      />
+      <p>Undo available: {String(historyState.canUndo)}</p>
+      <p>Redo available: {String(historyState.canRedo)}</p>
+    </>
+  );
+};`;
+
+const historyControlsSnippet = `const components = {
+  HistoryControls: ({
+    undoButton,
+    redoButton,
+    canUndo,
+    canRedo,
+  }) => (
+    <div style={{ display: 'flex', gap: 8, alignItems: 'center' }}>
+      <span>History</span>
+      {undoButton}
+      {redoButton}
+      <small>{canUndo ? 'Undo ready' : 'No undo yet'}</small>
+      <small>{canRedo ? 'Redo ready' : 'No redo yet'}</small>
+    </div>
+  ),
+};
+
+<Builder
+  fields={fields}
+  data={data}
+  history
+  components={components}
+  onChange={setData}
+/>;
+
+// HistoryControls receives:
+// undoButton: React.ReactNode
+// redoButton: React.ReactNode
+// canUndo: boolean
+// canRedo: boolean
+// onUndo: () => void
+// onRedo: () => void`;
+
+export const historyDocumentationPage: IDocumentationPage = {
+  path: '/documentation/history',
+  title: 'Undo and Redo',
+  sectionKey: 'getting-started',
+  sectionTitle: 'Getting Started',
+  summary: '',
+  description:
+    'Documentation for enabling inverse-history undo and redo, built-in controls, state callbacks, and drag-and-drop coverage.',
+  searchText:
+    'undo redo history inverse history maxEntries controls canUndo canRedo onStateChange drag and drop clone delete edit builder',
+  content: (
+    <>
+      <p>
+        Set <InlineCode>history</InlineCode> on{' '}
+        <TextLink to="/api/builder">Builder</TextLink> to enable built-in undo
+        and redo support for structural edits and value changes. The builder
+        records inverse actions internally, so history stays smaller than
+        full-query snapshots and still works with drag-and-drop, cloning,
+        deletes, and inline edits.
+      </p>
+      <CodeBlock code={historySnippet} language="tsx" label="History support" />
+      <SectionTitle>How to enable it</SectionTitle>
+      <List>
+        <li>
+          <InlineCode>history={true}</InlineCode> enables history with default
+          behavior.
+        </li>
+        <li>
+          <InlineCode>history={`{{ maxEntries, controls }}`}</InlineCode>{' '}
+          enables history with custom configuration.
+        </li>
+        <li>
+          <InlineCode>maxEntries</InlineCode> limits how many undo steps are
+          kept in memory.
+        </li>
+        <li>
+          <InlineCode>controls</InlineCode> controls whether the built-in Undo
+          and Redo buttons are rendered.
+        </li>
+      </List>
+      <SectionTitle>What gets tracked</SectionTitle>
+      <List>
+        <li>Adding, removing, cloning, and editing rules.</li>
+        <li>Adding, removing, cloning, and editing groups.</li>
+        <li>Drag-and-drop reordering and movement between groups.</li>
+        <li>
+          Changes driven through the builder UI that emit through{' '}
+          <InlineCode>onChange</InlineCode>.
+        </li>
+      </List>
+      <SectionTitle>State callbacks</SectionTitle>
+      <List>
+        <li>
+          <InlineCode>onStateChange</InlineCode> includes{' '}
+          <InlineCode>canUndo</InlineCode> and <InlineCode>canRedo</InlineCode>{' '}
+          so custom toolbars can stay in sync.
+        </li>
+        <li>
+          The built-in controls already use those flags and render disabled when
+          no action is available.
+        </li>
+        <li>
+          Redo history is cleared after a new forward edit, which matches
+          standard editor behavior.
+        </li>
+      </List>
+      <SectionTitle>Custom HistoryControls</SectionTitle>
+      <p>
+        Use <InlineCode>components.HistoryControls</InlineCode> when you want to
+        change the placement or surrounding layout of the built-in history
+        controls without reimplementing undo and redo behavior yourself.
+      </p>
+      <CodeBlock
+        code={historyControlsSnippet}
+        language="tsx"
+        label="HistoryControls override"
+      />
+      <List>
+        <li>
+          The override receives ready-to-render{' '}
+          <InlineCode>undoButton</InlineCode> and{' '}
+          <InlineCode>redoButton</InlineCode> nodes.
+        </li>
+        <li>
+          It also receives <InlineCode>canUndo</InlineCode>,{' '}
+          <InlineCode>canRedo</InlineCode>, <InlineCode>onUndo</InlineCode>, and{' '}
+          <InlineCode>onRedo</InlineCode> when you need custom wrappers or
+          auxiliary UI.
+        </li>
+        <li>
+          This lets you reorder, wrap, or annotate the default buttons without
+          having to rebuild their disabled-state logic.
+        </li>
+      </List>
+      <AlertBox title="Related docs" variant="info">
+        <TextLink to="/documentation/builder-behavior">
+          Builder Behavior
+        </TextLink>
+        , <TextLink to="/documentation/builder-ref">Builder Ref</TextLink>,{' '}
+        <TextLink to="/demo">Demo</TextLink>, and{' '}
+        <TextLink to="/api/builder">Builder</TextLink>.
+      </AlertBox>
+    </>
+  ),
+};

--- a/example/src/v1/pages/documentation-page/pages/installation.documentation-page.tsx
+++ b/example/src/v1/pages/documentation-page/pages/installation.documentation-page.tsx
@@ -1,0 +1,33 @@
+import * as React from 'react';
+import { AlertBox } from '../../../../components/alert-box';
+import { CodeBlock } from '../../../../components/code-block';
+import { InlineCode } from '../../../../components/docs-primitives';
+import type { IDocumentationPage } from '../types/documentation-page';
+
+const installationSnippet = `npm install @vojtechportes/react-query-builder`;
+
+export const installationDocumentationPage: IDocumentationPage = {
+  path: '/documentation/installation',
+  title: 'Installation',
+  sectionKey: 'getting-started',
+  sectionTitle: 'Getting Started',
+  summary: '',
+  description:
+    'Package installation details for React Query Builder and React version requirements.',
+  searchText:
+    'Installation npm install React Query Builder react 18 peer dependencies package import library',
+  content: (
+    <>
+      <p>
+        Install the package and use it with React <InlineCode>18+</InlineCode>.
+      </p>
+      <CodeBlock code={installationSnippet} language="bash" label="npm" />
+      <AlertBox title="Peer dependencies" variant="info">
+        The package expects compatible <InlineCode>react</InlineCode> and{' '}
+        <InlineCode>react-dom</InlineCode> versions in the consuming app. In
+        monorepos, it is worth checking that your app and the library resolve to
+        the same React instance.
+      </AlertBox>
+    </>
+  ),
+};

--- a/example/src/v1/pages/documentation-page/pages/localization.documentation-page.tsx
+++ b/example/src/v1/pages/documentation-page/pages/localization.documentation-page.tsx
@@ -1,0 +1,197 @@
+import * as React from 'react';
+import { AlertBox } from '../../../../components/alert-box';
+import { CodeBlock } from '../../../../components/code-block';
+import {
+  InlineCode,
+  List,
+  SectionTitle,
+  TextLink,
+} from '../../../../components/docs-primitives';
+import type { IDocumentationPage } from '../types/documentation-page';
+
+const stringsSnippet = `import { strings } from '@vojtechportes/react-query-builder';
+
+<Builder
+  fields={fields}
+  data={data}
+  strings={{
+    ...strings,
+    group: {
+      ...strings.group,
+      addRule: 'Add filter',
+      addGroup: 'Add condition group',
+    },
+    operators: {
+      ...strings.operators,
+      EQUAL: 'Is exactly',
+      NOT_EQUAL: 'Is not',
+    },
+    validation: {
+      ...strings.validation,
+      required: 'Please provide a value',
+    },
+  }}
+  onChange={setData}
+/>;
+
+// You can override only the keys you need.
+// Unspecified labels fall back to the built-in defaults.`;
+
+const firstPartyLocaleSnippet = `import { Builder } from '@vojtechportes/react-query-builder';
+import { strings } from '@vojtechportes/react-query-builder/locale/fr-FR';
+
+<Builder
+  fields={fields}
+  data={data}
+  strings={strings}
+  onChange={setData}
+/>;`;
+
+const localizationSnippet = `const fields: IBuilderFieldProps[] = [
+  {
+    field: 'STATE',
+    label: 'Stav',
+    type: 'LIST',
+    operators: ['EQUAL'],
+    value: [{ value: 'CZ', label: 'Ceska republika' }],
+  },
+];`;
+
+export const localizationDocumentationPage: IDocumentationPage = {
+  path: '/documentation/localization',
+  title: 'Localization',
+  sectionKey: 'single-localization',
+  sectionTitle: 'Localization',
+  summary: '',
+  description:
+    'Documentation for localizing field labels, option labels, and built-in UI strings.',
+  searchText:
+    'Localization localized labels fields translated copy internationalization i18n query builder',
+  content: (
+    <>
+      <p>
+        Localize field labels, option labels, and surrounding UI in the host
+        application. Built-in action labels can be customized through{' '}
+        <TextLink to="/api/builder">Builder</TextLink> via{' '}
+        <InlineCode>strings</InlineCode>.
+      </p>
+      <CodeBlock
+        code={localizationSnippet}
+        language="ts"
+        label="Localized fields"
+      />
+      <SectionTitle>Built-in UI strings</SectionTitle>
+      <p>
+        Locales can be imported from their subpaths and passed to the Builder
+        through the <InlineCode>strings</InlineCode> prop.
+      </p>
+      <CodeBlock
+        code={firstPartyLocaleSnippet}
+        language="tsx"
+        label="Built-in French translations"
+      />
+      <p>Supported locale subpaths:</p>
+      <List>
+        <li>
+          <InlineCode>
+            @vojtechportes/react-query-builder/locale/en-US
+          </InlineCode>{' '}
+          — English (United States)
+        </li>
+        <li>
+          <InlineCode>
+            @vojtechportes/react-query-builder/locale/fr-FR
+          </InlineCode>{' '}
+          — French (France)
+        </li>
+        <li>
+          <InlineCode>
+            @vojtechportes/react-query-builder/locale/it-IT
+          </InlineCode>{' '}
+          — Italian (Italy)
+        </li>
+        <li>
+          <InlineCode>
+            @vojtechportes/react-query-builder/locale/de-DE
+          </InlineCode>{' '}
+          — German (Germany)
+        </li>
+        <li>
+          <InlineCode>
+            @vojtechportes/react-query-builder/locale/es-ES
+          </InlineCode>{' '}
+          — Spanish (Spain)
+        </li>
+        <li>
+          <InlineCode>
+            @vojtechportes/react-query-builder/locale/pt-PT
+          </InlineCode>{' '}
+          — Portuguese (Portugal)
+        </li>
+        <li>
+          <InlineCode>
+            @vojtechportes/react-query-builder/locale/cs-CZ
+          </InlineCode>{' '}
+          — Czech (Czechia)
+        </li>
+        <li>
+          <InlineCode>
+            @vojtechportes/react-query-builder/locale/sk-SK
+          </InlineCode>{' '}
+          — Slovak (Slovakia)
+        </li>
+        <li>
+          <InlineCode>
+            @vojtechportes/react-query-builder/locale/zh-CN
+          </InlineCode>{' '}
+          — Simplified Chinese
+        </li>
+        <li>
+          <InlineCode>
+            @vojtechportes/react-query-builder/locale/zh-TW
+          </InlineCode>{' '}
+          — Traditional Chinese
+        </li>
+      </List>
+      <p>
+        The package-root <InlineCode>strings</InlineCode> import remains the
+        backward-compatible English (<InlineCode>en-US</InlineCode>) form. Use
+        it as a base when you only need selective overrides.
+      </p>
+      <CodeBlock
+        code={stringsSnippet}
+        language="tsx"
+        label="Custom UI strings"
+      />
+      <List>
+        <li>
+          <InlineCode>group</InlineCode> covers labels such as add, delete, and
+          group mode choices.
+        </li>
+        <li>
+          <InlineCode>rule</InlineCode> covers rule-level action labels.
+        </li>
+        <li>
+          <InlineCode>textMode</InlineCode> covers text-mode labels and messages
+          such as the mode toggle, syntax error prefix, lock warning, and
+          locked-range hover text.
+        </li>
+        <li>
+          <InlineCode>textMode.sql</InlineCode> covers localized SQL parser and
+          syntax-validation messages used by text mode.
+        </li>
+        <li>
+          <InlineCode>operators</InlineCode> lets you rename operator captions
+          shown in selectors.
+        </li>
+        <li>
+          <InlineCode>validation</InlineCode> customizes built-in validation
+          messages.
+        </li>
+      </List>
+      <AlertBox title="API reference" variant="info">
+        <TextLink to="/api/builder">Builder</TextLink>.
+      </AlertBox>
+    </>
+  ),
+};

--- a/example/src/v1/pages/documentation-page/pages/locking-and-read-only.documentation-page.tsx
+++ b/example/src/v1/pages/documentation-page/pages/locking-and-read-only.documentation-page.tsx
@@ -1,0 +1,359 @@
+import * as React from 'react';
+import { AlertBox } from '../../../../components/alert-box';
+import { CodeBlock } from '../../../../components/code-block';
+import {
+  InlineCode,
+  List,
+  SectionTitle,
+  TextLink,
+} from '../../../../components/docs-primitives';
+import type { IDocumentationPage } from '../types/documentation-page';
+
+const lockingSnippet = `const data: DenormalizedQuery = [
+  {
+    type: 'GROUP',
+    value: 'AND',
+    isNegated: false,
+    children: [
+      {
+        field: 'STATUS',
+        operator: 'EQUAL',
+        value: 'ACTIVE',
+        readOnly: {
+          enabled: true,
+          targets: ['field', 'operator'],
+        },
+      },
+      {
+        type: 'GROUP',
+        value: 'OR',
+        isNegated: false,
+        readOnly: {
+          enabled: true,
+          targets: ['combinator'],
+        },
+        children: [
+          {
+            field: 'COUNTRY',
+            operator: 'EQUAL',
+            value: 'CZ',
+          },
+        ],
+      },
+      {
+        type: 'GROUP',
+        value: 'AND',
+        isNegated: false,
+        readOnly: {
+          enabled: true,
+          inheritToChildren: true,
+        },
+        children: [
+          {
+            field: 'IS_VAT_PAYER',
+            operator: 'EQUAL',
+            value: true,
+          },
+        ],
+      },
+    ],
+  },
+];
+
+<Builder fields={fields} data={data} onChange={setData} />;`;
+
+const targetedReadOnlySnippet = `const data: DenormalizedQuery = [
+  {
+    type: 'GROUP',
+    value: 'AND',
+    isNegated: false,
+    readOnly: {
+      enabled: true,
+      targets: ['combinator'],
+    },
+    children: [
+      {
+        field: 'CUSTOMER_COUNTRY',
+        operator: 'EQUAL',
+        value: 'CZ',
+        readOnly: {
+          enabled: true,
+          targets: ['field', 'operator'],
+        },
+      },
+      {
+        field: 'ORDER_TOTAL',
+        operator: 'BETWEEN',
+        value: [1000, 5000],
+        readOnly: {
+          enabled: true,
+          targets: ['value'],
+        },
+      },
+    ],
+  },
+];`;
+
+const lockingGuiSnippet = `<Builder
+  fields={fields}
+  data={data}
+  lockable
+  onChange={setData}
+/>;
+
+// Rules cycle through:
+// unlocked -> locked
+//
+// Groups cycle through:
+// unlocked -> locked group only -> locked group and descendants
+//
+// The emitted query stores those states in readOnly:
+// rule: readOnly: true
+// group: readOnly: true
+// group + descendants: readOnly: { enabled: true, inheritToChildren: true }
+//
+// If a node already uses readOnly.targets, the lock toggle preserves those
+// targets and only changes enabled/inheritToChildren.`;
+
+const lockToggleSnippet = `const components = {
+  LockToggle: MyLockToggle,
+};
+
+<Builder
+  fields={fields}
+  data={data}
+  lockable
+  components={components}
+  onChange={setData}
+/>;
+
+// LockToggle receives:
+// state: 'unlocked' | 'self' | 'all'
+// nodeType: 'rule' | 'group'
+// disabled?: boolean
+// onChange?: (nextState) => void`;
+
+const cloneButtonSnippet = `const components = {
+  CloneButton: MyCloneButton,
+};
+
+<Builder
+  fields={fields}
+  data={data}
+  cloneable
+  components={components}
+  onChange={setData}
+/>;
+
+// CloneButton receives:
+// nodeType: 'rule' | 'group'
+// disabled?: boolean
+// onClick?: () => void`;
+
+export const lockingAndReadOnlyDocumentationPage: IDocumentationPage = {
+  path: '/documentation/locking-and-read-only',
+  title: 'Locking and Read-only',
+  sectionKey: 'getting-started',
+  sectionTitle: 'Getting Started',
+  summary: '',
+  description:
+    'Documentation for builder-level, rule-level, and group-level read-only behavior, including targeted read-only and group inheritance semantics.',
+  searchText:
+    'readOnly locking locked rule group targets field operator value combinator negation inheritToChildren inheritance read only builder rule group drag delete add controls',
+  content: (
+    <>
+      <p>
+        Locking can be applied at the builder, rule, or group level. The key
+        distinction is that rules lock only themselves, while groups can lock
+        either just their own controls or their entire subtree. Object-based{' '}
+        <InlineCode>readOnly</InlineCode> configs also support targeted
+        read-only for specific controls.
+      </p>
+      <SectionTitle>GUI Locking</SectionTitle>
+      <p>
+        Set <InlineCode>lockable</InlineCode> on{' '}
+        <TextLink to="/api/builder">Builder</TextLink> to render lock controls
+        directly in the UI. The built-in controls update the same{' '}
+        <InlineCode>readOnly</InlineCode> fields that are already part of the
+        query data model, so the resulting lock state is preserved in output. If
+        a node already has <InlineCode>readOnly.targets</InlineCode>, the lock
+        toggle preserves those targets and only changes whether the lock is
+        enabled and, for groups, whether it inherits to descendants.
+      </p>
+      <CodeBlock code={lockingGuiSnippet} language="tsx" label="GUI locking" />
+      <List>
+        <li>Rules cycle through two states: unlocked and locked.</li>
+        <li>
+          Groups cycle through three states: unlocked, locked group only, and
+          locked group with descendants.
+        </li>
+        <li>
+          The default group cycle maps to <InlineCode>false</InlineCode>,{' '}
+          <InlineCode>true</InlineCode>, and{' '}
+          <InlineCode>{`{ enabled: true, inheritToChildren: true }`}</InlineCode>
+          .
+        </li>
+        <li>
+          When a parent group inherits a lock to descendants, child lock
+          controls render disabled because descendants cannot override that
+          inherited state.
+        </li>
+        <li>
+          When <InlineCode>cloneable</InlineCode> is also enabled, the clone
+          button renders immediately to the left of the lock button.
+        </li>
+      </List>
+      <SectionTitle>Targeted read-only</SectionTitle>
+      <p>
+        Use object-based <InlineCode>readOnly</InlineCode> configs when you want
+        to keep specific controls visible but non-editable instead of locking
+        the entire rule or group.
+      </p>
+      <CodeBlock
+        code={targetedReadOnlySnippet}
+        language="tsx"
+        label="Targeted read-only"
+      />
+      <List>
+        <li>
+          Rule targets are <InlineCode>field</InlineCode>,{' '}
+          <InlineCode>operator</InlineCode>, and <InlineCode>value</InlineCode>.
+        </li>
+        <li>
+          Group targets are <InlineCode>combinator</InlineCode> and{' '}
+          <InlineCode>negation</InlineCode>.
+        </li>
+        <li>
+          If <InlineCode>enabled</InlineCode> is <InlineCode>true</InlineCode>{' '}
+          and <InlineCode>targets</InlineCode> is omitted, the whole node is
+          read-only.
+        </li>
+        <li>
+          If <InlineCode>enabled</InlineCode> is <InlineCode>false</InlineCode>,
+          the config stays dormant until the node is locked again.
+        </li>
+      </List>
+      <SectionTitle>How each level behaves</SectionTitle>
+      <List>
+        <li>
+          <InlineCode>{'<Builder readOnly />'}</InlineCode> locks the entire
+          builder. No rules or groups remain editable.
+        </li>
+        <li>
+          <InlineCode>rule.readOnly = true</InlineCode> locks only that rule.
+          Siblings and parent groups are unaffected.
+        </li>
+        <li>
+          <InlineCode>{`rule.readOnly = { enabled: true, targets: ['field'] }`}</InlineCode>{' '}
+          keeps the field visible but non-editable, and also prevents deleting
+          that rule.
+        </li>
+        <li>
+          <InlineCode>group.readOnly = true</InlineCode> locks only that
+          group&apos;s own controls. Its child rules and child groups stay
+          editable by default.
+        </li>
+        <li>
+          <InlineCode>{`group.readOnly = { enabled: true, targets: ['combinator'] }`}</InlineCode>{' '}
+          keeps the group combinator visible but non-editable without forcing
+          descendant rules to become read-only.
+        </li>
+        <li>
+          <InlineCode>{`group.readOnly = { enabled: true, inheritToChildren: true }`}</InlineCode>{' '}
+          locks the group and all descendant rules and groups.
+        </li>
+      </List>
+      <CodeBlock
+        code={lockingSnippet}
+        language="tsx"
+        label="Locking examples"
+      />
+      <SectionTitle>Custom Lock Control</SectionTitle>
+      <p>
+        The default lock button can be replaced through{' '}
+        <InlineCode>components.LockToggle</InlineCode>.
+      </p>
+      <CodeBlock
+        code={lockToggleSnippet}
+        language="tsx"
+        label="LockToggle override"
+      />
+      <SectionTitle>Custom Clone Control</SectionTitle>
+      <p>
+        The default clone button can be replaced through{' '}
+        <InlineCode>components.CloneButton</InlineCode>.
+      </p>
+      <CodeBlock
+        code={cloneButtonSnippet}
+        language="tsx"
+        label="CloneButton override"
+      />
+      <SectionTitle>What &quot;locked&quot; means in the UI</SectionTitle>
+      <List>
+        <li>
+          Read-only targets stay visible. They become disabled, not hidden.
+        </li>
+        <li>
+          Locked rules cannot change field, operator, or value, and cannot be
+          deleted.
+        </li>
+        <li>
+          Targeted rule read-only also blocks deleting that rule, even if only
+          one target such as <InlineCode>field</InlineCode> is protected.
+        </li>
+        <li>
+          Locked groups cannot change their group operator, negation, add
+          actions, or delete action.
+        </li>
+        <li>
+          By default, groups also cannot be deleted when that would remove
+          protected descendants indirectly.
+        </li>
+        <li>
+          Set <InlineCode>Builder.readOnlyProtectsDelete={false}</InlineCode> to
+          disable that subtree delete protection while keeping direct node-level
+          read-only deletion rules.
+        </li>
+        <li>
+          Locked rules and groups are removed from drag-and-drop interactions.
+        </li>
+        <li>
+          Clone controls render only for editable rules and groups. Cloned nodes
+          preserve their read-only configuration.
+        </li>
+        <li>
+          A locked group without inheritance still renders editable descendants
+          when those descendants are not otherwise locked.
+        </li>
+      </List>
+      <SectionTitle>Inheritance and precedence</SectionTitle>
+      <List>
+        <li>Inheritance only applies to groups, never to rules.</li>
+        <li>
+          <InlineCode>inheritToChildren</InlineCode> has an effect only when{' '}
+          <InlineCode>enabled</InlineCode> is <InlineCode>true</InlineCode>.
+        </li>
+        <li>
+          Once a parent group inherits read-only to descendants, child nodes
+          cannot opt back into editability with{' '}
+          <InlineCode>readOnly: false</InlineCode>.
+        </li>
+        <li>
+          Descendants may still add their own local{' '}
+          <InlineCode>readOnly</InlineCode> flags, but they cannot override an
+          inherited lock from an ancestor.
+        </li>
+        <li>
+          Group target inheritance preserves only the group-level semantics of
+          the inherited lock. It does not turn rule-specific controls such as{' '}
+          <InlineCode>field</InlineCode> or <InlineCode>value</InlineCode> into
+          inherited targets.
+        </li>
+      </List>
+      <AlertBox title="API reference" variant="info">
+        <TextLink to="/api/builder">Builder</TextLink> and{' '}
+        <TextLink to="/api/data">Data</TextLink>.
+      </AlertBox>
+    </>
+  ),
+};

--- a/example/src/v1/pages/documentation-page/pages/overview.documentation-page.tsx
+++ b/example/src/v1/pages/documentation-page/pages/overview.documentation-page.tsx
@@ -1,0 +1,56 @@
+import * as React from 'react';
+import { AlertBox } from '../../../../components/alert-box';
+import { List, TextLink } from '../../../../components/docs-primitives';
+import type { IDocumentationPage } from '../types/documentation-page';
+
+export const overviewDocumentationPage: IDocumentationPage = {
+  path: '/documentation',
+  title: 'Documentation Overview',
+  sectionKey: 'overview',
+  sectionTitle: 'Documentation',
+  summary: '',
+  description:
+    'Documentation overview for installation, usage, parsing and formatting, customization, adapters, and localization.',
+  searchText:
+    'Documentation overview installation usage parsing formatting configuration theming localization adapters bootstrap demo query builder react library website',
+  content: (
+    <>
+      <List>
+        <li>
+          Start with installation and the first controlled builder example.
+        </li>
+        <li>
+          Use{' '}
+          <TextLink to="/documentation/dynamic-field-options">
+            Dynamic Field Options
+          </TextLink>{' '}
+          when list values need to come from async or dependent data sources.
+        </li>
+        <li>
+          <TextLink to="/documentation/field-comparisons">
+            Field Comparisons
+          </TextLink>{' '}
+          shows how to compare one field against another field.
+        </li>
+        <li>
+          Move to parsing and formatting when you need interoperability with
+          external query syntaxes.
+        </li>
+        <li>
+          Visit <TextLink to="/documentation/adapters">Adapters</TextLink> if
+          you want ready-made mappings for MUI, ANTD, Bootstrap, Mantine, Fluent
+          UI, or Radix Themes.
+        </li>
+        <li>
+          Use the <TextLink to="/api">API reference</TextLink> when you need
+          prop, data-shape, or export-level details.
+        </li>
+      </List>
+      <AlertBox title="Recommended path" variant="tip">
+        If you are evaluating the library, visit the{' '}
+        <TextLink to="/demo">Demo</TextLink> first and then continue with{' '}
+        <TextLink to="/documentation/usage">Usage</TextLink>.
+      </AlertBox>
+    </>
+  ),
+};

--- a/example/src/v1/pages/documentation-page/pages/parsing-and-formatting-supported-formats.documentation-page.tsx
+++ b/example/src/v1/pages/documentation-page/pages/parsing-and-formatting-supported-formats.documentation-page.tsx
@@ -1,0 +1,194 @@
+import * as React from 'react';
+import { AlertBox } from '../../../../components/alert-box';
+import { CodeBlock } from '../../../../components/code-block';
+import {
+  InlineCode,
+  List,
+  SectionTitle,
+  TextLink,
+} from '../../../../components/docs-primitives';
+import type { IDocumentationPage } from '../types/documentation-page';
+
+const sqlSnippet = `import { formatQuery } from '@vojtechportes/react-query-builder/formatQuery';
+
+const sql = formatQuery(data, 'SQL', {
+  fields,
+  wrapWhereClause: true,
+});
+
+// WHERE (CUSTOMER_COUNTRY = 'CZ' AND ORDER_TOTAL BETWEEN 1000 AND 5000)`;
+
+const fieldComparisonFormatSnippet = `import { type DenormalizedQuery } from '@vojtechportes/react-query-builder';
+import { formatQuery } from '@vojtechportes/react-query-builder/formatQuery';
+
+const data: DenormalizedQuery = [
+  {
+    type: 'GROUP',
+    value: 'AND',
+    isNegated: false,
+    children: [
+      {
+        field: 'ORDER_TOTAL',
+        operator: 'LARGER_EQUAL',
+        valueSource: 'field',
+        valueField: 'ORDER_APPROVAL_LIMIT',
+      },
+    ],
+  },
+];
+
+const sql = formatQuery(data, 'SQL', {
+  fields,
+  wrapWhereClause: true,
+});
+
+// WHERE ORDER_TOTAL >= ORDER_APPROVAL_LIMIT`;
+
+const fieldComparisonParseSnippet = `import { parseQuery } from '@vojtechportes/react-query-builder/parseQuery';
+
+const result = parseQuery(
+  'WHERE ORDER_TOTAL >= ORDER_APPROVAL_LIMIT',
+  'SQL'
+);
+
+console.log(result.data[0]);
+// {
+//   type: 'GROUP',
+//   value: 'AND',
+//   isNegated: false,
+//   children: [
+//     {
+//       field: 'ORDER_TOTAL',
+//       operator: 'LARGER_EQUAL',
+//       valueSource: 'field',
+//       valueField: 'ORDER_APPROVAL_LIMIT',
+//     },
+//   ],
+// }`;
+
+export const parsingAndFormattingSupportedFormatsDocumentationPage: IDocumentationPage =
+  {
+    path: '/documentation/parsing-and-formatting/supported-formats',
+    title: 'Supported Formats',
+    sectionKey: 'parsing',
+    sectionTitle: 'Parsing and Formatting',
+    summary: '',
+    description:
+      'Supported query conversion formats including SQL, Mongo, AQL, JSONata, JsonLogic, CEL, Elasticsearch, SpEL, Prisma, OData, RSQL, Dynamo, and Django.',
+    searchText:
+      'SQL Mongo AQL JSONata JsonLogic CEL Elasticsearch SpEL Prisma OData RSQL Dynamo Django supported formats parser formatter query builder',
+    content: (
+      <>
+        <p>Supported formats and their primary use cases.</p>
+        <SectionTitle>SQL</SectionTitle>
+        <p>
+          Formatting and predicate parsing for builder-compatible SQL
+          expressions.
+        </p>
+        <CodeBlock code={sqlSnippet} language="ts" label="SQL formatter" />
+        <AlertBox title="Parsing scope" variant="warning">
+          SQL support is aimed at builder-compatible predicates. It is not meant
+          to be a full SQL parser for arbitrary queries with joins, projections,
+          or nested subqueries.
+        </AlertBox>
+        <SectionTitle>Mongo</SectionTitle>
+        <p>
+          Formatting returns a serialized JSON filter document. Parsing expects
+          a JSON object string and can infer{' '}
+          <TextLink to="/api/fields">fields</TextLink> from the document shape.
+        </p>
+        <CodeBlock
+          code={`const mongo = formatQuery(data, 'Mongo');\n// { "$and": [ ... ] }`}
+          language="ts"
+          label="Mongo formatter"
+        />
+        <AlertBox title="Field inference" variant="tip">
+          Mongo parsing can infer field names and basic types from the filter
+          document.
+        </AlertBox>
+        <SectionTitle>AQL</SectionTitle>
+        <List>
+          <li>
+            ArangoDB-style filter expressions with optional filter-clause
+            wrapping and configurable variable names.
+          </li>
+        </List>
+        <SectionTitle>JSONata and JsonLogic</SectionTitle>
+        <List>
+          <li>
+            JSON-oriented expression formats for rules evaluated against
+            object-shaped data.
+          </li>
+        </List>
+        <SectionTitle>CEL and SpEL</SectionTitle>
+        <List>
+          <li>
+            Expression languages used in application and policy evaluation
+            environments.
+          </li>
+        </List>
+        <SectionTitle>Prisma and Django</SectionTitle>
+        <List>
+          <li>Framework-oriented filter output for backend query layers.</li>
+        </List>
+        <SectionTitle>OData, RSQL, Dynamo, and Elasticsearch</SectionTitle>
+        <List>
+          <li>
+            API and datastore integrations with format-specific output
+            conventions.
+          </li>
+        </List>
+        <SectionTitle>Advanced: Field-To-Field Comparisons</SectionTitle>
+        <p>
+          Most formats on this page can be explored with ordinary literal-based
+          rules. If you specifically need one field to compare against another,
+          start with{' '}
+          <TextLink to="/documentation/field-comparisons">
+            Field Comparisons
+          </TextLink>{' '}
+          and then use the native field-reference support only in formats that
+          have a direct right-hand-side field form.
+        </p>
+        <List>
+          <li>
+            Supported native field-to-field formats in this feature are{' '}
+            <InlineCode>SQL</InlineCode>, <InlineCode>Mongo</InlineCode>,{' '}
+            <InlineCode>AQL</InlineCode>, <InlineCode>JSONata</InlineCode>,{' '}
+            <InlineCode>JsonLogic</InlineCode>, <InlineCode>CEL</InlineCode>,{' '}
+            <InlineCode>SpEL</InlineCode>, <InlineCode>Prisma</InlineCode>,{' '}
+            <InlineCode>OData</InlineCode>, <InlineCode>Dynamo</InlineCode>, and{' '}
+            <InlineCode>Django</InlineCode>.
+          </li>
+          <li>
+            String-style field references are also supported where the target
+            format has a native form for them, such as{' '}
+            <InlineCode>contains</InlineCode>,{' '}
+            <InlineCode>startsWith</InlineCode>, and{' '}
+            <InlineCode>endsWith</InlineCode> in <InlineCode>CEL</InlineCode>,{' '}
+            <InlineCode>OData</InlineCode>, <InlineCode>Django</InlineCode>, and{' '}
+            <InlineCode>SpEL</InlineCode>.
+          </li>
+          <li>
+            <InlineCode>Elasticsearch</InlineCode> and{' '}
+            <InlineCode>RSQL</InlineCode> intentionally reject field comparisons
+            because supporting them would require invented syntax or non-native
+            backend semantics.
+          </li>
+        </List>
+        <CodeBlock
+          code={fieldComparisonFormatSnippet}
+          language="ts"
+          label="Formatting a field comparison"
+        />
+        <CodeBlock
+          code={fieldComparisonParseSnippet}
+          language="ts"
+          label="Parsing a field comparison"
+        />
+        <AlertBox title="API reference" variant="info">
+          <TextLink to="/api/format-query">formatQuery</TextLink> and{' '}
+          <TextLink to="/api/parse-query">parseQuery</TextLink>.
+        </AlertBox>
+      </>
+    ),
+  };

--- a/example/src/v1/pages/documentation-page/pages/parsing-and-formatting.documentation-page.tsx
+++ b/example/src/v1/pages/documentation-page/pages/parsing-and-formatting.documentation-page.tsx
@@ -1,0 +1,66 @@
+import * as React from 'react';
+import { AlertBox } from '../../../../components/alert-box';
+import { CodeBlock } from '../../../../components/code-block';
+import { List, TextLink } from '../../../../components/docs-primitives';
+import type { IDocumentationPage } from '../types/documentation-page';
+
+const sqlSnippet = `import { formatQuery } from '@vojtechportes/react-query-builder/formatQuery';
+
+const sql = formatQuery(data, 'SQL', {
+  fields,
+  wrapWhereClause: true,
+});
+
+// WHERE (CUSTOMER_COUNTRY = 'CZ' AND ORDER_TOTAL BETWEEN 1000 AND 5000)`;
+
+const parseSnippet = `import { parseQuery } from '@vojtechportes/react-query-builder/parseQuery';
+
+const result = parseQuery(
+  "WHERE CUSTOMER_COUNTRY = 'CZ' AND ORDER_TOTAL >= 1000",
+  'SQL'
+);
+
+console.log(result.fields);
+console.log(result.data);`;
+
+export const parsingAndFormattingDocumentationPage: IDocumentationPage = {
+  path: '/documentation/parsing-and-formatting',
+  title: 'Overview',
+  sectionKey: 'parsing',
+  sectionTitle: 'Parsing and Formatting',
+  summary: '',
+  description:
+    'Overview of parsing and formatting query data across supported external formats.',
+  searchText:
+    'Parsing formatting SQL Mongo AQL JSONata JsonLogic CEL Elasticsearch SpEL Prisma OData RSQL Dynamo Django parseQuery formatQuery interoperability sandbox',
+  content: (
+    <>
+      <p>Query data can be converted to and from supported external formats.</p>
+      <List>
+        <li>
+          <TextLink to="/api/format-query">formatQuery</TextLink> converts
+          builder state to a target syntax.
+        </li>
+        <li>
+          <TextLink to="/api/parse-query">parseQuery</TextLink> converts
+          supported syntaxes back into builder state.
+        </li>
+        <li>
+          The documentation sandbox on this page lets you experiment with every
+          supported format live.
+        </li>
+      </List>
+      <CodeBlock code={sqlSnippet} language="ts" label="Formatting to SQL" />
+      <CodeBlock code={parseSnippet} language="ts" label="Parsing from SQL" />
+      <AlertBox title="Round-tripping" variant="info">
+        Some formats are more expressive than others. A round-trip is best when
+        the source expression stays within the subset that maps cleanly to the
+        builder model.
+      </AlertBox>
+      <AlertBox title="API reference" variant="info">
+        <TextLink to="/api/format-query">formatQuery</TextLink> and{' '}
+        <TextLink to="/api/parse-query">parseQuery</TextLink>.
+      </AlertBox>
+    </>
+  ),
+};

--- a/example/src/v1/pages/documentation-page/pages/text-mode.documentation-page.tsx
+++ b/example/src/v1/pages/documentation-page/pages/text-mode.documentation-page.tsx
@@ -1,0 +1,388 @@
+import * as React from 'react';
+import { AlertBox } from '../../../../components/alert-box';
+import { CodeBlock } from '../../../../components/code-block';
+import {
+  InlineCode,
+  ItemTitle,
+  List,
+  SectionTitle,
+  TextLink,
+} from '../../../../components/docs-primitives';
+import type { IDocumentationPage } from '../types/documentation-page';
+
+const textModeSnippet = `import React, { useState } from 'react';
+import {
+  Builder,
+  type DenormalizedQuery,
+  type IBuilderFieldProps,
+} from '@vojtechportes/react-query-builder';
+
+const fields: IBuilderFieldProps[] = [
+  {
+    field: 'CUSTOMER_COUNTRY',
+    label: 'Customer country',
+    type: 'LIST',
+    operators: ['EQUAL', 'NOT_EQUAL'],
+    value: [
+      { value: 'CZ', label: 'Czech Republic' },
+      { value: 'SK', label: 'Slovakia' },
+    ],
+  },
+  {
+    field: 'ORDER_TOTAL',
+    label: 'Order total',
+    type: 'NUMBER',
+    operators: ['LARGER_EQUAL', 'BETWEEN'],
+  },
+];
+
+export const TextModeBuilder = () => {
+  const [data, setData] = useState<DenormalizedQuery>(initialData);
+
+  return (
+    <Builder
+      fields={fields}
+      data={data}
+      textMode
+      onChange={setData}
+    />
+  );
+};`;
+
+const textModeDefaultModeSnippet = `<Builder
+  fields={fields}
+  data={data}
+  textMode
+  defaultMode="text"
+  onChange={setData}
+/>;
+
+// defaultMode only takes effect when textMode is enabled.`;
+
+const textModeConfigSnippet = `<Builder
+  fields={fields}
+  data={data}
+  textMode={{
+    format: 'SQL',
+    defaultMode: 'builder',
+  }}
+  defaultMode="text"
+  onChange={setData}
+/>;
+
+// textMode can be either:
+// - true
+// - { format?: 'SQL'; defaultMode?: 'builder' | 'text' }
+//
+// If both are provided, the top-level defaultMode prop wins.`;
+
+const monacoInstallSnippet = `npm install monaco-editor`;
+
+const monacoTextModeSnippet = `import React, { useState } from 'react';
+import {
+  Builder,
+  type DenormalizedQuery,
+} from '@vojtechportes/react-query-builder';
+import { createMonacoComponents } from '@vojtechportes/react-query-builder/monaco';
+
+const components = createMonacoComponents({});
+
+export const MonacoTextModeBuilder = () => {
+  const [data, setData] = useState<DenormalizedQuery>(initialData);
+
+  return (
+    <Builder
+      fields={fields}
+      data={data}
+      textMode
+      defaultMode="text"
+      components={components}
+      onChange={setData}
+    />
+  );
+};`;
+
+const monacoWithMuiSnippet = `import { Builder } from '@vojtechportes/react-query-builder';
+import { components as muiComponents } from '@vojtechportes/react-query-builder/mui/v9';
+import { createMonacoComponents } from '@vojtechportes/react-query-builder/monaco';
+
+const components = createMonacoComponents(muiComponents);
+
+<Builder
+  fields={fields}
+  data={data}
+  textMode
+  components={components}
+  onChange={setData}
+/>;
+
+// The same pattern works with @vojtechportes/react-query-builder/antd/v6.`;
+
+const monacoWithAntdSnippet = `import { Builder } from '@vojtechportes/react-query-builder';
+import { components as antdComponents } from '@vojtechportes/react-query-builder/antd/v6';
+import { createMonacoComponents } from '@vojtechportes/react-query-builder/monaco';
+
+const components = createMonacoComponents(antdComponents);
+
+<Builder
+  fields={fields}
+  data={data}
+  textMode
+  components={components}
+  onChange={setData}
+/>;`;
+
+const textModeStringsSnippet = `import { strings } from '@vojtechportes/react-query-builder';
+
+<Builder
+  fields={fields}
+  data={data}
+  textMode
+  strings={{
+    ...strings,
+    textMode: {
+      ...strings.textMode,
+      toggleToText: 'Switch to SQL mode',
+      toggleToBuilder: 'Switch to visual builder',
+      syntaxError: 'SQL syntax error',
+      locksUnsupported: 'Locked rules and groups are not supported in this text editor mode.',
+      lockedRangesHover: 'This SQL fragment is locked and cannot be edited.',
+    },
+  }}
+  onChange={setData}
+/>;`;
+
+export const textModeDocumentationPage: IDocumentationPage = {
+  path: '/documentation/text-mode',
+  title: 'Text Mode',
+  sectionKey: 'customization',
+  sectionTitle: 'Customization',
+  summary: '',
+  description:
+    'Documentation for SQL text mode, syntax and semantic validation, default mode selection, and the optional Monaco text editor integration.',
+  searchText:
+    'Text mode SQL text editor monaco createMonacoComponents syntax highlighting syntax validation semantic validation locked rules locked groups defaultMode singleRootGroup',
+  content: (
+    <>
+      <p>
+        Text mode lets the builder switch between the visual query UI and a SQL
+        editor view of the same query.
+      </p>
+      <CodeBlock
+        code={textModeSnippet}
+        language="tsx"
+        label="Enable built-in text mode"
+      />
+      <SectionTitle>Current scope</SectionTitle>
+      <List>
+        <li>Text mode currently uses SQL as the editable text format.</li>
+        <li>
+          It requires <InlineCode>singleRootGroup</InlineCode> to stay enabled.
+          If <InlineCode>singleRootGroup</InlineCode> is{' '}
+          <InlineCode>false</InlineCode>, text mode is unavailable and the
+          builder stays in visual mode.
+        </li>
+        <li>
+          When text mode is enabled, modifierless groups are normalized to{' '}
+          <InlineCode>AND</InlineCode> groups so the query can round-trip
+          through SQL.
+        </li>
+      </List>
+      <SectionTitle>Opening mode</SectionTitle>
+      <p>
+        Use <InlineCode>defaultMode</InlineCode> to choose whether the builder
+        opens in the visual builder or in text mode.
+      </p>
+      <CodeBlock
+        code={textModeDefaultModeSnippet}
+        language="tsx"
+        label="Open directly in text mode"
+      />
+      <CodeBlock
+        code={textModeConfigSnippet}
+        language="tsx"
+        label="Explicit textMode config"
+      />
+      <SectionTitle>Validation</SectionTitle>
+      <List>
+        <li>
+          Missing brackets, quotes, commas, and other SQL syntax mistakes are
+          highlighted directly in the editor.
+        </li>
+        <li>Unknown fields are highlighted on the field token.</li>
+        <li>
+          Unsupported operators for a field are highlighted on the operator
+          token.
+        </li>
+        <li>
+          Invalid <InlineCode>LIST</InlineCode> values are highlighted on the
+          invalid value token.
+        </li>
+        <li>
+          Invalid <InlineCode>MULTI_LIST</InlineCode> values are highlighted on
+          the invalid value token.
+        </li>
+        <li>
+          Read-only negation changes are rejected after parsing and shown as
+          below-editor semantic errors.
+        </li>
+      </List>
+      <SectionTitle>Invalid text behavior</SectionTitle>
+      <List>
+        <li>
+          Invalid text stays local to the text editor until the SQL becomes
+          valid again.
+        </li>
+        <li>
+          The last valid builder query is preserved while the user is fixing
+          text-mode errors.
+        </li>
+        <li>
+          <InlineCode>onChange</InlineCode> is fired only after a valid parse
+          and successful semantic validation.
+        </li>
+      </List>
+      <SectionTitle>History behavior</SectionTitle>
+      <List>
+        <li>
+          Valid text edits are committed into builder history, so they can be
+          undone and redone.
+        </li>
+        <li>
+          Invalid intermediate text is not committed into builder state or
+          history.
+        </li>
+      </List>
+      <SectionTitle>Choosing an editor</SectionTitle>
+      <List>
+        <li>
+          <ItemTitle>Choose the built-in editor:</ItemTitle> when you want
+          lightweight SQL editing, built-in validation, and no extra
+          dependencies.
+        </li>
+        <li>
+          <ItemTitle>Choose Monaco:</ItemTitle> when locked or targeted
+          read-only query segments must stay protected in text mode, or when you
+          want a more advanced editor experience.
+        </li>
+      </List>
+      <SectionTitle>Built-in editor vs Monaco</SectionTitle>
+      <List>
+        <li>
+          <ItemTitle>Built-in text mode:</ItemTitle> Included in the core
+          package, uses the default <InlineCode>TextModeEditor</InlineCode>, and
+          supports SQL formatting, syntax highlighting, syntax validation, and
+          semantic validation without extra dependencies.
+        </li>
+        <li>
+          <ItemTitle>Built-in editor limitation:</ItemTitle> Locked rules,
+          locked groups, and targeted read-only queries are blocked before
+          entering text mode there, because the basic editor cannot preserve
+          protected query segments safely after freeform text edits.
+        </li>
+        <li>
+          <ItemTitle>Monaco text mode:</ItemTitle> Optional advanced editor
+          integration exposed from{' '}
+          <InlineCode>@vojtechportes/react-query-builder/monaco</InlineCode>. It
+          preserves locked and targeted read-only query segments by rendering
+          them as protected ranges.
+        </li>
+        <li>
+          <ItemTitle>Monaco protected behavior:</ItemTitle> Protected SQL
+          fragments are dimmed, protected from edits, and expose their lock
+          explanation on hover.
+        </li>
+        <li>
+          <ItemTitle>Localized read-only protection:</ItemTitle> Rule field,
+          operator, and value segments can be protected inline, while read-only
+          negation is additionally enforced semantically and reported below the
+          editor when changed.
+        </li>
+        <li>
+          <ItemTitle>Group negation validation:</ItemTitle> When{' '}
+          <InlineCode>allowGroupNegation={false}</InlineCode>, the text editor
+          rejects group-level <InlineCode>NOT (...)</InlineCode> expressions and
+          highlights the offending <InlineCode>NOT</InlineCode> token, while
+          still allowing operator-level negation such as{' '}
+          <InlineCode>NOT IN</InlineCode> or{' '}
+          <InlineCode>IS NOT NULL</InlineCode>.
+        </li>
+        <li>
+          <ItemTitle>Monaco packaging:</ItemTitle>{' '}
+          <InlineCode>monaco-editor</InlineCode> is an optional peer dependency.
+          Consumers only need to install it when they actually want the Monaco
+          editor.
+        </li>
+      </List>
+      <SectionTitle>Using Monaco text mode</SectionTitle>
+      <CodeBlock
+        code={monacoTextModeSnippet}
+        language="tsx"
+        label="Monaco text mode with default components"
+      />
+      <CodeBlock
+        code={monacoWithMuiSnippet}
+        language="tsx"
+        label="Compose Monaco with MUI"
+      />
+      <CodeBlock
+        code={monacoWithAntdSnippet}
+        language="tsx"
+        label="Compose Monaco with ANTD"
+      />
+      <SectionTitle>Text-mode strings</SectionTitle>
+      <p>
+        Text-mode labels and messages are part of the regular{' '}
+        <InlineCode>strings</InlineCode> override surface.
+      </p>
+      <CodeBlock
+        code={textModeStringsSnippet}
+        language="tsx"
+        label="Custom text-mode strings"
+      />
+      <List>
+        <li>
+          <InlineCode>strings.textMode.toggleToText</InlineCode> customizes the
+          button label for entering text mode.
+        </li>
+        <li>
+          <InlineCode>strings.textMode.toggleToBuilder</InlineCode> customizes
+          the button label for returning to the visual builder.
+        </li>
+        <li>
+          <InlineCode>strings.textMode.syntaxError</InlineCode> customizes the
+          syntax error prefix.
+        </li>
+        <li>
+          <InlineCode>strings.textMode.locksUnsupported</InlineCode> customizes
+          the built-in alert shown when the basic editor cannot open a locked or
+          targeted read-only query.
+        </li>
+        <li>
+          <InlineCode>strings.textMode.lockedRangesHover</InlineCode> customizes
+          the hover message shown for protected Monaco ranges.
+        </li>
+        <li>
+          <InlineCode>strings.textMode.sql</InlineCode> customizes SQL parser
+          and syntax-validation messages such as missing brackets, missing
+          quotes, missing keywords, and unexpected tokens.
+        </li>
+      </List>
+      <SectionTitle>Installing Monaco</SectionTitle>
+      <CodeBlock
+        code={monacoInstallSnippet}
+        language="bash"
+        label="Monaco peer dependency"
+      />
+      <AlertBox title="Locks and Monaco" variant="info">
+        The built-in text editor blocks locked and targeted read-only queries.
+        Monaco is the intended path when protected query segments need to remain
+        editable only around their unlocked ranges.
+      </AlertBox>
+      <AlertBox title="API reference" variant="info">
+        <TextLink to="/api/builder">Builder</TextLink> and{' '}
+        <TextLink to="/api/components">Components</TextLink>.
+      </AlertBox>
+    </>
+  ),
+};

--- a/example/src/v1/pages/documentation-page/pages/theming.documentation-page.tsx
+++ b/example/src/v1/pages/documentation-page/pages/theming.documentation-page.tsx
@@ -1,0 +1,58 @@
+import * as React from 'react';
+import { AlertBox } from '../../../../components/alert-box';
+import { CodeBlock } from '../../../../components/code-block';
+import { InlineCode, TextLink } from '../../../../components/docs-primitives';
+import type { IDocumentationPage } from '../types/documentation-page';
+
+const themeSnippet = `import { ThemeProvider } from '@vojtechportes/react-query-builder/theme-provider';
+import { colors } from '@vojtechportes/react-query-builder';
+
+<ThemeProvider
+  colors={{
+    ...colors,
+    primary: {
+      ...colors.primary,
+      default: '#3f51b5',
+    },
+  }}
+>
+  <Builder data={data} fields={fields} onChange={setData} />
+</ThemeProvider>;`;
+
+export const themingDocumentationPage: IDocumentationPage = {
+  path: '/documentation/theming',
+  title: 'Theming',
+  sectionKey: 'customization',
+  sectionTitle: 'Customization',
+  summary: '',
+  description:
+    'Documentation for customizing builder colors with ThemeProvider and shared theme tokens.',
+  searchText:
+    'Theming theme provider colors primary secondary grey tokens design system',
+  content: (
+    <>
+      <p>
+        Use the theme provider to override builder color tokens. For control and
+        container replacement, see{' '}
+        <TextLink to="/documentation/components">Components</TextLink>.
+      </p>
+      <CodeBlock code={themeSnippet} language="tsx" label="Theme provider" />
+      <AlertBox title="Adapters and theming" variant="info">
+        <InlineCode>ThemeProvider</InlineCode> customizes the built-in default
+        component set. If you use an adapter from{' '}
+        <TextLink to="/documentation/adapters">Adapters</TextLink>, such as{' '}
+        <InlineCode>mui/v7</InlineCode>, <InlineCode>mui/v9</InlineCode>,{' '}
+        <InlineCode>antd/v5</InlineCode>, <InlineCode>antd/v6</InlineCode>,{' '}
+        <InlineCode>bootstrap/v5</InlineCode>,{' '}
+        <InlineCode>fluentui/v8</InlineCode>,{' '}
+        <InlineCode>mantine/v8</InlineCode>, <InlineCode>mantine/v9</InlineCode>
+        , or <InlineCode>radix/v1</InlineCode>, these theme tokens do not affect
+        the adapter UI.
+      </AlertBox>
+      <AlertBox title="API reference" variant="info">
+        <TextLink to="/api/theming">Theming</TextLink> and{' '}
+        <TextLink to="/api/adapters">Adapters</TextLink>.
+      </AlertBox>
+    </>
+  ),
+};

--- a/example/src/v1/pages/documentation-page/pages/usage.documentation-page.tsx
+++ b/example/src/v1/pages/documentation-page/pages/usage.documentation-page.tsx
@@ -1,0 +1,112 @@
+import * as React from 'react';
+import { AlertBox } from '../../../../components/alert-box';
+import { CodeBlock } from '../../../../components/code-block';
+import { InlineCode, TextLink } from '../../../../components/docs-primitives';
+import type { IDocumentationPage } from '../types/documentation-page';
+
+const basicUsageSnippet = `import React, { useState } from 'react';
+import {
+  Builder,
+  type DenormalizedQuery,
+  type IBuilderFieldProps,
+} from '@vojtechportes/react-query-builder';
+
+const fields: IBuilderFieldProps[] = [
+  {
+    field: 'STATE',
+    label: 'State',
+    type: 'LIST',
+    operators: ['EQUAL', 'NOT_EQUAL'],
+    value: [
+      { value: 'CZ', label: 'Czech Republic' },
+      { value: 'SK', label: 'Slovakia' },
+    ],
+  },
+  {
+    field: 'IS_IN_EU',
+    label: 'Is in EU',
+    type: 'BOOLEAN',
+  },
+];
+
+const initialData: DenormalizedQuery = [
+  {
+    type: 'GROUP',
+    value: 'AND',
+    isNegated: false,
+    children: [
+      {
+        field: 'STATE',
+        operator: 'EQUAL',
+        value: 'CZ',
+        readOnly: true,
+      },
+      {
+        field: 'IS_IN_EU',
+        operator: 'EQUAL',
+        value: true,
+      },
+    ],
+  },
+];
+
+export const MyBuilder = () => {
+  const [data, setData] = useState(initialData);
+
+  return <Builder fields={fields} data={data} onChange={setData} />;
+};`;
+
+export const usageDocumentationPage: IDocumentationPage = {
+  path: '/documentation/usage',
+  title: 'Usage',
+  sectionKey: 'getting-started',
+  sectionTitle: 'Getting Started',
+  summary: '',
+  description:
+    'Basic controlled usage with Builder, field definitions, query data, and onChange handling.',
+  searchText:
+    'Usage Builder controlled component fields data onChange React useState denormalized query query builder example',
+  content: (
+    <>
+      <p>Basic controlled usage.</p>
+      <CodeBlock code={basicUsageSnippet} language="tsx" label="Basic setup" />
+      <p>
+        The example includes a single rule with{' '}
+        <InlineCode>readOnly: true</InlineCode> to show that locking can live
+        directly in the query data without changing the rest of the builder
+        configuration.
+      </p>
+      <AlertBox title="Related guide" variant="info">
+        Need a rule to compare against another field instead of a literal value?
+        Visit{' '}
+        <TextLink to="/documentation/field-comparisons">
+          Field Comparisons
+        </TextLink>
+        .
+      </AlertBox>
+      <AlertBox title="Next step" variant="tip">
+        Continue with{' '}
+        <TextLink to="/documentation/builder-ref">Builder Ref</TextLink> for
+        imperative control,{' '}
+        <TextLink to="/documentation/field-comparisons">
+          Field Comparisons
+        </TextLink>{' '}
+        for cross-field rules,{' '}
+        <TextLink to="/documentation/builder-behavior">
+          Builder Behavior
+        </TextLink>{' '}
+        or <TextLink to="/documentation/text-mode">Text Mode</TextLink> or{' '}
+        <TextLink to="/documentation/history">Undo and Redo</TextLink> for
+        editing workflows, or{' '}
+        <TextLink to="/documentation/dynamic-field-options">
+          Dynamic Field Options
+        </TextLink>{' '}
+        for async select data, or{' '}
+        <TextLink to="/documentation/locking-and-read-only">
+          Locking and Read-only
+        </TextLink>{' '}
+        for partial locking.
+      </AlertBox>
+    </>
+  ),
+};

--- a/example/src/v1/pages/documentation-page/pages/validation.documentation-page.tsx
+++ b/example/src/v1/pages/documentation-page/pages/validation.documentation-page.tsx
@@ -1,0 +1,228 @@
+import * as React from 'react';
+import { AlertBox } from '../../../../components/alert-box';
+import { CodeBlock } from '../../../../components/code-block';
+import {
+  InlineCode,
+  List,
+  SectionTitle,
+  TextLink,
+} from '../../../../components/docs-primitives';
+import type { IDocumentationPage } from '../types/documentation-page';
+
+const validationSnippet = `const fields: IBuilderFieldProps[] = [
+  {
+    field: 'COMPANY_NAME',
+    label: 'Company name',
+    type: 'TEXT',
+    operators: ['EQUAL', 'CONTAINS'],
+    validation: {
+      common: {
+        required: true,
+      },
+      rules: [
+        {
+          operators: ['EQUAL', 'CONTAINS'],
+          minLength: 2,
+          maxLength: 50,
+        },
+      ],
+    },
+  },
+  {
+    field: 'ORDER_TOTAL',
+    label: 'Order total',
+    type: 'NUMBER',
+    operators: ['EQUAL', 'BETWEEN'],
+    validation: {
+      common: {
+        required: true,
+      },
+      rules: [
+        {
+          operators: ['EQUAL'],
+          min: 0,
+          max: 100000,
+        },
+        {
+          operators: ['BETWEEN'],
+          range: {
+            common: {
+              min: 0,
+            },
+            requireAscending: true,
+            allowEqual: false,
+          },
+        },
+      ],
+    },
+  },
+];
+
+<Builder
+  fields={fields}
+  data={data}
+  showValidation
+  onStateChange={state => {
+    console.log(state.isValid);
+    console.log(state.validation);
+  }}
+  onChange={setData}
+/>;`;
+
+const usageLimitSnippet = `const fields: IBuilderFieldProps[] = [
+  {
+    field: 'PRIMARY_EMAIL',
+    label: 'Primary email',
+    type: 'TEXT',
+    operators: ['EQUAL', 'CONTAINS'],
+    usageLimit: {
+      max: 1,
+      scope: 'global',
+    },
+  },
+  {
+    field: 'BILLING_CONTACT',
+    label: 'Billing contact',
+    type: 'TEXT',
+    operators: ['EQUAL'],
+    usageLimit: {
+      key: 'contact-field',
+      max: 1,
+      scope: 'parent',
+    },
+  },
+  {
+    field: 'SHIPPING_CONTACT',
+    label: 'Shipping contact',
+    type: 'TEXT',
+    operators: ['EQUAL'],
+    usageLimit: {
+      key: 'contact-field',
+      max: 1,
+      scope: 'parent',
+    },
+  },
+];
+
+<Builder
+  fields={fields}
+  data={data}
+  showValidation
+  onChange={setData}
+/>;`;
+
+export const validationDocumentationPage: IDocumentationPage = {
+  path: '/documentation/validation',
+  title: 'Validation',
+  sectionKey: 'getting-started',
+  sectionTitle: 'Getting Started',
+  summary: '',
+  description:
+    'Built-in validation for fields and rules, structural usageLimit constraints, validation rendering with showValidation, and custom validator integration.',
+  searchText:
+    'Validation built-in validation validator usageLimit showValidation onStateChange required minLength maxLength minItems maxItems range validation rules fields builder',
+  content: (
+    <>
+      <p>
+        Built-in validation is defined in{' '}
+        <TextLink to="/api/fields">field metadata</TextLink> and evaluated by{' '}
+        <TextLink to="/api/builder">Builder</TextLink>.
+      </p>
+      <List>
+        <li>
+          Use <InlineCode>validation.common</InlineCode> for operator-agnostic
+          rules such as required values.
+        </li>
+        <li>
+          Use <InlineCode>validation.rules</InlineCode> for operator-specific
+          rules.
+        </li>
+        <li>
+          Use <InlineCode>showValidation</InlineCode> to render built-in
+          validation messages in the UI.
+        </li>
+        <li>
+          Use <InlineCode>onStateChange</InlineCode> when query data and
+          validation state need to be read together.
+        </li>
+      </List>
+      <CodeBlock
+        code={validationSnippet}
+        language="tsx"
+        label="Built-in validation"
+      />
+      <SectionTitle>Built-in rule types</SectionTitle>
+      <List>
+        <li>
+          Text fields support rules such as <InlineCode>minLength</InlineCode>{' '}
+          and <InlineCode>maxLength</InlineCode>.
+        </li>
+        <li>
+          Number and date fields support boundary rules such as{' '}
+          <InlineCode>min</InlineCode>, <InlineCode>max</InlineCode>,{' '}
+          <InlineCode>minDate</InlineCode>, and <InlineCode>maxDate</InlineCode>
+          .
+        </li>
+        <li>
+          List and multi-list fields support item-count constraints such as{' '}
+          <InlineCode>minItems</InlineCode> and{' '}
+          <InlineCode>maxItems</InlineCode>.
+        </li>
+        <li>
+          Range operators such as <InlineCode>BETWEEN</InlineCode> can use{' '}
+          <InlineCode>range</InlineCode> validation to validate both values
+          together.
+        </li>
+      </List>
+      <SectionTitle>Structural usage limits</SectionTitle>
+      <p>
+        Use <InlineCode>usageLimit</InlineCode> when a constraint depends on how
+        many rules already use a field or a shared usage bucket. This is
+        separate from value validation because it governs query structure rather
+        than the validity of a single rule value.
+      </p>
+      <CodeBlock
+        code={usageLimitSnippet}
+        language="tsx"
+        label="Field usage limits"
+      />
+      <List>
+        <li>
+          <InlineCode>max</InlineCode> defines how many matching rules are
+          allowed inside the selected scope.
+        </li>
+        <li>
+          <InlineCode>scope=&quot;global&quot;</InlineCode> limits usage across
+          the whole query tree.
+        </li>
+        <li>
+          <InlineCode>scope=&quot;parent&quot;</InlineCode> limits usage only
+          among sibling rules in the same immediate parent group.
+        </li>
+        <li>
+          <InlineCode>key</InlineCode> lets multiple different fields share the
+          same quota bucket.
+        </li>
+        <li>
+          Exhausted fields are disabled in the field selector, and the Add Rule
+          button is disabled when no selectable fields remain in the current
+          scope.
+        </li>
+        <li>
+          <InlineCode>showValidation</InlineCode> still surfaces an issue when
+          data arrives in an already invalid state, such as external input or
+          text mode edits.
+        </li>
+      </List>
+      <AlertBox title="Custom validator" variant="info">
+        Use <InlineCode>validator</InlineCode> when validation depends on
+        multiple rules, external state, or rules that are not expressible in
+        field-level validation config or <InlineCode>usageLimit</InlineCode>.
+      </AlertBox>
+      <AlertBox title="API reference" variant="info">
+        <TextLink to="/api/builder">Builder</TextLink> and{' '}
+        <TextLink to="/api/fields">Fields</TextLink>.
+      </AlertBox>
+    </>
+  ),
+};

--- a/example/src/v1/pages/documentation-page/types/documentation-group.ts
+++ b/example/src/v1/pages/documentation-page/types/documentation-group.ts
@@ -1,0 +1,7 @@
+import type { IDocumentationPage } from './documentation-page';
+
+export interface IDocumentationGroup {
+  key: string;
+  title: string;
+  pages: IDocumentationPage[];
+}

--- a/example/src/v1/pages/documentation-page/types/documentation-page.ts
+++ b/example/src/v1/pages/documentation-page/types/documentation-page.ts
@@ -1,0 +1,13 @@
+import type * as React from 'react';
+
+export interface IDocumentationPage {
+  path: string;
+  title: string;
+  depth?: number;
+  sectionKey: string;
+  sectionTitle: string;
+  summary: string;
+  description: string;
+  searchText: string;
+  content: React.ReactNode;
+}

--- a/example/src/v1/pages/documentation-page/utils/find-documentation-page.util.ts
+++ b/example/src/v1/pages/documentation-page/utils/find-documentation-page.util.ts
@@ -1,0 +1,10 @@
+import { documentationPages } from '../constants/documentation-pages';
+
+export const findDocumentationPage = (pathname: string) => {
+  const normalizedPath = pathname.replace(/\/+$/, '') || '/';
+
+  return (
+    documentationPages.find((page) => page.path === normalizedPath) ??
+    documentationPages[0]
+  );
+};

--- a/example/src/v1/pages/documentation-page/utils/hash-documentation-content.util.ts
+++ b/example/src/v1/pages/documentation-page/utils/hash-documentation-content.util.ts
@@ -1,0 +1,10 @@
+export const hashDocumentationContent = async (content: string) => {
+  const digest = await crypto.subtle.digest(
+    'SHA-256',
+    new TextEncoder().encode(content)
+  );
+
+  return Array.from(new Uint8Array(digest), (byte) =>
+    byte.toString(16).padStart(2, '0')
+  ).join('');
+};

--- a/example/src/v1/pages/documentation-page/utils/load-imperative-field-options-demo.util.ts
+++ b/example/src/v1/pages/documentation-page/utils/load-imperative-field-options-demo.util.ts
@@ -1,0 +1,4 @@
+export const loadImperativeFieldOptionsDemo = () =>
+  import('../components/imperative-field-options-demo').then((module) => ({
+    default: module.ImperativeFieldOptionsDemo,
+  }));

--- a/example/src/v1/pages/documentation-page/utils/load-parsing-sandbox.util.ts
+++ b/example/src/v1/pages/documentation-page/utils/load-parsing-sandbox.util.ts
@@ -1,0 +1,4 @@
+export const loadParsingSandbox = () =>
+  import('../components/parsing-sandbox').then((module) => ({
+    default: module.ParsingSandbox,
+  }));

--- a/example/src/v1/pages/documentation-page/utils/load-shared-field-options-demo.util.ts
+++ b/example/src/v1/pages/documentation-page/utils/load-shared-field-options-demo.util.ts
@@ -1,0 +1,4 @@
+export const loadSharedFieldOptionsDemo = () =>
+  import('../components/shared-field-options-demo').then((module) => ({
+    default: module.SharedFieldOptionsDemo,
+  }));

--- a/example/src/v1/pages/documentation-page/utils/wait-for-timeout.util.ts
+++ b/example/src/v1/pages/documentation-page/utils/wait-for-timeout.util.ts
@@ -1,0 +1,23 @@
+export const waitForTimeout = (
+  durationMs: number,
+  signal?: AbortSignal
+): Promise<void> =>
+  new Promise<void>((resolve, reject) => {
+    const timeoutId = window.setTimeout(() => {
+      signal?.removeEventListener('abort', handleAbort);
+      resolve();
+    }, durationMs);
+
+    const handleAbort = () => {
+      window.clearTimeout(timeoutId);
+      signal?.removeEventListener('abort', handleAbort);
+      reject(new DOMException('Request aborted', 'AbortError'));
+    };
+
+    if (signal?.aborted) {
+      handleAbort();
+      return;
+    }
+
+    signal?.addEventListener('abort', handleAbort);
+  });

--- a/example/src/v2/entry-client.tsx
+++ b/example/src/v2/entry-client.tsx
@@ -2,6 +2,13 @@ import * as React from 'react';
 import { App } from '../app/app';
 import { DemoPage } from './pages/demo-page/demo-page';
 import { HomePage } from './pages/home-page/home-page';
+import { DocumentationPage } from '../pages/documentation-page/documentation-page';
 import { hydrateApp } from '../shared/client/hydrate-app.util';
 
-hydrateApp(<App demoPage={<DemoPage />} homePage={<HomePage />} />);
+hydrateApp(
+  <App
+    demoPage={<DemoPage />}
+    documentationPage={<DocumentationPage />}
+    homePage={<HomePage />}
+  />
+);

--- a/example/src/v2/entry-server.tsx
+++ b/example/src/v2/entry-server.tsx
@@ -3,11 +3,16 @@ import { AppRoutes } from '../app/app-routes';
 import { routerBasename } from '../app/router-basename';
 import { DemoPage } from './pages/demo-page/demo-page';
 import { HomePage } from './pages/home-page/home-page';
+import { DocumentationPage } from '../pages/documentation-page/documentation-page';
 import { renderApp } from '../shared/ssr/render-app.util';
 
 export const renderPage = (pathname: string) =>
   renderApp(
     pathname,
     routerBasename,
-    <AppRoutes demoPage={<DemoPage />} homePage={<HomePage />} />
+    <AppRoutes
+      demoPage={<DemoPage />}
+      documentationPage={<DocumentationPage />}
+      homePage={<HomePage />}
+    />
   );


### PR DESCRIPTION
- Added independent v1 implementations for all documentation routes and content
- Added v1-owned interactive documentation components, loaders, and supporting data
- Injected version-owned documentation pages through client and server entry points
- Added content parity, SSR, loader, and import-boundary tests
- Marked T016 as done