### PR TITLE
feat: Created the independent v2 API tree

### DIFF
--- a/.codex/TASKS.md
+++ b/.codex/TASKS.md
@@ -949,7 +949,7 @@ sharing only non-content site infrastructure.
 
 ### T019 - Create the independent v2 API tree
 
-**Status:** `[ ]` Not started
+**Status:** `[x]` Done
 
 **Depends on:** T018
 

--- a/.codex/t019-create-independent-v2-api-tree-tasks.md
+++ b/.codex/t019-create-independent-v2-api-tree-tasks.md
@@ -1,0 +1,10 @@
+# T019 - Create the independent v2 API tree
+
+- [x] Create v2-owned API pages, signatures, adapter references, navigation, and examples.
+- [x] Bind API types, functions, adapters, and Monaco references to the local v2 package target.
+- [x] Wire v2 client and SSR entries to the v2-owned API tree.
+- [x] Add route, content, sidebar, SSR, package-binding, and ownership tests.
+- [x] Run v2 API tests, type checks, ownership checks, and regression checks.
+- [x] Run Prettier on all modified code.
+- [x] Mark T019 done after verification succeeds.
+- [x] Run the required code review agent and resolve findings.

--- a/example/config/versioned-site/import-boundaries.test.ts
+++ b/example/config/versioned-site/import-boundaries.test.ts
@@ -86,6 +86,7 @@ describe('versioned site import boundaries', () => {
       resolve(sourceRoot, 'utils/builder-source'),
       resolve(sourceRoot, 'utils/query-formatters'),
       resolve(sourceRoot, 'pages/documentation-page'),
+      resolve(sourceRoot, 'pages/api-page'),
       resolve(sourceRoot, 'components/imperative-field-options-demo'),
       resolve(sourceRoot, 'components/shared-field-options-demo'),
       resolve(sourceRoot, 'components/parsing-sandbox'),

--- a/example/src/v2/entry-client.tsx
+++ b/example/src/v2/entry-client.tsx
@@ -4,7 +4,7 @@ import { DemoPage } from './pages/demo-page/demo-page';
 import { HomePage } from './pages/home-page/home-page';
 import { DocumentationPage } from './pages/documentation-page/documentation-page';
 import { hydrateApp } from '../shared/client/hydrate-app.util';
-import { ApiPage } from '../pages/api-page/api-page';
+import { ApiPage } from './pages/api-page/api-page';
 
 hydrateApp(
   <App

--- a/example/src/v2/entry-server.test.tsx
+++ b/example/src/v2/entry-server.test.tsx
@@ -1,4 +1,5 @@
 import { describe, expect, it } from 'vitest';
+import { apiBaseline } from './pages/api-page/constants/api-baseline';
 import { documentationBaseline } from './pages/documentation-page/constants/documentation-baseline';
 import { renderPage } from './entry-server';
 
@@ -39,6 +40,15 @@ describe('v2 version-owned SSR', () => {
     }
   );
 
+  it.each(apiBaseline)(
+    'renders the v2-owned API content for $path',
+    ({ path, title }) => {
+      const page = renderPage(path);
+
+      expect(page.html).toContain(`>${title}</h1>`);
+      expect(page.styles).toContain('data-styled="true"');
+    }
+  );
   it('renders the parsing sandbox client-only boundary', () => {
     const page = renderPage('/documentation/parsing-and-formatting');
 

--- a/example/src/v2/entry-server.tsx
+++ b/example/src/v2/entry-server.tsx
@@ -5,7 +5,7 @@ import { DemoPage } from './pages/demo-page/demo-page';
 import { HomePage } from './pages/home-page/home-page';
 import { DocumentationPage } from './pages/documentation-page/documentation-page';
 import { renderApp } from '../shared/ssr/render-app.util';
-import { ApiPage } from '../pages/api-page/api-page';
+import { ApiPage } from './pages/api-page/api-page';
 
 export const renderPage = (pathname: string) =>
   renderApp(

--- a/example/src/v2/pages/api-page/api-content.test.tsx
+++ b/example/src/v2/pages/api-page/api-content.test.tsx
@@ -1,0 +1,87 @@
+import * as React from 'react';
+import { renderToStaticMarkup } from 'react-dom/server';
+import { StaticRouter } from 'react-router-dom';
+import { describe, expect, it } from 'vitest';
+import { apiBaseline } from './constants/api-baseline';
+import { apiGroups } from './constants/api-groups';
+import { apiPages } from './constants/api-pages';
+import { findApiPage } from './utils/find-api-page.util';
+import { hashApiContent } from './utils/hash-api-content.util';
+
+describe('v2 API content', () => {
+  it('preserves the complete ordered route and title registry', () => {
+    expect(apiPages.map(({ path, title }) => ({ path, title }))).toEqual(
+      apiBaseline.map(({ path, title }) => ({ path, title }))
+    );
+  });
+
+  it('preserves the API sidebar groups and route order', () => {
+    expect(
+      apiGroups.map(({ title, pages }) => ({
+        title,
+        paths: pages.map(({ path }) => path),
+      }))
+    ).toEqual([
+      {
+        title: 'Core API',
+        paths: ['/api/builder', '/api/builder-ref', '/api/fields', '/api/data'],
+      },
+      {
+        title: 'Customization',
+        paths: [
+          '/api/components',
+          '/api/adapters',
+          '/api/adapters/mui',
+          '/api/adapters/antd',
+          '/api/adapters/fluentui',
+          '/api/adapters/mantine',
+          '/api/adapters/bootstrap',
+          '/api/adapters/radix',
+          '/api/theming',
+        ],
+      },
+      {
+        title: 'Query Conversion',
+        paths: ['/api/format-query', '/api/parse-query'],
+      },
+    ]);
+  });
+
+  it('preserves the normalized raw content for every route', async () => {
+    for (const { path, contentHash } of apiBaseline) {
+      const content = renderToStaticMarkup(
+        <StaticRouter location={path}>{findApiPage(path).content}</StaticRouter>
+      ).replace(/ class="[^"]*"/g, '');
+
+      await expect(hashApiContent(content)).resolves.toBe(contentHash);
+    }
+  });
+
+  it('normalizes trailing slashes and preserves the overview fallback', () => {
+    expect(findApiPage('/api/adapters/mui///').path).toBe('/api/adapters/mui');
+    expect(findApiPage('/api/unknown').path).toBe('/api');
+  });
+
+  it.each([
+    ['/api/builder', 'IBuilderProps'],
+    ['/api/builder-ref', 'IBuilderRef'],
+    ['/api/fields', 'BuilderFieldType'],
+    ['/api/data', 'QueryGroupValue'],
+    ['/api/components', 'IBuilderComponentsProps'],
+    ['/api/adapters/mui', 'react-query-builder/mui/v9'],
+    ['/api/adapters/antd', 'react-query-builder/antd/v6'],
+    ['/api/adapters/fluentui', 'react-query-builder/fluentui/v8'],
+    ['/api/adapters/mantine', 'react-query-builder/mantine/v9'],
+    ['/api/adapters/bootstrap', 'react-query-builder/bootstrap/v5'],
+    ['/api/adapters/radix', 'react-query-builder/radix/v1'],
+    ['/api/theming', 'ThemeProvider'],
+    ['/api/format-query', 'formatQuery'],
+    ['/api/parse-query', 'parseQuery'],
+  ])('renders the v2-owned %s signature or example', (path, sample) => {
+    const content = renderToStaticMarkup(
+      <StaticRouter location={path}>{findApiPage(path).content}</StaticRouter>
+    );
+
+    expect(content).toContain(sample);
+  });
+});

--- a/example/src/v2/pages/api-page/api-package-binding.test.ts
+++ b/example/src/v2/pages/api-page/api-package-binding.test.ts
@@ -1,0 +1,45 @@
+import { describe, expectTypeOf, it } from 'vitest';
+import type {
+  DenormalizedQuery,
+  IBuilderComponentsProps,
+  IBuilderFieldProps,
+  IBuilderProps,
+} from '@vojtechportes/react-query-builder';
+import type { formatQuery } from '@vojtechportes/react-query-builder/formatQuery';
+import type { parseQuery } from '@vojtechportes/react-query-builder/parseQuery';
+
+type AntdAdapterComponents =
+  (typeof import('@vojtechportes/react-query-builder/antd/v6'))['components'];
+type BootstrapAdapterComponents =
+  (typeof import('@vojtechportes/react-query-builder/bootstrap/v5'))['components'];
+type FluentUiAdapterComponents =
+  (typeof import('@vojtechportes/react-query-builder/fluentui/v8'))['components'];
+type MantineAdapterComponents =
+  (typeof import('@vojtechportes/react-query-builder/mantine/v9'))['components'];
+type MuiAdapterComponents =
+  (typeof import('@vojtechportes/react-query-builder/mui/v9'))['components'];
+type RadixAdapterComponents =
+  (typeof import('@vojtechportes/react-query-builder/radix/v1'))['components'];
+type MonacoFactory =
+  (typeof import('@vojtechportes/react-query-builder/monaco'))['createMonacoComponents'];
+
+describe('v2 API package bindings', () => {
+  it('binds core signatures and query conversion exports to the local v2 target', () => {
+    expectTypeOf<IBuilderProps['fields']>().toEqualTypeOf<
+      IBuilderFieldProps[]
+    >();
+    expectTypeOf<IBuilderProps['data']>().toEqualTypeOf<DenormalizedQuery>();
+    expectTypeOf<typeof formatQuery>().toBeFunction();
+    expectTypeOf<typeof parseQuery>().toBeFunction();
+  });
+
+  it('binds every documented adapter and Monaco entry to the local v2 target', () => {
+    expectTypeOf<AntdAdapterComponents>().toMatchTypeOf<IBuilderComponentsProps>();
+    expectTypeOf<BootstrapAdapterComponents>().toMatchTypeOf<IBuilderComponentsProps>();
+    expectTypeOf<FluentUiAdapterComponents>().toMatchTypeOf<IBuilderComponentsProps>();
+    expectTypeOf<MantineAdapterComponents>().toMatchTypeOf<IBuilderComponentsProps>();
+    expectTypeOf<MuiAdapterComponents>().toMatchTypeOf<IBuilderComponentsProps>();
+    expectTypeOf<RadixAdapterComponents>().toMatchTypeOf<IBuilderComponentsProps>();
+    expectTypeOf<MonacoFactory>().toBeFunction();
+  });
+});

--- a/example/src/v2/pages/api-page/api-page.tsx
+++ b/example/src/v2/pages/api-page/api-page.tsx
@@ -1,0 +1,64 @@
+import * as React from 'react';
+import styled from 'styled-components';
+import { useLocation } from 'react-router-dom';
+import { ContentArticle } from '../../../components/content-article';
+import { DocumentationSidebar } from '../../../components/documentation-sidebar';
+import { RelatedRecipes } from '../../../components/related-recipes';
+import { relatedRecipesByPath } from './constants/related-recipes-by-path';
+import { findSeoPage } from '../../../constants/seo-pages';
+import { usePageMetadata } from '../../../hooks/use-page-metadata';
+import { apiGroups } from './constants/api-groups';
+import { apiPages } from './constants/api-pages';
+import { findApiPage } from './utils/find-api-page.util';
+
+const Layout = styled.div`
+  display: grid;
+  grid-template-columns: 280px minmax(0, 1fr);
+  gap: 1.5rem;
+
+  @media (max-width: 1080px) {
+    grid-template-columns: 1fr;
+  }
+`;
+
+const SectionLabel = styled.span`
+  font-size: 0.8rem;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: #64748b;
+`;
+
+const Title = styled.h1`
+  margin: 0;
+  margin-bottom: 1rem;
+  font-size: clamp(2rem, 4vw, 3rem);
+`;
+
+const Summary = styled.p`
+  font-size: 1.05rem;
+  margin-top: 0.55rem;
+`;
+
+export const ApiPage: React.FC = () => {
+  const location = useLocation();
+  const page = findApiPage(location.pathname);
+  const seoPage = findSeoPage(page.path);
+  usePageMetadata(seoPage.title, seoPage.description, seoPage);
+
+  return (
+    <Layout>
+      <DocumentationSidebar
+        title="API"
+        overviewPage={apiPages[0]}
+        groups={apiGroups}
+      />
+      <ContentArticle>
+        <SectionLabel>{page.sectionTitle}</SectionLabel>
+        <Title>{page.title}</Title>
+        {page.summary ? <Summary>{page.summary}</Summary> : null}
+        {page.content}
+        <RelatedRecipes links={relatedRecipesByPath[page.path]} />
+      </ContentArticle>
+    </Layout>
+  );
+};

--- a/example/src/v2/pages/api-page/components/adapters-antd-api-content.tsx
+++ b/example/src/v2/pages/api-page/components/adapters-antd-api-content.tsx
@@ -1,0 +1,70 @@
+import * as React from 'react';
+import { AlertBox } from '../../../../components/alert-box';
+import { CodeBlock } from '../../../../components/code-block';
+import {
+  InlineCode,
+  ItemTitle,
+  List,
+  SectionTitle,
+  TextLink,
+} from '../../../../components/docs-primitives';
+import { antdAdapterSnippet } from '../constants/antd-adapter-snippet';
+import { antdV5Snippet } from '../constants/antd-v5-snippet';
+import { antdCreateComponentsSnippet } from '../constants/antd-create-components-snippet';
+
+export const AdaptersAntdApiContent: React.FC = () => (
+  <>
+    <CodeBlock
+      code={antdAdapterSnippet}
+      language="tsx"
+      label="ANTD v6 adapter usage"
+    />
+    <CodeBlock code={antdV5Snippet} language="tsx" label="ANTD v5 import" />
+    <CodeBlock
+      code={antdCreateComponentsSnippet}
+      language="tsx"
+      label="createAntdComponents"
+    />
+    <SectionTitle>Available entrypoints</SectionTitle>
+    <List>
+      <li>
+        <ItemTitle>
+          <InlineCode>@vojtechportes/react-query-builder/antd/v6</InlineCode>:
+        </ItemTitle>{' '}
+        Recommended Ant Design adapter for new projects.
+      </li>
+      <li>
+        <ItemTitle>
+          <InlineCode>@vojtechportes/react-query-builder/antd/v5</InlineCode>:
+        </ItemTitle>{' '}
+        Ant Design adapter for applications still on Ant Design 5.
+      </li>
+    </List>
+    <SectionTitle>Exports</SectionTitle>
+    <List>
+      <li>
+        <ItemTitle>
+          <InlineCode>components</InlineCode>:
+        </ItemTitle>{' '}
+        Ready-made Ant Design component mapping for{' '}
+        <InlineCode>Builder</InlineCode>.
+      </li>
+      <li>
+        <ItemTitle>Individual mapped components:</ItemTitle> Named exports such
+        as <InlineCode>AntdSelect</InlineCode>,{' '}
+        <InlineCode>AntdInput</InlineCode>, and related ANTD-backed controls for
+        partial overrides.
+      </li>
+      <li>
+        <ItemTitle>
+          <InlineCode>createAntdComponents</InlineCode>:
+        </ItemTitle>{' '}
+        Merges ANTD defaults with local overrides while preserving nested{' '}
+        <InlineCode>form</InlineCode> keys.
+      </li>
+    </List>
+    <AlertBox title="Documentation" variant="info">
+      <TextLink to="/documentation/adapters/antd">ANTD adapter guide</TextLink>.
+    </AlertBox>
+  </>
+);

--- a/example/src/v2/pages/api-page/components/adapters-api-content.tsx
+++ b/example/src/v2/pages/api-page/components/adapters-api-content.tsx
@@ -1,0 +1,109 @@
+import * as React from 'react';
+import { AlertBox } from '../../../../components/alert-box';
+import {
+  InlineCode,
+  ItemTitle,
+  List,
+  SectionTitle,
+  TextLink,
+} from '../../../../components/docs-primitives';
+
+export const AdaptersApiContent: React.FC = () => (
+  <>
+    <SectionTitle>Available adapter entrypoints</SectionTitle>
+    <List>
+      <li>
+        <ItemTitle>
+          <TextLink to="/api/adapters/mui">MUI</TextLink>:
+        </ItemTitle>{' '}
+        Covers <InlineCode>mui/v9</InlineCode>, legacy{' '}
+        <InlineCode>mui/v7</InlineCode>, and the MUI-specific merge helper.
+      </li>
+      <li>
+        <ItemTitle>
+          <TextLink to="/api/adapters/antd">ANTD</TextLink>:
+        </ItemTitle>{' '}
+        Covers <InlineCode>antd/v6</InlineCode>, legacy{' '}
+        <InlineCode>antd/v5</InlineCode>, and the ANTD-specific merge helper.
+      </li>
+      <li>
+        <ItemTitle>
+          <TextLink to="/api/adapters/fluentui">Fluent UI</TextLink>:
+        </ItemTitle>{' '}
+        Covers <InlineCode>fluentui/v8</InlineCode> and the Fluent-UI-specific
+        merge helper.
+      </li>
+      <li>
+        <ItemTitle>
+          <TextLink to="/api/adapters/mantine">Mantine</TextLink>:
+        </ItemTitle>{' '}
+        Covers <InlineCode>mantine/v9</InlineCode>, legacy{' '}
+        <InlineCode>mantine/v8</InlineCode>, and the Mantine-specific merge
+        helper.
+      </li>
+      <li>
+        <ItemTitle>
+          <TextLink to="/api/adapters/bootstrap">Bootstrap</TextLink>:
+        </ItemTitle>{' '}
+        Covers <InlineCode>bootstrap/v5</InlineCode> and the Bootstrap-specific
+        merge helper.
+      </li>
+      <li>
+        <ItemTitle>
+          <TextLink to="/api/adapters/radix">Radix</TextLink>:
+        </ItemTitle>{' '}
+        Covers <InlineCode>radix/v1</InlineCode>, Radix Themes provider setup,
+        and the Radix-specific merge helper.
+      </li>
+    </List>
+    <SectionTitle>What adapters export</SectionTitle>
+    <List>
+      <li>
+        <ItemTitle>
+          <InlineCode>components</InlineCode>:
+        </ItemTitle>{' '}
+        A ready-to-pass object that matches{' '}
+        <InlineCode>IBuilderComponentsProps</InlineCode>.
+      </li>
+      <li>
+        <ItemTitle>Individual mapped components:</ItemTitle> Named exports such
+        as <InlineCode>MuiSelect</InlineCode>,{' '}
+        <InlineCode>AntdSelect</InlineCode>,{' '}
+        <InlineCode>BootstrapSelect</InlineCode>,{' '}
+        <InlineCode>MantineSelect</InlineCode>,{' '}
+        <InlineCode>FluentUiSelect</InlineCode>, or{' '}
+        <InlineCode>RadixSelect</InlineCode> for partial customization.
+      </li>
+      <li>
+        <ItemTitle>Adapter merge helpers:</ItemTitle>{' '}
+        <InlineCode>createMuiComponents</InlineCode>,{' '}
+        <InlineCode>createAntdComponents</InlineCode>,{' '}
+        <InlineCode>createBootstrapComponents</InlineCode>,{' '}
+        <InlineCode>createMantineComponents</InlineCode>,{' '}
+        <InlineCode>createFluentUiComponents</InlineCode>, and{' '}
+        <InlineCode>createRadixComponents</InlineCode> merge adapter defaults
+        with local overrides while preserving the nested{' '}
+        <InlineCode>form</InlineCode> mapping.
+      </li>
+    </List>
+    <SectionTitle>Relationship to the Components API</SectionTitle>
+    <List>
+      <li>
+        Adapters are built on top of the same override surface documented in{' '}
+        <TextLink to="/api/components">Components</TextLink>.
+      </li>
+      <li>They are a convenience layer, not a separate rendering engine.</li>
+      <li>
+        Each <InlineCode>create*Components(base, overrides)</InlineCode> helper
+        returns a merged <InlineCode>IBuilderComponentsProps</InlineCode> object
+        and handles shallow top-level merging plus nested{' '}
+        <InlineCode>form</InlineCode> merging for you.
+      </li>
+    </List>
+    <AlertBox title="Documentation" variant="info">
+      <TextLink to="/documentation/adapters">Adapters</TextLink>,{' '}
+      <TextLink to="/documentation/components">Components</TextLink>, and{' '}
+      <TextLink to="/api/theming">Theming</TextLink>.
+    </AlertBox>
+  </>
+);

--- a/example/src/v2/pages/api-page/components/adapters-bootstrap-api-content.tsx
+++ b/example/src/v2/pages/api-page/components/adapters-bootstrap-api-content.tsx
@@ -1,0 +1,81 @@
+import * as React from 'react';
+import { AlertBox } from '../../../../components/alert-box';
+import { CodeBlock } from '../../../../components/code-block';
+import {
+  InlineCode,
+  ItemTitle,
+  List,
+  SectionTitle,
+  TextLink,
+} from '../../../../components/docs-primitives';
+import { bootstrapAdapterSnippet } from '../constants/bootstrap-adapter-snippet';
+import { bootstrapV5Snippet } from '../constants/bootstrap-v5-snippet';
+import { bootstrapCreateComponentsSnippet } from '../constants/bootstrap-create-components-snippet';
+
+export const AdaptersBootstrapApiContent: React.FC = () => (
+  <>
+    <CodeBlock
+      code={bootstrapAdapterSnippet}
+      language="tsx"
+      label="Bootstrap v5 adapter usage"
+    />
+    <CodeBlock
+      code={bootstrapV5Snippet}
+      language="tsx"
+      label="Bootstrap v5 import"
+    />
+    <CodeBlock
+      code={bootstrapCreateComponentsSnippet}
+      language="tsx"
+      label="createBootstrapComponents"
+    />
+    <SectionTitle>Available entrypoint</SectionTitle>
+    <List>
+      <li>
+        <ItemTitle>
+          <InlineCode>
+            @vojtechportes/react-query-builder/bootstrap/v5
+          </InlineCode>
+          :
+        </ItemTitle>{' '}
+        Bootstrap 5 adapter.
+      </li>
+    </List>
+    <SectionTitle>Exports</SectionTitle>
+    <List>
+      <li>
+        <ItemTitle>
+          <InlineCode>components</InlineCode>:
+        </ItemTitle>{' '}
+        Ready-made Bootstrap component mapping for{' '}
+        <InlineCode>Builder</InlineCode>.
+      </li>
+      <li>
+        <ItemTitle>Individual mapped components:</ItemTitle> Named exports such
+        as <InlineCode>BootstrapSelect</InlineCode>,{' '}
+        <InlineCode>BootstrapInput</InlineCode>, and related Bootstrap-backed
+        controls for partial overrides.
+      </li>
+      <li>
+        <ItemTitle>
+          <InlineCode>createBootstrapComponents</InlineCode>:
+        </ItemTitle>{' '}
+        Merges Bootstrap defaults with local overrides while preserving nested{' '}
+        <InlineCode>form</InlineCode> keys.
+      </li>
+      <li>
+        <ItemTitle>Stylesheet requirement:</ItemTitle> Import{' '}
+        <InlineCode>bootstrap/dist/css/bootstrap.min.css</InlineCode> and{' '}
+        <InlineCode>bootstrap-icons/font/bootstrap-icons.css</InlineCode> before
+        rendering the adapter so the Bootstrap classes and official icon set
+        resolve to actual styles.
+      </li>
+    </List>
+    <AlertBox title="Documentation" variant="info">
+      <TextLink to="/documentation/adapters/bootstrap">
+        Bootstrap adapter guide
+      </TextLink>
+      .
+    </AlertBox>
+  </>
+);

--- a/example/src/v2/pages/api-page/components/adapters-fluentui-api-content.tsx
+++ b/example/src/v2/pages/api-page/components/adapters-fluentui-api-content.tsx
@@ -1,0 +1,74 @@
+import * as React from 'react';
+import { AlertBox } from '../../../../components/alert-box';
+import { CodeBlock } from '../../../../components/code-block';
+import {
+  InlineCode,
+  ItemTitle,
+  List,
+  SectionTitle,
+  TextLink,
+} from '../../../../components/docs-primitives';
+import { fluentUiAdapterSnippet } from '../constants/fluent-ui-adapter-snippet';
+import { fluentUiV8Snippet } from '../constants/fluent-ui-v8-snippet';
+import { fluentUiCreateComponentsSnippet } from '../constants/fluent-ui-create-components-snippet';
+
+export const AdaptersFluentuiApiContent: React.FC = () => (
+  <>
+    <CodeBlock
+      code={fluentUiAdapterSnippet}
+      language="tsx"
+      label="Fluent UI v8 adapter usage"
+    />
+    <CodeBlock
+      code={fluentUiV8Snippet}
+      language="tsx"
+      label="Fluent UI v8 import"
+    />
+    <CodeBlock
+      code={fluentUiCreateComponentsSnippet}
+      language="tsx"
+      label="createFluentUiComponents"
+    />
+    <SectionTitle>Available entrypoint</SectionTitle>
+    <List>
+      <li>
+        <ItemTitle>
+          <InlineCode>
+            @vojtechportes/react-query-builder/fluentui/v8
+          </InlineCode>
+          :
+        </ItemTitle>{' '}
+        Fluent UI React 8 adapter.
+      </li>
+    </List>
+    <SectionTitle>Exports</SectionTitle>
+    <List>
+      <li>
+        <ItemTitle>
+          <InlineCode>components</InlineCode>:
+        </ItemTitle>{' '}
+        Ready-made Fluent UI component mapping for{' '}
+        <InlineCode>Builder</InlineCode>.
+      </li>
+      <li>
+        <ItemTitle>Individual mapped components:</ItemTitle> Named exports such
+        as <InlineCode>FluentUiSelect</InlineCode>,{' '}
+        <InlineCode>FluentUiInput</InlineCode>, and related Fluent-backed
+        controls for partial overrides.
+      </li>
+      <li>
+        <ItemTitle>
+          <InlineCode>createFluentUiComponents</InlineCode>:
+        </ItemTitle>{' '}
+        Merges Fluent UI defaults with local overrides while preserving nested{' '}
+        <InlineCode>form</InlineCode> keys.
+      </li>
+    </List>
+    <AlertBox title="Documentation" variant="info">
+      <TextLink to="/documentation/adapters/fluentui">
+        Fluent UI adapter guide
+      </TextLink>
+      .
+    </AlertBox>
+  </>
+);

--- a/example/src/v2/pages/api-page/components/adapters-mantine-api-content.tsx
+++ b/example/src/v2/pages/api-page/components/adapters-mantine-api-content.tsx
@@ -1,0 +1,93 @@
+import * as React from 'react';
+import { AlertBox } from '../../../../components/alert-box';
+import { CodeBlock } from '../../../../components/code-block';
+import {
+  InlineCode,
+  ItemTitle,
+  List,
+  SectionTitle,
+  TextLink,
+} from '../../../../components/docs-primitives';
+import { mantineAdapterSnippet } from '../constants/mantine-adapter-snippet';
+import { mantineV8Snippet } from '../constants/mantine-v8-snippet';
+import { mantineCreateComponentsSnippet } from '../constants/mantine-create-components-snippet';
+
+export const AdaptersMantineApiContent: React.FC = () => (
+  <>
+    <CodeBlock
+      code={mantineAdapterSnippet}
+      language="tsx"
+      label="Mantine v9 adapter usage"
+    />
+    <CodeBlock
+      code={mantineV8Snippet}
+      language="tsx"
+      label="Mantine v8 import"
+    />
+    <CodeBlock
+      code={mantineCreateComponentsSnippet}
+      language="tsx"
+      label="createMantineComponents"
+    />
+    <SectionTitle>Available entrypoints</SectionTitle>
+    <List>
+      <li>
+        <ItemTitle>
+          <InlineCode>@vojtechportes/react-query-builder/mantine/v9</InlineCode>
+          :
+        </ItemTitle>{' '}
+        Recommended Mantine adapter for new projects on Mantine 9.
+      </li>
+      <li>
+        <ItemTitle>
+          <InlineCode>@vojtechportes/react-query-builder/mantine/v8</InlineCode>
+          :
+        </ItemTitle>{' '}
+        Mantine adapter for applications still on Mantine 8.
+      </li>
+    </List>
+    <SectionTitle>Exports</SectionTitle>
+    <List>
+      <li>
+        <ItemTitle>
+          <InlineCode>components</InlineCode>:
+        </ItemTitle>{' '}
+        Ready-made Mantine component mapping for{' '}
+        <InlineCode>Builder</InlineCode>.
+      </li>
+      <li>
+        <ItemTitle>Individual mapped components:</ItemTitle> Named exports such
+        as <InlineCode>MantineSelect</InlineCode>,{' '}
+        <InlineCode>MantineInput</InlineCode>, and related Mantine-backed
+        controls for partial overrides.
+      </li>
+      <li>
+        <ItemTitle>
+          <InlineCode>createMantineComponents</InlineCode>:
+        </ItemTitle>{' '}
+        Merges Mantine defaults with local overrides while preserving nested{' '}
+        <InlineCode>form</InlineCode> keys.
+      </li>
+      <li>
+        <ItemTitle>
+          <InlineCode>MantineProvider</InlineCode>:
+        </ItemTitle>{' '}
+        Mantine-backed builders should be rendered within Mantine's provider so
+        the host app theme and styles are available.
+      </li>
+      <li>
+        <ItemTitle>
+          <InlineCode>@mantine/core/styles.css</InlineCode>:
+        </ItemTitle>{' '}
+        Import Mantine's base stylesheet once in your application entrypoint so
+        Mantine controls render correctly.
+      </li>
+    </List>
+    <AlertBox title="Documentation" variant="info">
+      <TextLink to="/documentation/adapters/mantine">
+        Mantine adapter guide
+      </TextLink>
+      .
+    </AlertBox>
+  </>
+);

--- a/example/src/v2/pages/api-page/components/adapters-mui-api-content.tsx
+++ b/example/src/v2/pages/api-page/components/adapters-mui-api-content.tsx
@@ -1,0 +1,68 @@
+import * as React from 'react';
+import { AlertBox } from '../../../../components/alert-box';
+import { CodeBlock } from '../../../../components/code-block';
+import {
+  InlineCode,
+  ItemTitle,
+  List,
+  SectionTitle,
+  TextLink,
+} from '../../../../components/docs-primitives';
+import { muiAdapterSnippet } from '../constants/mui-adapter-snippet';
+import { muiV7Snippet } from '../constants/mui-v7-snippet';
+import { muiCreateComponentsSnippet } from '../constants/mui-create-components-snippet';
+
+export const AdaptersMuiApiContent: React.FC = () => (
+  <>
+    <CodeBlock
+      code={muiAdapterSnippet}
+      language="tsx"
+      label="MUI v9 adapter usage"
+    />
+    <CodeBlock code={muiV7Snippet} language="tsx" label="MUI v7 import" />
+    <CodeBlock
+      code={muiCreateComponentsSnippet}
+      language="tsx"
+      label="createMuiComponents"
+    />
+    <SectionTitle>Available entrypoints</SectionTitle>
+    <List>
+      <li>
+        <ItemTitle>
+          <InlineCode>@vojtechportes/react-query-builder/mui/v9</InlineCode>:
+        </ItemTitle>{' '}
+        Recommended Material UI adapter for new projects.
+      </li>
+      <li>
+        <ItemTitle>
+          <InlineCode>@vojtechportes/react-query-builder/mui/v7</InlineCode>:
+        </ItemTitle>{' '}
+        Material UI adapter for applications still on MUI 7.
+      </li>
+    </List>
+    <SectionTitle>Exports</SectionTitle>
+    <List>
+      <li>
+        <ItemTitle>
+          <InlineCode>components</InlineCode>:
+        </ItemTitle>{' '}
+        Ready-made MUI component mapping for <InlineCode>Builder</InlineCode>.
+      </li>
+      <li>
+        <ItemTitle>Individual mapped components:</ItemTitle> Named exports such
+        as <InlineCode>MuiSelect</InlineCode>, <InlineCode>MuiInput</InlineCode>
+        , and related MUI-backed controls for partial overrides.
+      </li>
+      <li>
+        <ItemTitle>
+          <InlineCode>createMuiComponents</InlineCode>:
+        </ItemTitle>{' '}
+        Merges MUI defaults with local overrides while preserving nested{' '}
+        <InlineCode>form</InlineCode> keys.
+      </li>
+    </List>
+    <AlertBox title="Documentation" variant="info">
+      <TextLink to="/documentation/adapters/mui">MUI adapter guide</TextLink>.
+    </AlertBox>
+  </>
+);

--- a/example/src/v2/pages/api-page/components/adapters-radix-api-content.tsx
+++ b/example/src/v2/pages/api-page/components/adapters-radix-api-content.tsx
@@ -1,0 +1,82 @@
+import * as React from 'react';
+import { AlertBox } from '../../../../components/alert-box';
+import { CodeBlock } from '../../../../components/code-block';
+import {
+  InlineCode,
+  ItemTitle,
+  List,
+  SectionTitle,
+  TextLink,
+} from '../../../../components/docs-primitives';
+import { radixAdapterSnippet } from '../constants/radix-adapter-snippet';
+import { radixV1Snippet } from '../constants/radix-v1-snippet';
+import { radixCreateComponentsSnippet } from '../constants/radix-create-components-snippet';
+
+export const AdaptersRadixApiContent: React.FC = () => (
+  <>
+    <CodeBlock
+      code={radixAdapterSnippet}
+      language="tsx"
+      label="Radix v1 adapter usage"
+    />
+    <CodeBlock code={radixV1Snippet} language="tsx" label="Radix v1 import" />
+    <CodeBlock
+      code={radixCreateComponentsSnippet}
+      language="tsx"
+      label="createRadixComponents"
+    />
+    <SectionTitle>Available entrypoint</SectionTitle>
+    <List>
+      <li>
+        <ItemTitle>
+          <InlineCode>@vojtechportes/react-query-builder/radix/v1</InlineCode>:
+        </ItemTitle>{' '}
+        Radix Themes adapter for applications on{' '}
+        <InlineCode>@radix-ui/themes</InlineCode> 1.x.
+      </li>
+    </List>
+    <SectionTitle>Exports</SectionTitle>
+    <List>
+      <li>
+        <ItemTitle>
+          <InlineCode>components</InlineCode>:
+        </ItemTitle>{' '}
+        Ready-made Radix Themes component mapping for{' '}
+        <InlineCode>Builder</InlineCode>.
+      </li>
+      <li>
+        <ItemTitle>Individual mapped components:</ItemTitle> Named exports such
+        as <InlineCode>RadixSelect</InlineCode>,{' '}
+        <InlineCode>RadixInput</InlineCode>, and related Radix-backed controls
+        for partial overrides.
+      </li>
+      <li>
+        <ItemTitle>
+          <InlineCode>createRadixComponents</InlineCode>:
+        </ItemTitle>{' '}
+        Merges Radix defaults with local overrides while preserving nested{' '}
+        <InlineCode>form</InlineCode> keys.
+      </li>
+      <li>
+        <ItemTitle>
+          <InlineCode>Theme</InlineCode>:
+        </ItemTitle>{' '}
+        Radix-backed builders should be rendered within Radix Themes' provider
+        so the host app theme and tokens are available.
+      </li>
+      <li>
+        <ItemTitle>
+          <InlineCode>@radix-ui/themes/styles.css</InlineCode>:
+        </ItemTitle>{' '}
+        Import the Radix Themes stylesheet once in your application entrypoint
+        so the adapter controls render correctly.
+      </li>
+    </List>
+    <AlertBox title="Documentation" variant="info">
+      <TextLink to="/documentation/adapters/radix">
+        Radix adapter guide
+      </TextLink>
+      .
+    </AlertBox>
+  </>
+);

--- a/example/src/v2/pages/api-page/components/builder-api-content.tsx
+++ b/example/src/v2/pages/api-page/components/builder-api-content.tsx
@@ -1,0 +1,31 @@
+import * as React from 'react';
+import { AlertBox } from '../../../../components/alert-box';
+import { CodeBlock } from '../../../../components/code-block';
+import { TextLink } from '../../../../components/docs-primitives';
+import { builderSignature } from '../constants/builder-signature';
+import { historyConfigSignature } from '../constants/history-config-signature';
+import { BuilderPropsApiSection } from './builder-props-api-section';
+import { BuilderFieldComparisonsApiSection } from './builder-field-comparisons-api-section';
+import { BuilderTextModeApiSection } from './builder-text-mode-api-section';
+import { BuilderHistoryApiSection } from './builder-history-api-section';
+
+export const BuilderApiContent: React.FC = () => (
+  <>
+    <CodeBlock code={builderSignature} language="ts" label="IBuilderProps" />
+    <CodeBlock
+      code={historyConfigSignature}
+      language="ts"
+      label="IBuilderHistoryConfig"
+    />
+    <BuilderPropsApiSection />
+    <BuilderFieldComparisonsApiSection />
+    <BuilderTextModeApiSection />
+    <BuilderHistoryApiSection />
+    <AlertBox title="Documentation" variant="info">
+      <TextLink to="/documentation/usage">Usage</TextLink> and{' '}
+      <TextLink to="/documentation/text-mode">Text Mode</TextLink>, and{' '}
+      <TextLink to="/documentation/history">Undo and Redo</TextLink>, and{' '}
+      <TextLink to="/documentation/builder-ref">Builder Ref</TextLink>.
+    </AlertBox>
+  </>
+);

--- a/example/src/v2/pages/api-page/components/builder-behavior-props-api-items.tsx
+++ b/example/src/v2/pages/api-page/components/builder-behavior-props-api-items.tsx
@@ -1,0 +1,117 @@
+import * as React from 'react';
+import { InlineCode, ItemTitle } from '../../../../components/docs-primitives';
+
+export const BuilderBehaviorPropsApiItems: React.FC = () => (
+  <>
+    <li>
+      <ItemTitle>
+        <InlineCode>allowGroupNegation</InlineCode>:
+      </ItemTitle>{' '}
+      Defaults to <InlineCode>true</InlineCode>. When set to{' '}
+      <InlineCode>false</InlineCode>, group negation is disabled across the
+      builder: the group-level <InlineCode>NOT</InlineCode> control is hidden,
+      emitted groups are normalized to non-negated form, and SQL text mode
+      rejects group-level <InlineCode>NOT (...)</InlineCode> expressions.
+      Operator-level negation such as <InlineCode>NOT IN</InlineCode>,{' '}
+      <InlineCode>NOT LIKE</InlineCode>, <InlineCode>IS NOT NULL</InlineCode>,
+      and <InlineCode>NOT BETWEEN</InlineCode> remains supported.
+    </li>
+    <li>
+      <ItemTitle>
+        <InlineCode>allowFieldComparisons</InlineCode>:
+      </ItemTitle>{' '}
+      Defaults to <InlineCode>false</InlineCode>. Enables the built-in
+      value-source toggle so supported rules can compare one field against
+      another through <InlineCode>valueSource: 'field'</InlineCode> and{' '}
+      <InlineCode>valueField</InlineCode>.
+    </li>
+    <li>
+      <ItemTitle>
+        <InlineCode>singleRootGroup</InlineCode>:
+      </ItemTitle>{' '}
+      Defaults to <InlineCode>true</InlineCode>. Wraps root-level items into a
+      single root group and prevents deleting that root group. Text mode
+      requires this to stay enabled.
+    </li>
+    <li>
+      <ItemTitle>
+        <InlineCode>groupTypes</InlineCode>:
+      </ItemTitle>{' '}
+      Defaults to <InlineCode>'with-modifiers'</InlineCode>. Controls whether
+      groups use combinator/negation controls, modifierless groups, or both.
+      When text mode is active, builder-compatible SQL round-tripping uses
+      groups with modifiers.
+    </li>
+    <li>
+      <ItemTitle>
+        <InlineCode>newNodePlacement</InlineCode>:
+      </ItemTitle>{' '}
+      Defaults to <InlineCode>'append'</InlineCode>. Controls whether newly
+      added rules and groups are inserted at the end or the beginning of their
+      parent when built-in add actions or imperative add methods omit an
+      explicit index.
+    </li>
+    <li>
+      <ItemTitle>
+        <InlineCode>validator</InlineCode>:
+      </ItemTitle>{' '}
+      Optional function that receives the denormalized query plus validation
+      context and returns a validation result synchronously or asynchronously.
+    </li>
+    <li>
+      <ItemTitle>
+        <InlineCode>onStateChange</InlineCode>:
+      </ItemTitle>{' '}
+      Optional callback fired with <InlineCode>data</InlineCode>,{' '}
+      <InlineCode>isValid</InlineCode>, the full validation object, and history
+      state flags such as <InlineCode>canUndo</InlineCode> and{' '}
+      <InlineCode>canRedo</InlineCode>.
+    </li>
+    <li>
+      <ItemTitle>
+        <InlineCode>onFieldOptionsReload</InlineCode>:
+      </ItemTitle>{' '}
+      Optional callback fired by{' '}
+      <InlineCode>reloadFieldOptions(field)</InlineCode> for shared field-level
+      runtime options.
+    </li>
+    <li>
+      <ItemTitle>
+        <InlineCode>onRuleOptionsReload</InlineCode>:
+      </ItemTitle>{' '}
+      Optional callback fired by{' '}
+      <InlineCode>reloadRuleOptions(ruleId)</InlineCode> for dependency-aware
+      rule-level runtime options.
+    </li>
+    <li>
+      <ItemTitle>
+        <InlineCode>onFieldChange</InlineCode>:
+      </ItemTitle>{' '}
+      Optional callback fired with node id, field name, previous value, next
+      value, and denormalized data after a rule field or value changes.
+    </li>
+    <li>
+      <ItemTitle>
+        <InlineCode>showValidation</InlineCode>:
+      </ItemTitle>{' '}
+      Defaults to <InlineCode>false</InlineCode>. Controls whether validation
+      issues are rendered in the built-in UI.
+    </li>
+    <li>
+      <ItemTitle>
+        <InlineCode>history</InlineCode>:
+      </ItemTitle>{' '}
+      Optional. Set to <InlineCode>true</InlineCode> to enable undo and redo
+      with default settings, or pass{' '}
+      <InlineCode>IBuilderHistoryConfig</InlineCode> to customize retention and
+      built-in controls.
+    </li>
+    <li>
+      <ItemTitle>
+        <InlineCode>onChange</InlineCode>:
+      </ItemTitle>{' '}
+      Optional callback fired with the denormalized query tree after changes are
+      emitted.
+    </li>
+  </>
+);

--- a/example/src/v2/pages/api-page/components/builder-core-props-api-items.tsx
+++ b/example/src/v2/pages/api-page/components/builder-core-props-api-items.tsx
@@ -1,0 +1,95 @@
+import * as React from 'react';
+import { InlineCode, ItemTitle } from '../../../../components/docs-primitives';
+
+export const BuilderCorePropsApiItems: React.FC = () => (
+  <>
+    <li>
+      <ItemTitle>
+        <InlineCode>fields</InlineCode>:
+      </ItemTitle>{' '}
+      Required. Defines the available fields, their types, allowed operators,
+      and optional validation metadata.
+    </li>
+    <li>
+      <ItemTitle>
+        <InlineCode>data</InlineCode>:
+      </ItemTitle>{' '}
+      Required. The current denormalized query tree. The builder treats this as
+      controlled input.
+    </li>
+    <li>
+      <ItemTitle>Ref support:</ItemTitle> <InlineCode>Builder</InlineCode>{' '}
+      supports React refs and can be paired with{' '}
+      <InlineCode>useBuilderRef()</InlineCode> for imperative access.
+    </li>
+    <li>
+      <ItemTitle>
+        <InlineCode>components</InlineCode>:
+      </ItemTitle>{' '}
+      Optional overrides for internal UI pieces. Omitted entries fall back to
+      default components.
+    </li>
+    <li>
+      <ItemTitle>
+        <InlineCode>strings</InlineCode>:
+      </ItemTitle>{' '}
+      Optional localized UI strings used by the built-in controls.
+    </li>
+    <li>
+      <ItemTitle>
+        <InlineCode>textMode</InlineCode>:
+      </ItemTitle>{' '}
+      Optional. Enables SQL text mode. Pass <InlineCode>true</InlineCode> for
+      the default configuration or{' '}
+      <InlineCode>IBuilderTextModeConfig</InlineCode> for explicit SQL text-mode
+      settings.
+    </li>
+    <li>
+      <ItemTitle>
+        <InlineCode>defaultMode</InlineCode>:
+      </ItemTitle>{' '}
+      Optional. Controls whether the builder initially opens in{' '}
+      <InlineCode>'builder'</InlineCode> or <InlineCode>'text'</InlineCode>{' '}
+      mode. This only takes effect when text mode is enabled.
+    </li>
+    <li>
+      <ItemTitle>
+        <InlineCode>readOnly</InlineCode>:
+      </ItemTitle>{' '}
+      Defaults to <InlineCode>false</InlineCode>. Makes the whole builder
+      non-editable.
+    </li>
+    <li>
+      <ItemTitle>
+        <InlineCode>readOnlyProtectsDelete</InlineCode>:
+      </ItemTitle>{' '}
+      Defaults to <InlineCode>true</InlineCode>. When enabled, groups cannot be
+      deleted if that would indirectly remove read-only protected descendants.
+      Set it to <InlineCode>false</InlineCode> to allow those parent-group
+      deletes while keeping direct read-only node restrictions.
+    </li>
+    <li>
+      <ItemTitle>
+        <InlineCode>lockable</InlineCode>:
+      </ItemTitle>{' '}
+      Defaults to <InlineCode>false</InlineCode>. Renders lock controls for
+      rules and groups and writes the resulting lock state back into emitted
+      query data without discarding existing targeted{' '}
+      <InlineCode>readOnly.targets</InlineCode> configurations.
+    </li>
+    <li>
+      <ItemTitle>
+        <InlineCode>cloneable</InlineCode>:
+      </ItemTitle>{' '}
+      Defaults to <InlineCode>false</InlineCode>. Renders clone controls for
+      rules and groups and inserts the cloned node directly below the original.
+    </li>
+    <li>
+      <ItemTitle>
+        <InlineCode>draggable</InlineCode>:
+      </ItemTitle>{' '}
+      Defaults to <InlineCode>false</InlineCode>. Enables drag-and-drop
+      reordering and movement of query nodes.
+    </li>
+  </>
+);

--- a/example/src/v2/pages/api-page/components/builder-field-comparisons-api-section.tsx
+++ b/example/src/v2/pages/api-page/components/builder-field-comparisons-api-section.tsx
@@ -1,0 +1,33 @@
+import * as React from 'react';
+import { CodeBlock } from '../../../../components/code-block';
+import {
+  InlineCode,
+  ItemTitle,
+  List,
+  SectionTitle,
+} from '../../../../components/docs-primitives';
+import { builderFieldComparisonSnippet } from '../constants/builder-field-comparison-snippet';
+
+export const BuilderFieldComparisonsApiSection: React.FC = () => (
+  <>
+    <SectionTitle>Field comparisons</SectionTitle>
+    <CodeBlock
+      code={builderFieldComparisonSnippet}
+      language="tsx"
+      label="Builder field comparison setup"
+    />
+    <List>
+      <li>
+        <ItemTitle>Opt-in:</ItemTitle> The default UI exposes field-to-field
+        comparisons only when <InlineCode>allowFieldComparisons</InlineCode> is
+        enabled.
+      </li>
+      <li>
+        <ItemTitle>Persisted data:</ItemTitle> Preloaded field-comparison rules
+        stay representable through <InlineCode>valueSource</InlineCode> and{' '}
+        <InlineCode>valueField</InlineCode>, even though validation will block
+        them when the prop is disabled.
+      </li>
+    </List>
+  </>
+);

--- a/example/src/v2/pages/api-page/components/builder-history-api-section.tsx
+++ b/example/src/v2/pages/api-page/components/builder-history-api-section.tsx
@@ -1,0 +1,28 @@
+import * as React from 'react';
+import {
+  InlineCode,
+  ItemTitle,
+  List,
+  SectionTitle,
+} from '../../../../components/docs-primitives';
+
+export const BuilderHistoryApiSection: React.FC = () => (
+  <>
+    <SectionTitle>History config</SectionTitle>
+    <List>
+      <li>
+        <ItemTitle>
+          <InlineCode>maxEntries</InlineCode>:
+        </ItemTitle>{' '}
+        Optional limit for how many undo steps are retained.
+      </li>
+      <li>
+        <ItemTitle>
+          <InlineCode>controls</InlineCode>:
+        </ItemTitle>{' '}
+        Optional toggle for rendering the built-in Undo and Redo buttons inside
+        the builder UI.
+      </li>
+    </List>
+  </>
+);

--- a/example/src/v2/pages/api-page/components/builder-props-api-section.tsx
+++ b/example/src/v2/pages/api-page/components/builder-props-api-section.tsx
@@ -1,0 +1,14 @@
+import * as React from 'react';
+import { List, SectionTitle } from '../../../../components/docs-primitives';
+import { BuilderCorePropsApiItems } from './builder-core-props-api-items';
+import { BuilderBehaviorPropsApiItems } from './builder-behavior-props-api-items';
+
+export const BuilderPropsApiSection: React.FC = () => (
+  <>
+    <SectionTitle>Props</SectionTitle>
+    <List>
+      <BuilderCorePropsApiItems />
+      <BuilderBehaviorPropsApiItems />
+    </List>
+  </>
+);

--- a/example/src/v2/pages/api-page/components/builder-ref-api-content.tsx
+++ b/example/src/v2/pages/api-page/components/builder-ref-api-content.tsx
@@ -1,0 +1,47 @@
+import * as React from 'react';
+import { AlertBox } from '../../../../components/alert-box';
+import { CodeBlock } from '../../../../components/code-block';
+import { TextLink } from '../../../../components/docs-primitives';
+import { builderRefSignature } from '../constants/builder-ref-signature';
+import { builderRuleDependenciesHookSignature } from '../constants/builder-rule-dependencies-hook-signature';
+import { builderRuleOptionsBindingSignature } from '../constants/builder-rule-options-binding-signature';
+import { BuilderRefAttachmentApiSection } from './builder-ref-attachment-api-section';
+import { BuilderRefReadMethodsApiSection } from './builder-ref-read-methods-api-section';
+import { BuilderRefMutationMethodsApiSection } from './builder-ref-mutation-methods-api-section';
+import { BuilderRefFieldOptionMethodsApiSection } from './builder-ref-field-option-methods-api-section';
+import { BuilderRefRuleOptionMethodsApiSection } from './builder-ref-rule-option-methods-api-section';
+import { BuilderRefLockHistoryMethodsApiSection } from './builder-ref-lock-history-methods-api-section';
+
+export const BuilderRefApiContent: React.FC = () => (
+  <>
+    <CodeBlock
+      code={builderRefSignature}
+      language="ts"
+      label="Builder ref API"
+    />
+    <CodeBlock
+      code={builderRuleDependenciesHookSignature}
+      language="ts"
+      label="Rule dependencies hook"
+    />
+    <CodeBlock
+      code={builderRuleOptionsBindingSignature}
+      language="ts"
+      label="Rule options binding"
+    />
+    <BuilderRefAttachmentApiSection />
+    <BuilderRefReadMethodsApiSection />
+    <BuilderRefMutationMethodsApiSection />
+    <BuilderRefFieldOptionMethodsApiSection />
+    <BuilderRefRuleOptionMethodsApiSection />
+    <BuilderRefLockHistoryMethodsApiSection />
+    <AlertBox title="Documentation" variant="info">
+      <TextLink to="/documentation/builder-ref">Builder Ref</TextLink>,{' '}
+      <TextLink to="/documentation/dynamic-field-options">
+        Dynamic Field Options
+      </TextLink>
+      , <TextLink to="/documentation/history">Undo and Redo</TextLink>, and{' '}
+      <TextLink to="/api/builder">Builder</TextLink>.
+    </AlertBox>
+  </>
+);

--- a/example/src/v2/pages/api-page/components/builder-ref-attachment-api-section.tsx
+++ b/example/src/v2/pages/api-page/components/builder-ref-attachment-api-section.tsx
@@ -1,0 +1,92 @@
+import * as React from 'react';
+import { AlertBox } from '../../../../components/alert-box';
+import {
+  InlineCode,
+  ItemTitle,
+  List,
+  SectionTitle,
+} from '../../../../components/docs-primitives';
+
+export const BuilderRefAttachmentApiSection: React.FC = () => (
+  <>
+    <SectionTitle>How to attach it</SectionTitle>
+    <List>
+      <li>
+        <ItemTitle>
+          <InlineCode>useBuilderRef()</InlineCode>:
+        </ItemTitle>{' '}
+        Returns a typed React ref controller for the builder instance.
+      </li>
+      <li>
+        <ItemTitle>
+          <InlineCode>
+            useBuilderRuleDependencies(builderRef, field, dependencyFields)
+          </InlineCode>
+          :
+        </ItemTitle>{' '}
+        Returns one dependency snapshot per matching rule and is the recommended
+        React-first integration for React Query or similar hook-based data
+        layers.
+      </li>
+      <li>
+        <ItemTitle>
+          <InlineCode>{'<Builder ref={builderRef} />'}</InlineCode>:
+        </ItemTitle>{' '}
+        Attaches the ref to the builder so{' '}
+        <InlineCode>builderRef.current</InlineCode> exposes the imperative
+        methods.
+      </li>
+      <li>
+        <ItemTitle>
+          <InlineCode>builderRef.subscribe(listener)</InlineCode>:
+        </ItemTitle>{' '}
+        Subscribes to builder handle updates. The listener fires immediately
+        with the current handle and then again whenever committed builder state
+        replaces that handle.
+      </li>
+      <li>
+        <ItemTitle>
+          <InlineCode>builderRef.bindRuleOptions(field, config)</InlineCode>:
+        </ItemTitle>{' '}
+        Automatically hydrates and refreshes rule-scoped options for
+        dependency-aware fields. This is the recommended entrypoint when you do
+        not need an external query library to own the orchestration, and{' '}
+        <InlineCode>onOptionsResolved</InlineCode> is the clean place for
+        follow-up work such as explicit value reconciliation.
+      </li>
+      <li>
+        <ItemTitle>
+          <InlineCode>
+            builderRef.subscribeToRuleDependencies(field, dependencyFields,
+            listener)
+          </InlineCode>
+          :
+        </ItemTitle>{' '}
+        Subscribes to dependency snapshots for one field. The listener receives
+        one entry per matching rule and only re-runs when that rule&apos;s
+        dependency context changes.
+      </li>
+      <li>
+        <ItemTitle>
+          <InlineCode>
+            builderRef.subscribeToFieldOptionState(field, listener)
+          </InlineCode>{' '}
+          and{' '}
+          <InlineCode>
+            builderRef.subscribeToRuleOptionState(ruleId, listener)
+          </InlineCode>
+          :
+        </ItemTitle>{' '}
+        Subscribe to reactive loading and option snapshots for external UI such
+        as badges, spinners, or helper text.
+      </li>
+    </List>
+    <AlertBox title="Reactive option state" variant="info">
+      <InlineCode>getFieldOptionState()</InlineCode> and{' '}
+      <InlineCode>getRuleOptionState()</InlineCode> return snapshots. Use{' '}
+      <InlineCode>subscribeToFieldOptionState()</InlineCode> or{' '}
+      <InlineCode>subscribeToRuleOptionState()</InlineCode> when surrounding
+      React UI should rerender as the state changes.
+    </AlertBox>
+  </>
+);

--- a/example/src/v2/pages/api-page/components/builder-ref-field-option-methods-api-section.tsx
+++ b/example/src/v2/pages/api-page/components/builder-ref-field-option-methods-api-section.tsx
@@ -1,0 +1,51 @@
+import * as React from 'react';
+import {
+  InlineCode,
+  ItemTitle,
+  List,
+  SectionTitle,
+} from '../../../../components/docs-primitives';
+
+export const BuilderRefFieldOptionMethodsApiSection: React.FC = () => (
+  <>
+    <SectionTitle>Field Option Methods</SectionTitle>
+    <List>
+      <li>
+        <ItemTitle>
+          <InlineCode>setFieldOptions(field, options)</InlineCode>:
+        </ItemTitle>{' '}
+        Replaces the shared runtime option set for a field without changing the
+        original <InlineCode>fields</InlineCode> prop.
+      </li>
+      <li>
+        <ItemTitle>
+          <InlineCode>setFieldOptionsStatus(field, status)</InlineCode>:
+        </ItemTitle>{' '}
+        Stores a shared option loading state of <InlineCode>'idle'</InlineCode>,{' '}
+        <InlineCode>'loading'</InlineCode>, <InlineCode>'success'</InlineCode>,
+        or <InlineCode>'error'</InlineCode>.
+      </li>
+      <li>
+        <ItemTitle>
+          <InlineCode>invalidateFieldOptions(field)</InlineCode>:
+        </ItemTitle>{' '}
+        Clears the shared runtime cache and falls back to the static options
+        defined in <InlineCode>field.value</InlineCode>.
+      </li>
+      <li>
+        <ItemTitle>
+          <InlineCode>reloadFieldOptions(field)</InlineCode>:
+        </ItemTitle>{' '}
+        Invalidates the shared runtime cache and then calls{' '}
+        <InlineCode>onFieldOptionsReload(field)</InlineCode> so the surrounding
+        app can trigger a refetch.
+      </li>
+      <li>
+        <ItemTitle>
+          <InlineCode>clearFieldOptions(field)</InlineCode>:
+        </ItemTitle>{' '}
+        Removes the shared runtime option state entirely.
+      </li>
+    </List>
+  </>
+);

--- a/example/src/v2/pages/api-page/components/builder-ref-lock-history-methods-api-section.tsx
+++ b/example/src/v2/pages/api-page/components/builder-ref-lock-history-methods-api-section.tsx
@@ -1,0 +1,50 @@
+import * as React from 'react';
+import {
+  InlineCode,
+  ItemTitle,
+  List,
+  SectionTitle,
+} from '../../../../components/docs-primitives';
+
+export const BuilderRefLockHistoryMethodsApiSection: React.FC = () => (
+  <>
+    <SectionTitle>Lock and history methods</SectionTitle>
+    <List>
+      <li>
+        <ItemTitle>
+          <InlineCode>setNodeLock(nodeId, state)</InlineCode>:
+        </ItemTitle>{' '}
+        Sets the explicit lock state for a rule or group. Groups additionally
+        support <InlineCode>'all'</InlineCode> for descendant inheritance.
+      </li>
+      <li>
+        <ItemTitle>
+          <InlineCode>lockNode(nodeId, state?)</InlineCode>:
+        </ItemTitle>{' '}
+        Convenience wrapper for locking a node. For rules, the effective lock
+        state is always <InlineCode>'self'</InlineCode>.
+      </li>
+      <li>
+        <ItemTitle>
+          <InlineCode>unlockNode(nodeId)</InlineCode>:
+        </ItemTitle>{' '}
+        Clears the node&apos;s lock state while preserving object-based{' '}
+        <InlineCode>readOnly.targets</InlineCode> metadata so it can be restored
+        by later lock toggles.
+      </li>
+      <li>
+        <ItemTitle>
+          <InlineCode>undo()</InlineCode> and <InlineCode>redo()</InlineCode>:
+        </ItemTitle>{' '}
+        Replay history steps when history is enabled.
+      </li>
+      <li>
+        <ItemTitle>
+          <InlineCode>setHistory(history)</InlineCode>:
+        </ItemTitle>{' '}
+        Replaces the current history state. This is useful for clearing or
+        restoring custom history snapshots.
+      </li>
+    </List>
+  </>
+);

--- a/example/src/v2/pages/api-page/components/builder-ref-mutation-methods-api-section.tsx
+++ b/example/src/v2/pages/api-page/components/builder-ref-mutation-methods-api-section.tsx
@@ -1,0 +1,74 @@
+import * as React from 'react';
+import {
+  InlineCode,
+  ItemTitle,
+  List,
+  SectionTitle,
+} from '../../../../components/docs-primitives';
+
+export const BuilderRefMutationMethodsApiSection: React.FC = () => (
+  <>
+    <SectionTitle>Mutation methods</SectionTitle>
+    <List>
+      <li>
+        <ItemTitle>
+          <InlineCode>cloneNode(nodeId)</InlineCode>:
+        </ItemTitle>{' '}
+        Clones a rule or group subtree directly below the original node and
+        preserves its read-only configuration.
+      </li>
+      <li>
+        <ItemTitle>
+          <InlineCode>deleteNode(nodeId)</InlineCode>:
+        </ItemTitle>{' '}
+        Removes a node subtree unless the node itself or one of its descendants
+        is protected by effective read-only state.
+      </li>
+      <li>
+        <ItemTitle>
+          <InlineCode>replaceNode(nodeId, node)</InlineCode>:
+        </ItemTitle>{' '}
+        Replaces a normalized node directly.
+      </li>
+      <li>
+        <ItemTitle>
+          <InlineCode>updateNode(nodeId, updater)</InlineCode>:
+        </ItemTitle>{' '}
+        Reads the current normalized node, passes it to an updater, and replaces
+        it with the updater result.
+      </li>
+      <li>
+        <ItemTitle>
+          <InlineCode>insertNodes(nodes, index, parentId?)</InlineCode>:
+        </ItemTitle>{' '}
+        Inserts one or more normalized nodes at the target index, either at the
+        root or inside a group.
+      </li>
+      <li>
+        <ItemTitle>
+          <InlineCode>addNode(node, parentId?, index?)</InlineCode>:
+        </ItemTitle>{' '}
+        Inserts one normalized node and appends it when{' '}
+        <InlineCode>index</InlineCode> is omitted.
+      </li>
+      <li>
+        <ItemTitle>
+          <InlineCode>addGroup(groupType?, parentId?, index?)</InlineCode>:
+        </ItemTitle>{' '}
+        Creates and inserts a new group node.
+      </li>
+      <li>
+        <ItemTitle>
+          <InlineCode>addRule(rule?, parentId?, index?)</InlineCode>:
+        </ItemTitle>{' '}
+        Creates and inserts a new rule node with optional initial values.
+      </li>
+      <li>
+        <ItemTitle>
+          <InlineCode>moveNode(nodeId, index, parentId?)</InlineCode>:
+        </ItemTitle>{' '}
+        Moves a node to a new index and optional parent group.
+      </li>
+    </List>
+  </>
+);

--- a/example/src/v2/pages/api-page/components/builder-ref-read-methods-api-section.tsx
+++ b/example/src/v2/pages/api-page/components/builder-ref-read-methods-api-section.tsx
@@ -1,0 +1,116 @@
+import * as React from 'react';
+import {
+  InlineCode,
+  ItemTitle,
+  List,
+  SectionTitle,
+} from '../../../../components/docs-primitives';
+
+export const BuilderRefReadMethodsApiSection: React.FC = () => (
+  <>
+    <SectionTitle>Read methods</SectionTitle>
+    <List>
+      <li>
+        <ItemTitle>
+          <InlineCode>getNodeById(nodeId)</InlineCode>:
+        </ItemTitle>{' '}
+        Returns one normalized node by id, or <InlineCode>undefined</InlineCode>{' '}
+        when it does not exist.
+      </li>
+      <li>
+        <ItemTitle>
+          <InlineCode>getNodes()</InlineCode>:
+        </ItemTitle>{' '}
+        Returns the current normalized query array.
+      </li>
+      <li>
+        <ItemTitle>
+          <InlineCode>getData()</InlineCode>:
+        </ItemTitle>{' '}
+        Returns the current denormalized query tree in the same shape emitted by{' '}
+        <InlineCode>onChange</InlineCode>.
+      </li>
+      <li>
+        <ItemTitle>
+          <InlineCode>getHistory()</InlineCode>:
+        </ItemTitle>{' '}
+        Returns the current history object with <InlineCode>past</InlineCode>{' '}
+        and <InlineCode>future</InlineCode> stacks.
+      </li>
+      <li>
+        <ItemTitle>
+          <InlineCode>
+            getNearestField(currentNodeId, targetFieldName)
+          </InlineCode>
+          :
+        </ItemTitle>{' '}
+        Returns the nearest matching rule in the current ancestor chain. This is
+        especially useful for dependency-aware rule options.
+      </li>
+      <li>
+        <ItemTitle>
+          <InlineCode>isFieldInUse(field)</InlineCode>:
+        </ItemTitle>{' '}
+        Returns <InlineCode>true</InlineCode> when at least one rule currently
+        targets the given field.
+      </li>
+      <li>
+        <ItemTitle>
+          <InlineCode>getFieldOptionState(field)</InlineCode>:
+        </ItemTitle>{' '}
+        Returns the shared runtime option list and loading status for a field.
+      </li>
+      <li>
+        <ItemTitle>
+          <InlineCode>getRuleOptionState(ruleId)</InlineCode>:
+        </ItemTitle>{' '}
+        Returns the rule-scoped runtime option list and loading status for one
+        rule instance.
+      </li>
+      <li>
+        <ItemTitle>
+          <InlineCode>bindRuleOptions(field, config)</InlineCode>:
+        </ItemTitle>{' '}
+        Resolves dependency-aware options, sets <InlineCode>loading</InlineCode>
+        , <InlineCode>success</InlineCode>, and <InlineCode>error</InlineCode>{' '}
+        states, aborts stale requests, and clears removed rules automatically.
+        Use <InlineCode>onOptionsResolved</InlineCode> when you want to run
+        post-load logic such as{' '}
+        <InlineCode>reconcileRuleValueWithOptions(...)</InlineCode>.
+      </li>
+      <li>
+        <ItemTitle>
+          <InlineCode>
+            subscribeToRuleDependencies(field, dependencyFields, listener)
+          </InlineCode>
+          :
+        </ItemTitle>{' '}
+        Emits dependency entries such as the nearest country for every city
+        rule, which is ideal for dependency-aware dynamic options.
+      </li>
+      <li>
+        <ItemTitle>
+          <InlineCode>subscribeToFieldOptionState(field, listener)</InlineCode>{' '}
+          and{' '}
+          <InlineCode>subscribeToRuleOptionState(ruleId, listener)</InlineCode>:
+        </ItemTitle>{' '}
+        Emit reactive option-state snapshots so external UI can reflect{' '}
+        <InlineCode>idle</InlineCode>, <InlineCode>loading</InlineCode>,{' '}
+        <InlineCode>success</InlineCode>, or <InlineCode>error</InlineCode>{' '}
+        without waiting for unrelated renders.
+      </li>
+      <li>
+        <ItemTitle>
+          <InlineCode>
+            reconcileRuleValueWithOptions(ruleId, {'{'} strategy {'}'} )
+          </InlineCode>
+          :
+        </ItemTitle>{' '}
+        Reconciles the current rule value against the effective option list. The
+        built-in <InlineCode>clear-if-missing</InlineCode> strategy is useful
+        when a value should be cleared once it is no longer available after a
+        dependency-driven reload.
+      </li>
+    </List>
+  </>
+);

--- a/example/src/v2/pages/api-page/components/builder-ref-rule-option-methods-api-section.tsx
+++ b/example/src/v2/pages/api-page/components/builder-ref-rule-option-methods-api-section.tsx
@@ -1,0 +1,59 @@
+import * as React from 'react';
+import {
+  InlineCode,
+  ItemTitle,
+  List,
+  SectionTitle,
+} from '../../../../components/docs-primitives';
+
+export const BuilderRefRuleOptionMethodsApiSection: React.FC = () => (
+  <>
+    <SectionTitle>Rule Option Methods</SectionTitle>
+    <List>
+      <li>
+        <ItemTitle>
+          <InlineCode>setRuleOptions(ruleId, options)</InlineCode>:
+        </ItemTitle>{' '}
+        Replaces the runtime option set for one specific rule instance.
+      </li>
+      <li>
+        <ItemTitle>
+          <InlineCode>setRuleOptionsStatus(ruleId, status)</InlineCode>:
+        </ItemTitle>{' '}
+        Stores a loading state for one specific rule instance.
+      </li>
+      <li>
+        <ItemTitle>
+          <InlineCode>invalidateRuleOptions(ruleId)</InlineCode>:
+        </ItemTitle>{' '}
+        Clears the rule-scoped runtime cache and falls back to field-scoped or
+        static options.
+      </li>
+      <li>
+        <ItemTitle>
+          <InlineCode>reloadRuleOptions(ruleId)</InlineCode>:
+        </ItemTitle>{' '}
+        Invalidates the rule-scoped runtime cache and then calls{' '}
+        <InlineCode>onRuleOptionsReload(ruleId)</InlineCode>.
+      </li>
+      <li>
+        <ItemTitle>
+          <InlineCode>clearRuleOptions(ruleId)</InlineCode>:
+        </ItemTitle>{' '}
+        Removes the rule-scoped runtime option state entirely.
+      </li>
+      <li>
+        <ItemTitle>
+          <InlineCode>
+            reconcileRuleValueWithOptions(ruleId, {'{'} strategy:
+            'clear-if-missing' {'}'})
+          </InlineCode>
+          :
+        </ItemTitle>{' '}
+        Compares the current rule value against the effective option list for
+        that rule and clears missing selections explicitly instead of doing it
+        automatically on every reload.
+      </li>
+    </List>
+  </>
+);

--- a/example/src/v2/pages/api-page/components/builder-text-mode-api-section.tsx
+++ b/example/src/v2/pages/api-page/components/builder-text-mode-api-section.tsx
@@ -1,0 +1,82 @@
+import * as React from 'react';
+import { CodeBlock } from '../../../../components/code-block';
+import {
+  InlineCode,
+  ItemTitle,
+  List,
+  SectionTitle,
+} from '../../../../components/docs-primitives';
+import { textModeConfigSignature } from '../constants/text-mode-config-signature';
+
+export const BuilderTextModeApiSection: React.FC = () => (
+  <>
+    <SectionTitle>Text mode behavior</SectionTitle>
+    <CodeBlock
+      code={textModeConfigSignature}
+      language="ts"
+      label="Text mode types"
+    />
+    <List>
+      <li>
+        <ItemTitle>Format:</ItemTitle> The current text-mode implementation
+        edits SQL.
+      </li>
+      <li>
+        <ItemTitle>Config shape:</ItemTitle> <InlineCode>textMode</InlineCode>{' '}
+        accepts either <InlineCode>true</InlineCode> or{' '}
+        <InlineCode>{`{ format?: 'SQL'; defaultMode?: 'builder' | 'text' }`}</InlineCode>
+        .
+      </li>
+      <li>
+        <ItemTitle>Default-mode precedence:</ItemTitle> If both{' '}
+        <InlineCode>textMode.defaultMode</InlineCode> and the top-level{' '}
+        <InlineCode>defaultMode</InlineCode> prop are provided, the top-level
+        prop wins.
+      </li>
+      <li>
+        <ItemTitle>Syntax and semantic validation:</ItemTitle> The built-in
+        editor highlights invalid SQL syntax plus builder-specific issues such
+        as unknown fields, unsupported operators, and invalid select values.
+      </li>
+      <li>
+        <ItemTitle>Field comparisons:</ItemTitle> When{' '}
+        <InlineCode>allowFieldComparisons</InlineCode> is enabled, SQL text mode
+        accepts builder-compatible right-hand-side field references such as{' '}
+        <InlineCode>ORDER_TOTAL &gt;= ORDER_APPROVAL_LIMIT</InlineCode>. When
+        disabled, the same expression is reported as a semantic validation
+        issue.
+      </li>
+      <li>
+        <ItemTitle>Invalid text flow:</ItemTitle> Invalid text stays local to
+        text mode, the last valid builder query is preserved, and{' '}
+        <InlineCode>onChange</InlineCode> is fired only after a valid parse and
+        semantic validation.
+      </li>
+      <li>
+        <ItemTitle>History:</ItemTitle> Valid text edits are committed into
+        builder history. Invalid intermediate text is not committed into builder
+        state or history.
+      </li>
+      <li>
+        <ItemTitle>Built-in editor:</ItemTitle> Included in the main package and
+        suitable for freely editable SQL text mode.
+      </li>
+      <li>
+        <ItemTitle>Locked queries:</ItemTitle> The built-in text editor blocks
+        locked or targeted read-only queries because it cannot preserve
+        protected text ranges safely after freeform edits.
+      </li>
+      <li>
+        <ItemTitle>Custom editors:</ItemTitle> Custom text editors receive{' '}
+        <InlineCode>protectedRanges</InlineCode> so localized read-only SQL
+        fragments can stay visible while remaining non-editable.
+      </li>
+      <li>
+        <ItemTitle>Monaco path:</ItemTitle> Use the optional{' '}
+        <InlineCode>@vojtechportes/react-query-builder/monaco</InlineCode>{' '}
+        subpackage when you need a protected-range editor that can preserve
+        locked and targeted read-only query segments.
+      </li>
+    </List>
+  </>
+);

--- a/example/src/v2/pages/api-page/components/component-overrides-api-section.tsx
+++ b/example/src/v2/pages/api-page/components/component-overrides-api-section.tsx
@@ -1,0 +1,117 @@
+import * as React from 'react';
+import {
+  InlineCode,
+  ItemTitle,
+  List,
+  SectionTitle,
+} from '../../../../components/docs-primitives';
+
+export const ComponentOverridesApiSection: React.FC = () => (
+  <>
+    <SectionTitle>Props</SectionTitle>
+    <List>
+      <li>
+        <ItemTitle>
+          <InlineCode>Alert</InlineCode>:
+        </ItemTitle>{' '}
+        Replaces the built-in alert component used for builder-level notices
+        such as blocked text mode.
+      </li>
+      <li>
+        <ItemTitle>
+          <InlineCode>form.Select</InlineCode> /{' '}
+          <InlineCode>form.SelectMulti</InlineCode> /{' '}
+          <InlineCode>form.Switch</InlineCode> /{' '}
+          <InlineCode>form.Input</InlineCode>:
+        </ItemTitle>{' '}
+        Replace the built-in form controls used by rules and groups.
+      </li>
+      <li>
+        <ItemTitle>
+          <InlineCode>Remove</InlineCode> and <InlineCode>Add</InlineCode>:
+        </ItemTitle>{' '}
+        Replace action buttons used for structural editing.
+      </li>
+      <li>
+        <ItemTitle>
+          <InlineCode>OutlinedButton</InlineCode>:
+        </ItemTitle>{' '}
+        Replaces the built-in outlined action button used by undo, redo, and the
+        builder/text mode toggle.
+      </li>
+      <li>
+        <ItemTitle>
+          <InlineCode>TextModeToggleContent</InlineCode>:
+        </ItemTitle>{' '}
+        Replaces the label-and-icon content rendered inside the builder/text
+        mode toggle button.
+      </li>
+      <li>
+        <ItemTitle>
+          <InlineCode>TextModeEditor</InlineCode>:
+        </ItemTitle>{' '}
+        Replaces the whole text-mode editor surface. This is the integration
+        point for Monaco and other advanced editors.
+      </li>
+      <li>
+        <ItemTitle>
+          <InlineCode>TextModeInput</InlineCode>:
+        </ItemTitle>{' '}
+        Replaces only the input layer used by the built-in text editor.
+      </li>
+      <li>
+        <ItemTitle>
+          <InlineCode>CloneButton</InlineCode>:
+        </ItemTitle>{' '}
+        Replaces the built-in clone control used when{' '}
+        <InlineCode>cloneable</InlineCode> is enabled.
+      </li>
+      <li>
+        <ItemTitle>
+          <InlineCode>LockToggle</InlineCode>:
+        </ItemTitle>{' '}
+        Replaces the built-in lock control used when{' '}
+        <InlineCode>lockable</InlineCode> is enabled.
+      </li>
+      <li>
+        <ItemTitle>
+          <InlineCode>HistoryControls</InlineCode>:
+        </ItemTitle>{' '}
+        Replaces the layout wrapper around the built-in undo and redo controls
+        used when history controls are enabled.
+      </li>
+      <li>
+        <ItemTitle>
+          <InlineCode>Rule</InlineCode> and <InlineCode>Group</InlineCode>:
+        </ItemTitle>{' '}
+        Replace the main structural containers.
+      </li>
+      <li>
+        <ItemTitle>
+          <InlineCode>GroupHeaderOption</InlineCode>:
+        </ItemTitle>{' '}
+        Replaces the header option control used in group UIs.
+      </li>
+      <li>
+        <ItemTitle>
+          <InlineCode>Text</InlineCode>:
+        </ItemTitle>{' '}
+        Replaces the built-in text rendering component.
+      </li>
+      <li>
+        <ItemTitle>
+          <InlineCode>DropZone</InlineCode> and{' '}
+          <InlineCode>EmptyGroupDropZone</InlineCode>:
+        </ItemTitle>{' '}
+        Replaces drag-and-drop target renderers.
+      </li>
+      <li>
+        <ItemTitle>
+          <InlineCode>Popover</InlineCode> and{' '}
+          <InlineCode>PopoverItem</InlineCode>:
+        </ItemTitle>{' '}
+        Replaces the popover UI used by group creation mode where relevant.
+      </li>
+    </List>
+  </>
+);

--- a/example/src/v2/pages/api-page/components/component-prop-contracts-api-section.tsx
+++ b/example/src/v2/pages/api-page/components/component-prop-contracts-api-section.tsx
@@ -1,0 +1,123 @@
+import * as React from 'react';
+import {
+  InlineCode,
+  ItemTitle,
+  List,
+  SectionTitle,
+} from '../../../../components/docs-primitives';
+
+export const ComponentPropContractsApiSection: React.FC = () => (
+  <>
+    <SectionTitle>Key prop contracts</SectionTitle>
+    <List>
+      <li>
+        <ItemTitle>
+          <InlineCode>form.Input</InlineCode>:
+        </ItemTitle>{' '}
+        Receives <InlineCode>type</InlineCode>, <InlineCode>value</InlineCode>,{' '}
+        <InlineCode>onChange(value)</InlineCode>, and optional{' '}
+        <InlineCode>disabled</InlineCode>, <InlineCode>id</InlineCode>, and{' '}
+        <InlineCode>name</InlineCode>.
+      </li>
+      <li>
+        <ItemTitle>
+          <InlineCode>form.Select</InlineCode>:
+        </ItemTitle>{' '}
+        Receives <InlineCode>values</InlineCode>,{' '}
+        <InlineCode>selectedValue</InlineCode>,{' '}
+        <InlineCode>emptyValue</InlineCode>, and{' '}
+        <InlineCode>onChange(value)</InlineCode>.
+      </li>
+      <li>
+        <ItemTitle>
+          <InlineCode>form.SelectMulti</InlineCode>:
+        </ItemTitle>{' '}
+        Receives <InlineCode>selectedValue</InlineCode>,{' '}
+        <InlineCode>values</InlineCode>,{' '}
+        <InlineCode>onChange(value)</InlineCode>, and{' '}
+        <InlineCode>onDelete(value)</InlineCode>.
+      </li>
+      <li>
+        <ItemTitle>
+          <InlineCode>form.Switch</InlineCode>:
+        </ItemTitle>{' '}
+        Receives <InlineCode>switched</InlineCode>, optional{' '}
+        <InlineCode>onChange(value)</InlineCode>, and optional{' '}
+        <InlineCode>disabled</InlineCode>.
+      </li>
+      <li>
+        <ItemTitle>
+          <InlineCode>TextModeEditor</InlineCode>:
+        </ItemTitle>{' '}
+        Receives the current SQL text, diagnostics, optional protected ranges,
+        an optional hover message for protected ranges, and{' '}
+        <InlineCode>onChange(value)</InlineCode>.
+      </li>
+      <li>
+        <ItemTitle>
+          <InlineCode>TextModeInput</InlineCode>:
+        </ItemTitle>{' '}
+        Receives the current text value plus controlled input props such as{' '}
+        <InlineCode>disabled</InlineCode>, <InlineCode>readOnly</InlineCode>,
+        and class names used by the built-in text-mode layout.
+      </li>
+      <li>
+        <ItemTitle>
+          <InlineCode>CloneButton</InlineCode>:
+        </ItemTitle>{' '}
+        Receives <InlineCode>nodeType</InlineCode>, optional{' '}
+        <InlineCode>disabled</InlineCode>, and{' '}
+        <InlineCode>onClick()</InlineCode>.
+      </li>
+      <li>
+        <ItemTitle>
+          <InlineCode>LockToggle</InlineCode>:
+        </ItemTitle>{' '}
+        Receives <InlineCode>state</InlineCode>,{' '}
+        <InlineCode>nodeType</InlineCode>, optional{' '}
+        <InlineCode>disabled</InlineCode>, and{' '}
+        <InlineCode>onChange(nextState)</InlineCode>.
+      </li>
+      <li>
+        <ItemTitle>
+          <InlineCode>HistoryControls</InlineCode>:
+        </ItemTitle>{' '}
+        Receives built-in <InlineCode>undoButton</InlineCode> and{' '}
+        <InlineCode>redoButton</InlineCode> nodes plus{' '}
+        <InlineCode>canUndo</InlineCode>, <InlineCode>canRedo</InlineCode>,{' '}
+        <InlineCode>onUndo()</InlineCode>, and <InlineCode>onRedo()</InlineCode>
+        .
+      </li>
+      <li>
+        <ItemTitle>
+          <InlineCode>Rule</InlineCode>:
+        </ItemTitle>{' '}
+        Receives already-built <InlineCode>children</InlineCode>,{' '}
+        <InlineCode>controls</InlineCode>, and optional{' '}
+        <InlineCode>dragHandle</InlineCode>.
+      </li>
+      <li>
+        <ItemTitle>
+          <InlineCode>Group</InlineCode>:
+        </ItemTitle>{' '}
+        Receives <InlineCode>controlsLeft</InlineCode>,{' '}
+        <InlineCode>controlsRight</InlineCode>,{' '}
+        <InlineCode>children</InlineCode>, and optional overlays or drag
+        handles.
+      </li>
+      <li>
+        <ItemTitle>
+          <InlineCode>DropZone</InlineCode>:
+        </ItemTitle>{' '}
+        Receives <InlineCode>id</InlineCode>, <InlineCode>index</InlineCode>,
+        optional <InlineCode>parentId</InlineCode>, and drag-state flags.
+      </li>
+      <li>
+        <ItemTitle>
+          <InlineCode>EmptyGroupDropZone</InlineCode>:
+        </ItemTitle>{' '}
+        Receives the target group id plus drag-state flags for empty containers.
+      </li>
+    </List>
+  </>
+);

--- a/example/src/v2/pages/api-page/components/components-api-content.tsx
+++ b/example/src/v2/pages/api-page/components/components-api-content.tsx
@@ -1,0 +1,50 @@
+import * as React from 'react';
+import { AlertBox } from '../../../../components/alert-box';
+import { CodeBlock } from '../../../../components/code-block';
+import { TextLink } from '../../../../components/docs-primitives';
+import { componentsSignature } from '../constants/components-signature';
+import { textModeEditorSignature } from '../constants/text-mode-editor-signature';
+import { historyControlsSignature } from '../constants/history-controls-signature';
+import { lockToggleSignature } from '../constants/lock-toggle-signature';
+import { cloneButtonSignature } from '../constants/clone-button-signature';
+import { ComponentOverridesApiSection } from './component-overrides-api-section';
+import { ComponentPropContractsApiSection } from './component-prop-contracts-api-section';
+import { MonacoSubpackageApiSection } from './monaco-subpackage-api-section';
+
+export const ComponentsApiContent: React.FC = () => (
+  <>
+    <CodeBlock
+      code={componentsSignature}
+      language="ts"
+      label="Component overrides"
+    />
+    <CodeBlock
+      code={textModeEditorSignature}
+      language="ts"
+      label="Text mode editor props"
+    />
+    <CodeBlock
+      code={cloneButtonSignature}
+      language="ts"
+      label="CloneButton props"
+    />
+    <CodeBlock
+      code={lockToggleSignature}
+      language="ts"
+      label="LockToggle props"
+    />
+    <CodeBlock
+      code={historyControlsSignature}
+      language="ts"
+      label="HistoryControls props"
+    />
+    <ComponentOverridesApiSection />
+    <ComponentPropContractsApiSection />
+    <MonacoSubpackageApiSection />
+    <AlertBox title="Documentation" variant="info">
+      <TextLink to="/documentation/components">Components</TextLink>,{' '}
+      <TextLink to="/documentation/text-mode">Text Mode</TextLink>, and{' '}
+      <TextLink to="/documentation/adapters">Adapters</TextLink>.
+    </AlertBox>
+  </>
+);

--- a/example/src/v2/pages/api-page/components/data-api-content.tsx
+++ b/example/src/v2/pages/api-page/components/data-api-content.tsx
@@ -1,0 +1,215 @@
+import * as React from 'react';
+import { AlertBox } from '../../../../components/alert-box';
+import { CodeBlock } from '../../../../components/code-block';
+import {
+  InlineCode,
+  ItemTitle,
+  List,
+  SectionTitle,
+  TextLink,
+} from '../../../../components/docs-primitives';
+import { queryTreeSignature } from '../constants/query-tree-signature';
+import { dataFieldComparisonSnippet } from '../constants/data-field-comparison-snippet';
+
+export const DataApiContent: React.FC = () => (
+  <>
+    <CodeBlock
+      code={queryTreeSignature}
+      language="ts"
+      label="Query tree types"
+    />
+    <CodeBlock
+      code={dataFieldComparisonSnippet}
+      language="ts"
+      label="Field-reference rule data"
+    />
+    <SectionTitle>Rule props</SectionTitle>
+    <List>
+      <li>
+        <ItemTitle>
+          <InlineCode>field</InlineCode>:
+        </ItemTitle>{' '}
+        Required field identifier matching one of the configured fields.
+      </li>
+      <li>
+        <ItemTitle>
+          <InlineCode>operator</InlineCode>:
+        </ItemTitle>{' '}
+        Optional operator for the rule. Some field and operator combinations
+        imply different value shapes.
+      </li>
+      <li>
+        <ItemTitle>
+          <InlineCode>valueSource</InlineCode>:
+        </ItemTitle>{' '}
+        Optional discriminant. Omit it or set <InlineCode>'value'</InlineCode>{' '}
+        for literal comparisons, or set <InlineCode>'field'</InlineCode> for
+        right-hand-side field references.
+      </li>
+      <li>
+        <ItemTitle>
+          <InlineCode>value</InlineCode>:
+        </ItemTitle>{' '}
+        Optional literal rule value used when{' '}
+        <InlineCode>valueSource</InlineCode> is omitted or set to{' '}
+        <InlineCode>'value'</InlineCode>. Supported scalar and array forms are
+        defined by <InlineCode>QueryRuleValue</InlineCode>.
+      </li>
+      <li>
+        <ItemTitle>
+          <InlineCode>valueField</InlineCode>:
+        </ItemTitle>{' '}
+        Required when <InlineCode>valueSource</InlineCode> is{' '}
+        <InlineCode>'field'</InlineCode>. Stores the compared field identifier
+        instead of a literal value.
+      </li>
+      <li>
+        <ItemTitle>
+          <InlineCode>operators</InlineCode>:
+        </ItemTitle>{' '}
+        Optional rule-level operator override list.
+      </li>
+      <li>
+        <ItemTitle>
+          <InlineCode>readOnly</InlineCode>:
+        </ItemTitle>{' '}
+        Optional per-rule lock definition. Supported shapes are{' '}
+        <InlineCode>false</InlineCode> or omitted, <InlineCode>true</InlineCode>
+        , or{' '}
+        <InlineCode>{`{ enabled: boolean; targets?: ('field' | 'operator' | 'value')[] }`}</InlineCode>
+        .
+      </li>
+      <li>
+        <ItemTitle>
+          <InlineCode>readOnly.targets</InlineCode>:
+        </ItemTitle>{' '}
+        Part of the <InlineCode>readOnly</InlineCode> object config. Rule
+        targets are <InlineCode>'field'</InlineCode>,{' '}
+        <InlineCode>'operator'</InlineCode>, and{' '}
+        <InlineCode>'value'</InlineCode>. Targeted controls stay visible but
+        become non-editable.
+      </li>
+      <li>
+        <ItemTitle>
+          <InlineCode>readOnly.enabled</InlineCode>:
+        </ItemTitle>{' '}
+        Part of the <InlineCode>readOnly</InlineCode> object config. When{' '}
+        <InlineCode>true</InlineCode>, the listed targets are protected. When{' '}
+        <InlineCode>readOnly.targets</InlineCode> is omitted, the whole rule is
+        read-only.
+      </li>
+      <li>
+        <ItemTitle>Delete behavior:</ItemTitle> A rule with any effective
+        read-only target is also non-deletable, and cloned rules preserve the
+        same read-only configuration.
+      </li>
+      <li>
+        <ItemTitle>GUI cycle:</ItemTitle> When <InlineCode>lockable</InlineCode>{' '}
+        is enabled, rules cycle between unlocked and locked. Object-based{' '}
+        <InlineCode>readOnly.targets</InlineCode> are preserved when the user
+        unlocks and re-locks the same rule.
+      </li>
+      <li>
+        <ItemTitle>
+          <InlineCode>id</InlineCode> and <InlineCode>parent</InlineCode>:
+        </ItemTitle>{' '}
+        Optional in denormalized input. The builder can ingest data without
+        them.
+      </li>
+    </List>
+    <SectionTitle>Group props</SectionTitle>
+    <List>
+      <li>
+        <ItemTitle>
+          <InlineCode>type</InlineCode>:
+        </ItemTitle>{' '}
+        Always <InlineCode>'GROUP'</InlineCode>.
+      </li>
+      <li>
+        <ItemTitle>
+          <InlineCode>children</InlineCode>:
+        </ItemTitle>{' '}
+        Required nested nodes.
+      </li>
+      <li>
+        <ItemTitle>
+          <InlineCode>value</InlineCode>:
+        </ItemTitle>{' '}
+        Present only for groups with modifiers and must be{' '}
+        <InlineCode>'AND'</InlineCode> or <InlineCode>'OR'</InlineCode>.
+      </li>
+      <li>
+        <ItemTitle>
+          <InlineCode>isNegated</InlineCode>:
+        </ItemTitle>{' '}
+        Present only for groups with modifiers.
+      </li>
+      <li>
+        <ItemTitle>
+          <InlineCode>readOnly</InlineCode>:
+        </ItemTitle>{' '}
+        Can be <InlineCode>false</InlineCode> or omitted,{' '}
+        <InlineCode>true</InlineCode>, or{' '}
+        <InlineCode>{`{ enabled: boolean; targets?: ('negation' | 'combinator')[]; inheritToChildren?: boolean }`}</InlineCode>
+        .
+      </li>
+      <li>
+        <ItemTitle>
+          <InlineCode>readOnly: true</InlineCode>:
+        </ItemTitle>{' '}
+        Locks only the group&apos;s own controls by default. Descendant rules
+        and groups remain editable unless inheritance is enabled.
+      </li>
+      <li>
+        <ItemTitle>
+          <InlineCode>readOnly.targets</InlineCode>:
+        </ItemTitle>{' '}
+        Part of the <InlineCode>readOnly</InlineCode> object config. Group
+        targets are <InlineCode>'negation'</InlineCode> and{' '}
+        <InlineCode>'combinator'</InlineCode>. Targeted controls stay visible
+        but become non-editable.
+      </li>
+      <li>
+        <ItemTitle>
+          <InlineCode>readOnly.enabled</InlineCode>:
+        </ItemTitle>{' '}
+        Part of the <InlineCode>readOnly</InlineCode> object config. When{' '}
+        <InlineCode>true</InlineCode>, the listed targets are protected. When{' '}
+        <InlineCode>readOnly.targets</InlineCode> is omitted, the whole group is
+        read-only.
+      </li>
+      <li>
+        <ItemTitle>
+          <InlineCode>readOnly.inheritToChildren</InlineCode>:
+        </ItemTitle>{' '}
+        Part of the <InlineCode>readOnly</InlineCode> object config. Applies the
+        group lock to descendant groups and their children when the group is
+        enabled.
+      </li>
+      <li>
+        <ItemTitle>Delete behavior:</ItemTitle> A group cannot be deleted when
+        it has effective read-only targets. By default, it also cannot be
+        deleted when that would remove protected descendants indirectly. This
+        subtree behavior can be disabled with{' '}
+        <InlineCode>Builder.readOnlyProtectsDelete={false}</InlineCode>.
+      </li>
+      <li>
+        <ItemTitle>GUI cycle:</ItemTitle> When <InlineCode>lockable</InlineCode>{' '}
+        is enabled, groups cycle through unlocked, locked group only, and locked
+        group with descendants while preserving object-based{' '}
+        <InlineCode>readOnly.targets</InlineCode>.
+      </li>
+      <li>
+        <ItemTitle>Inheritance behavior:</ItemTitle> Descendants cannot override
+        an inherited lock from an ancestor.
+      </li>
+    </List>
+    <AlertBox title="Documentation" variant="info">
+      <TextLink to="/documentation/usage">Usage</TextLink> and{' '}
+      <TextLink to="/documentation/locking-and-read-only">
+        Locking and Read-only
+      </TextLink>
+      .
+    </AlertBox>
+  </>
+);

--- a/example/src/v2/pages/api-page/components/fields-api-content.tsx
+++ b/example/src/v2/pages/api-page/components/fields-api-content.tsx
@@ -1,0 +1,203 @@
+import * as React from 'react';
+import { AlertBox } from '../../../../components/alert-box';
+import { CodeBlock } from '../../../../components/code-block';
+import {
+  InlineCode,
+  ItemTitle,
+  List,
+  SectionTitle,
+  TextLink,
+} from '../../../../components/docs-primitives';
+import { fieldTypesSignature } from '../constants/field-types-signature';
+import { fieldBaseSignature } from '../constants/field-base-signature';
+import { fieldUsageLimitSignature } from '../constants/field-usage-limit-signature';
+import { fieldComparisonConfigSignature } from '../constants/field-comparison-config-signature';
+import { fieldOptionTypesSignature } from '../constants/field-option-types-signature';
+import { fieldsFieldComparisonSnippet } from '../constants/fields-field-comparison-snippet';
+
+export const FieldsApiContent: React.FC = () => (
+  <>
+    <CodeBlock code={fieldTypesSignature} language="ts" label="Field unions" />
+    <CodeBlock
+      code={fieldBaseSignature}
+      language="ts"
+      label="Shared field shape"
+    />
+    <CodeBlock
+      code={fieldUsageLimitSignature}
+      language="ts"
+      label="Field usage limits"
+    />
+    <CodeBlock
+      code={fieldComparisonConfigSignature}
+      language="ts"
+      label="Field comparison config"
+    />
+    <CodeBlock
+      code={fieldOptionTypesSignature}
+      language="ts"
+      label="Imperative option types"
+    />
+    <SectionTitle>Props</SectionTitle>
+    <List>
+      <li>
+        <ItemTitle>
+          <InlineCode>field</InlineCode>:
+        </ItemTitle>{' '}
+        Required stable identifier used in query data and conversion helpers.
+      </li>
+      <li>
+        <ItemTitle>
+          <InlineCode>label</InlineCode>:
+        </ItemTitle>{' '}
+        Required user-facing caption shown in the field selector.
+      </li>
+      <li>
+        <ItemTitle>
+          <InlineCode>type</InlineCode>:
+        </ItemTitle>{' '}
+        Required field type. This controls which widget and value semantics are
+        used.
+      </li>
+      <li>
+        <ItemTitle>
+          <InlineCode>value</InlineCode>:
+        </ItemTitle>{' '}
+        Optional default or backing field value metadata. For{' '}
+        <InlineCode>LIST</InlineCode> and <InlineCode>MULTI_LIST</InlineCode>,
+        this is the initial static option set.
+      </li>
+      <li>
+        <ItemTitle>
+          <InlineCode>operators</InlineCode>:
+        </ItemTitle>{' '}
+        Optional operator whitelist. When omitted, the builder falls back to the
+        default operators for the field type.
+      </li>
+      <li>
+        <ItemTitle>
+          <InlineCode>usageLimit</InlineCode>:
+        </ItemTitle>{' '}
+        Optional structural constraint that limits how many rules may use this
+        field or its shared usage bucket.
+      </li>
+      <li>
+        <ItemTitle>
+          <InlineCode>validation</InlineCode>:
+        </ItemTitle>{' '}
+        Optional validation config. The shape depends on field type.
+      </li>
+      <li>
+        <ItemTitle>
+          <InlineCode>fieldComparison</InlineCode>:
+        </ItemTitle>{' '}
+        Optional semantic config for field-to-field comparisons, including a
+        comparison type override and an allowlist of valid target fields.
+      </li>
+    </List>
+    <SectionTitle>usageLimit</SectionTitle>
+    <List>
+      <li>
+        <ItemTitle>
+          <InlineCode>max</InlineCode>:
+        </ItemTitle>{' '}
+        Required maximum number of matching rules allowed in the selected scope.
+      </li>
+      <li>
+        <ItemTitle>
+          <InlineCode>scope</InlineCode>:
+        </ItemTitle>{' '}
+        Optional. Defaults to <InlineCode>global</InlineCode>. Use{' '}
+        <InlineCode>parent</InlineCode> to limit usage only within the same
+        immediate parent group.
+      </li>
+      <li>
+        <ItemTitle>
+          <InlineCode>key</InlineCode>:
+        </ItemTitle>{' '}
+        Optional shared bucket identifier. When omitted, the builder uses the
+        field&apos;s own <InlineCode>field</InlineCode> value.
+      </li>
+      <li>
+        <ItemTitle>
+          <InlineCode>message</InlineCode>:
+        </ItemTitle>{' '}
+        Optional custom validation message used when persisted or imported data
+        exceeds the allowed limit.
+      </li>
+    </List>
+    <SectionTitle>fieldComparison</SectionTitle>
+    <CodeBlock
+      code={fieldsFieldComparisonSnippet}
+      language="tsx"
+      label="Semantic field comparison metadata"
+    />
+    <List>
+      <li>
+        <ItemTitle>
+          <InlineCode>type</InlineCode>:
+        </ItemTitle>{' '}
+        Optional semantic comparison type. When omitted,{' '}
+        <InlineCode>TEXT</InlineCode>, <InlineCode>NUMBER</InlineCode>,{' '}
+        <InlineCode>DATE</InlineCode>, and <InlineCode>BOOLEAN</InlineCode>{' '}
+        infer automatically, while <InlineCode>LIST</InlineCode> can infer from
+        uniform option values.
+      </li>
+      <li>
+        <ItemTitle>
+          <InlineCode>comparableFields</InlineCode>:
+        </ItemTitle>{' '}
+        Optional source-owned allowlist that restricts which fields may appear
+        on the right-hand side.
+      </li>
+      <li>
+        <ItemTitle>Operator support:</ItemTitle> Field comparisons are only
+        offered for operators that have a direct single-value right-hand side.
+        Range and set-style operators continue to use literal values.
+      </li>
+    </List>
+    <SectionTitle>Type notes</SectionTitle>
+    <List>
+      <li>
+        <ItemTitle>
+          <InlineCode>BOOLEAN</InlineCode> / <InlineCode>TEXT</InlineCode> /{' '}
+          <InlineCode>DATE</InlineCode> / <InlineCode>NUMBER</InlineCode>:
+        </ItemTitle>{' '}
+        The standard scalar field families with built-in widget and validation
+        behavior.
+      </li>
+      <li>
+        <ItemTitle>
+          <InlineCode>LIST</InlineCode> / <InlineCode>MULTI_LIST</InlineCode>:
+        </ItemTitle>{' '}
+        Option-backed selectors where <InlineCode>value</InlineCode> holds the
+        initial static option set, field-level runtime options can be shared
+        across all rules of that field, and rule-level runtime options can
+        override them per rule instance.
+      </li>
+      <li>
+        <ItemTitle>
+          <InlineCode>STATEMENT</InlineCode>:
+        </ItemTitle>{' '}
+        Advanced field type for free-form statement-like values. Document it
+        carefully in consuming apps because it is less self-explanatory than
+        scalar or list fields.
+      </li>
+      <li>
+        <ItemTitle>
+          <InlineCode>GROUP</InlineCode>:
+        </ItemTitle>{' '}
+        Advanced structural field type intended for specialized query models
+        rather than everyday filter fields.
+      </li>
+    </List>
+    <AlertBox title="Documentation" variant="info">
+      <TextLink to="/documentation/usage">Usage</TextLink>,{' '}
+      <TextLink to="/documentation/validation">Validation</TextLink>,{' '}
+      <TextLink to="/documentation/dynamic-field-options">
+        Dynamic Field Options
+      </TextLink>
+      , and <TextLink to="/documentation/localization">Localization</TextLink>.
+    </AlertBox>
+  </>
+);

--- a/example/src/v2/pages/api-page/components/format-query-api-content.tsx
+++ b/example/src/v2/pages/api-page/components/format-query-api-content.tsx
@@ -1,0 +1,177 @@
+import * as React from 'react';
+import { AlertBox } from '../../../../components/alert-box';
+import { CodeBlock } from '../../../../components/code-block';
+import {
+  InlineCode,
+  ItemTitle,
+  List,
+  SectionTitle,
+  TextLink,
+} from '../../../../components/docs-primitives';
+import { formatQuerySignature } from '../constants/format-query-signature';
+import { formatOptionsSignature } from '../constants/format-options-signature';
+import { queryFormatSignature } from '../constants/query-format-signature';
+import { formatQueryFieldComparisonSnippet } from '../constants/format-query-field-comparison-snippet';
+
+export const FormatQueryApiContent: React.FC = () => (
+  <>
+    <CodeBlock
+      code={formatQuerySignature}
+      language="ts"
+      label="formatQuery signature"
+    />
+    <CodeBlock
+      code={queryFormatSignature}
+      language="ts"
+      label="Supported formats"
+    />
+    <CodeBlock
+      code={formatOptionsSignature}
+      language="ts"
+      label="Options types"
+    />
+    <SectionTitle>Parameters</SectionTitle>
+    <List>
+      <li>
+        <ItemTitle>
+          <InlineCode>value</InlineCode>:
+        </ItemTitle>{' '}
+        The <TextLink to="/api/data">denormalized query tree</TextLink> to
+        serialize.
+      </li>
+      <li>
+        <ItemTitle>
+          <InlineCode>format</InlineCode>:
+        </ItemTitle>{' '}
+        The target format. This determines both the formatter used and the shape
+        of accepted options.
+      </li>
+      <li>
+        <ItemTitle>
+          <InlineCode>options</InlineCode>:
+        </ItemTitle>{' '}
+        Optional formatter configuration.
+      </li>
+    </List>
+    <SectionTitle>Shared options</SectionTitle>
+    <List>
+      <li>
+        <ItemTitle>
+          <InlineCode>fields</InlineCode>:
+        </ItemTitle>{' '}
+        Supplies <TextLink to="/api/fields">field metadata</TextLink> to the
+        formatter. This is often required when output depends on field type,
+        option labels, or value semantics.
+      </li>
+      <li>
+        <ItemTitle>
+          <InlineCode>rootlessCombinator</InlineCode>:
+        </ItemTitle>{' '}
+        Chooses how root-level items are combined when the query does not have a
+        single explicit root group. This matters most when{' '}
+        <InlineCode>singleRootGroup</InlineCode> is disabled.
+      </li>
+      <li>
+        <ItemTitle>
+          <InlineCode>modifierlessGroupCombinator</InlineCode>:
+        </ItemTitle>{' '}
+        Chooses how children of modifierless groups are combined when a group
+        has structure but no embedded AND/OR modifier.
+      </li>
+    </List>
+    <SectionTitle>Behavior notes</SectionTitle>
+    <List>
+      <li>
+        <ItemTitle>
+          <InlineCode>fields</InlineCode>:
+        </ItemTitle>{' '}
+        Treat this as recommended for anything beyond trivial string-only
+        formatting, especially for typed values and list-backed fields.
+      </li>
+      <li>
+        <ItemTitle>
+          <InlineCode>rootlessCombinator</InlineCode>:
+        </ItemTitle>{' '}
+        If your tree has multiple top-level nodes, this decides whether the
+        exported expression joins them with <InlineCode>AND</InlineCode> or{' '}
+        <InlineCode>OR</InlineCode>.
+      </li>
+      <li>
+        <ItemTitle>
+          <InlineCode>modifierlessGroupCombinator</InlineCode>:
+        </ItemTitle>{' '}
+        Use this when your UI allows groups without modifiers and your target
+        syntax still needs a combinator in serialized output.
+      </li>
+    </List>
+    <SectionTitle>Format-specific options</SectionTitle>
+    <List>
+      <li>
+        <ItemTitle>
+          <InlineCode>wrapWhereClause</InlineCode>:
+        </ItemTitle>{' '}
+        Supported by SQL and Prisma format options. Prefixes the output with{' '}
+        <InlineCode>WHERE </InlineCode>.
+      </li>
+      <li>
+        <ItemTitle>
+          <InlineCode>wrapFilterClause</InlineCode>:
+        </ItemTitle>{' '}
+        Supported by AQL and OData format options. Prefixes the output with{' '}
+        <InlineCode>FILTER </InlineCode> or equivalent filter clause semantics.
+      </li>
+      <li>
+        <ItemTitle>
+          <InlineCode>variableName</InlineCode>:
+        </ItemTitle>{' '}
+        Supported by AQL format options. Sets the document variable prefix used
+        in generated expressions.
+      </li>
+      <li>
+        <ItemTitle>
+          <InlineCode>wrapQueryClause</InlineCode>:
+        </ItemTitle>{' '}
+        Supported by Elasticsearch format options. Wraps the generated
+        expression in the outer query clause shape.
+      </li>
+    </List>
+    <SectionTitle>Field comparisons</SectionTitle>
+    <CodeBlock
+      code={formatQueryFieldComparisonSnippet}
+      language="ts"
+      label="Formatting a field-reference rule"
+    />
+    <List>
+      <li>
+        <ItemTitle>Native support:</ItemTitle> <InlineCode>SQL</InlineCode>,{' '}
+        <InlineCode>Mongo</InlineCode>, <InlineCode>AQL</InlineCode>,{' '}
+        <InlineCode>JSONata</InlineCode>, <InlineCode>JsonLogic</InlineCode>,{' '}
+        <InlineCode>CEL</InlineCode>, <InlineCode>SpEL</InlineCode>,{' '}
+        <InlineCode>Prisma</InlineCode>, <InlineCode>OData</InlineCode>,{' '}
+        <InlineCode>Dynamo</InlineCode>, and <InlineCode>Django</InlineCode>{' '}
+        serialize field comparisons when the operator has a direct
+        right-hand-side field form.
+      </li>
+      <li>
+        <ItemTitle>
+          <InlineCode>fields</InlineCode> option:
+        </ItemTitle>{' '}
+        Treat field metadata as strongly recommended here because formatter
+        behavior depends on field semantics and operator compatibility.
+      </li>
+      <li>
+        <ItemTitle>Explicit rejection:</ItemTitle>{' '}
+        <InlineCode>Elasticsearch</InlineCode> and <InlineCode>RSQL</InlineCode>{' '}
+        intentionally throw for <InlineCode>valueSource: 'field'</InlineCode>{' '}
+        rules instead of inventing backend-only syntax.
+      </li>
+    </List>
+    <AlertBox title="See also" variant="info">
+      For a live sandbox that exercises these formats, use{' '}
+      <TextLink to="/documentation/parsing-and-formatting">
+        Parsing and Formatting
+      </TextLink>
+      .
+    </AlertBox>
+  </>
+);

--- a/example/src/v2/pages/api-page/components/monaco-subpackage-api-section.tsx
+++ b/example/src/v2/pages/api-page/components/monaco-subpackage-api-section.tsx
@@ -1,0 +1,44 @@
+import * as React from 'react';
+import { CodeBlock } from '../../../../components/code-block';
+import {
+  InlineCode,
+  ItemTitle,
+  List,
+  SectionTitle,
+} from '../../../../components/docs-primitives';
+import { monacoComponentsSnippet } from '../constants/monaco-components-snippet';
+
+export const MonacoSubpackageApiSection: React.FC = () => (
+  <>
+    <SectionTitle>Monaco subpackage</SectionTitle>
+    <CodeBlock
+      code={monacoComponentsSnippet}
+      language="tsx"
+      label="createMonacoComponents"
+    />
+    <List>
+      <li>
+        <ItemTitle>
+          <InlineCode>@vojtechportes/react-query-builder/monaco</InlineCode>:
+        </ItemTitle>{' '}
+        Exports <InlineCode>createMonacoComponents</InlineCode>,{' '}
+        <InlineCode>createMonacoComponentSet</InlineCode>, and{' '}
+        <InlineCode>MonacoTextModeEditor</InlineCode>.
+      </li>
+      <li>
+        <ItemTitle>Peer dependency:</ItemTitle>{' '}
+        <InlineCode>monaco-editor</InlineCode> is optional and only required
+        when you use that subpackage.
+      </li>
+      <li>
+        <ItemTitle>When to use it:</ItemTitle> Prefer it when text mode must
+        preserve locked rules or groups through protected editor ranges.
+      </li>
+      <li>
+        <ItemTitle>Protected ranges:</ItemTitle> Monaco text mode can render
+        locked SQL fragments as dimmed protected ranges with hover messaging
+        while still allowing edits around them.
+      </li>
+    </List>
+  </>
+);

--- a/example/src/v2/pages/api-page/components/overview-api-content.tsx
+++ b/example/src/v2/pages/api-page/components/overview-api-content.tsx
@@ -1,0 +1,48 @@
+import * as React from 'react';
+import { AlertBox } from '../../../../components/alert-box';
+import {
+  InlineCode,
+  ItemTitle,
+  List,
+  TextLink,
+} from '../../../../components/docs-primitives';
+
+export const OverviewApiContent: React.FC = () => (
+  <>
+    <List>
+      <li>
+        <ItemTitle>Core API:</ItemTitle> <InlineCode>Builder</InlineCode>,{' '}
+        <InlineCode>Fields</InlineCode>, and <InlineCode>Data</InlineCode>.
+      </li>
+      <li>
+        <ItemTitle>Editing state:</ItemTitle> <InlineCode>Builder</InlineCode>{' '}
+        also exposes history-related state such as{' '}
+        <InlineCode>canUndo</InlineCode> and <InlineCode>canRedo</InlineCode>{' '}
+        through <InlineCode>onStateChange</InlineCode>.
+      </li>
+      <li>
+        <ItemTitle>Imperative control:</ItemTitle>{' '}
+        <InlineCode>useBuilderRef</InlineCode> and{' '}
+        <InlineCode>IBuilderRef</InlineCode> expose builder actions through a
+        React ref.
+      </li>
+      <li>
+        <ItemTitle>Customization:</ItemTitle>{' '}
+        <InlineCode>Components</InlineCode>, <InlineCode>Adapters</InlineCode>,
+        and <InlineCode>Theming</InlineCode>, including packaged adapters for
+        MUI, ANTD, Bootstrap, Mantine, Fluent UI, and Radix.
+      </li>
+      <li>
+        <ItemTitle>Query Conversion:</ItemTitle>{' '}
+        <InlineCode>formatQuery</InlineCode> and{' '}
+        <InlineCode>parseQuery</InlineCode>.
+      </li>
+    </List>
+    <AlertBox title="Documentation and demo" variant="info">
+      Use <TextLink to="/documentation">Documentation</TextLink> for setup,
+      usage, and format walkthroughs. Use <TextLink to="/demo">Demo</TextLink>{' '}
+      for the live sandbox. Use API pages for exact signatures, props, and
+      option meanings.
+    </AlertBox>
+  </>
+);

--- a/example/src/v2/pages/api-page/components/parse-query-api-content.tsx
+++ b/example/src/v2/pages/api-page/components/parse-query-api-content.tsx
@@ -1,0 +1,100 @@
+import * as React from 'react';
+import { AlertBox } from '../../../../components/alert-box';
+import { CodeBlock } from '../../../../components/code-block';
+import {
+  InlineCode,
+  ItemTitle,
+  List,
+  SectionTitle,
+  TextLink,
+} from '../../../../components/docs-primitives';
+import { parseQuerySignature } from '../constants/parse-query-signature';
+import { parseResultSignature } from '../constants/parse-result-signature';
+import { queryFormatSignature } from '../constants/query-format-signature';
+import { parseQueryFieldComparisonSnippet } from '../constants/parse-query-field-comparison-snippet';
+
+export const ParseQueryApiContent: React.FC = () => (
+  <>
+    <CodeBlock
+      code={parseQuerySignature}
+      language="ts"
+      label="parseQuery signature"
+    />
+    <CodeBlock
+      code={queryFormatSignature}
+      language="ts"
+      label="Supported formats"
+    />
+    <CodeBlock code={parseResultSignature} language="ts" label="Parse result" />
+    <SectionTitle>Parameters</SectionTitle>
+    <List>
+      <li>
+        <ItemTitle>
+          <InlineCode>value</InlineCode>:
+        </ItemTitle>{' '}
+        The input string to parse.
+      </li>
+      <li>
+        <ItemTitle>
+          <InlineCode>format</InlineCode>:
+        </ItemTitle>{' '}
+        The source syntax. Parsing behavior is selected entirely from this
+        value.
+      </li>
+    </List>
+    <SectionTitle>Return value</SectionTitle>
+    <List>
+      <li>
+        <ItemTitle>
+          <InlineCode>fields</InlineCode>:
+        </ItemTitle>{' '}
+        <TextLink to="/api/fields">Field metadata</TextLink> inferred by the
+        parser where possible. Some parsers can infer types and operator sets
+        from the source expression.
+      </li>
+      <li>
+        <ItemTitle>
+          <InlineCode>data</InlineCode>:
+        </ItemTitle>{' '}
+        The <TextLink to="/api/data">denormalized query tree</TextLink> produced
+        from the input string.
+      </li>
+    </List>
+    <SectionTitle>Field comparisons</SectionTitle>
+    <CodeBlock
+      code={parseQueryFieldComparisonSnippet}
+      language="ts"
+      label="Parsing a field-reference rule"
+    />
+    <List>
+      <li>
+        <ItemTitle>Rule shape:</ItemTitle> When the source syntax uses a native
+        right-hand-side field reference, the parsed rule uses{' '}
+        <InlineCode>valueSource: 'field'</InlineCode> plus{' '}
+        <InlineCode>valueField</InlineCode>.
+      </li>
+      <li>
+        <ItemTitle>Supported native parsing:</ItemTitle>{' '}
+        <InlineCode>SQL</InlineCode>, <InlineCode>Mongo</InlineCode>,{' '}
+        <InlineCode>AQL</InlineCode>, <InlineCode>JSONata</InlineCode>,{' '}
+        <InlineCode>JsonLogic</InlineCode>, <InlineCode>CEL</InlineCode>,{' '}
+        <InlineCode>SpEL</InlineCode>, <InlineCode>Prisma</InlineCode>,{' '}
+        <InlineCode>OData</InlineCode>, <InlineCode>Dynamo</InlineCode>, and{' '}
+        <InlineCode>Django</InlineCode> can infer field comparisons from
+        builder-compatible expressions.
+      </li>
+      <li>
+        <ItemTitle>Guardrails:</ItemTitle> Unsupported or ambiguous shapes fail
+        explicitly rather than being guessed as field references, including the
+        intentionally unsupported <InlineCode>RSQL</InlineCode> and{' '}
+        <InlineCode>Elasticsearch</InlineCode> cases.
+      </li>
+    </List>
+    <AlertBox title="Documentation" variant="info">
+      <TextLink to="/documentation/parsing-and-formatting">
+        Parsing and Formatting
+      </TextLink>
+      .
+    </AlertBox>
+  </>
+);

--- a/example/src/v2/pages/api-page/components/theming-api-content.tsx
+++ b/example/src/v2/pages/api-page/components/theming-api-content.tsx
@@ -1,0 +1,68 @@
+import * as React from 'react';
+import { AlertBox } from '../../../../components/alert-box';
+import { CodeBlock } from '../../../../components/code-block';
+import {
+  InlineCode,
+  ItemTitle,
+  List,
+  SectionTitle,
+  TextLink,
+} from '../../../../components/docs-primitives';
+import { themeProviderSignature } from '../constants/theme-provider-signature';
+import { colorsSignature } from '../constants/colors-signature';
+
+export const ThemingApiContent: React.FC = () => (
+  <>
+    <CodeBlock
+      code={themeProviderSignature}
+      language="ts"
+      label="ThemeProvider"
+    />
+    <CodeBlock code={colorsSignature} language="ts" label="Color types" />
+    <SectionTitle>Props</SectionTitle>
+    <List>
+      <li>
+        <ItemTitle>
+          <InlineCode>colors</InlineCode>:
+        </ItemTitle>{' '}
+        Optional partial replacement source for theme color values provided
+        through context.
+      </li>
+      <li>
+        <ItemTitle>
+          <InlineCode>children</InlineCode>:
+        </ItemTitle>{' '}
+        Optional React subtree that receives the theme context.
+      </li>
+      <li>
+        <ItemTitle>
+          <InlineCode>colors.primary</InlineCode> and{' '}
+          <InlineCode>colors.secondary</InlineCode>:
+        </ItemTitle>{' '}
+        Color variants used by primary and secondary action surfaces.
+      </li>
+      <li>
+        <ItemTitle>
+          <InlineCode>colors.grey</InlineCode>:
+        </ItemTitle>{' '}
+        Neutral palette used for borders, text, backgrounds, and control states.
+      </li>
+      <li>
+        <ItemTitle>
+          <InlineCode>colors.white</InlineCode>:
+        </ItemTitle>{' '}
+        Surface color used by builder containers and controls.
+      </li>
+      <li>
+        <ItemTitle>Adapter note:</ItemTitle>{' '}
+        <InlineCode>ThemeProvider</InlineCode> affects the built-in default
+        components. If a packaged adapter is used instead, these tokens do not
+        theme the adapter UI.
+      </li>
+    </List>
+    <AlertBox title="Documentation" variant="info">
+      <TextLink to="/documentation/theming">Theming</TextLink> and{' '}
+      <TextLink to="/documentation/adapters">Adapters</TextLink>.
+    </AlertBox>
+  </>
+);

--- a/example/src/v2/pages/api-page/constants/antd-adapter-snippet.ts
+++ b/example/src/v2/pages/api-page/constants/antd-adapter-snippet.ts
@@ -1,0 +1,8 @@
+export const antdAdapterSnippet = `import { components } from '@vojtechportes/react-query-builder/antd/v6';
+
+<Builder
+  fields={fields}
+  data={data}
+  components={components}
+  onChange={setData}
+/>;`;

--- a/example/src/v2/pages/api-page/constants/antd-create-components-snippet.ts
+++ b/example/src/v2/pages/api-page/constants/antd-create-components-snippet.ts
@@ -1,0 +1,28 @@
+export const antdCreateComponentsSnippet = `import {
+  Builder,
+  type DenormalizedQuery,
+} from '@vojtechportes/react-query-builder';
+import {
+  createAntdComponents,
+  components as antdComponents,
+} from '@vojtechportes/react-query-builder/antd/v6';
+
+const components = createAntdComponents(antdComponents, {
+  form: {
+    Input: MyInput,
+  },
+  Add: MyAddButton,
+});
+
+export const MyAntdBuilder = () => {
+  const [data, setData] = useState<DenormalizedQuery>(initialData);
+
+  return (
+    <Builder
+      fields={fields}
+      data={data}
+      components={components}
+      onChange={setData}
+    />
+  );
+};`;

--- a/example/src/v2/pages/api-page/constants/antd-v5-snippet.ts
+++ b/example/src/v2/pages/api-page/constants/antd-v5-snippet.ts
@@ -1,0 +1,1 @@
+export const antdV5Snippet = `import { components } from '@vojtechportes/react-query-builder/antd/v5';`;

--- a/example/src/v2/pages/api-page/constants/api-baseline.ts
+++ b/example/src/v2/pages/api-page/constants/api-baseline.ts
@@ -1,0 +1,98 @@
+export const apiBaseline = [
+  {
+    path: '/api',
+    title: 'API Overview',
+    contentHash:
+      '26b3df4cfdbf60bbd6b6d01340770c742cca1843dac902a021710b997971a14f',
+  },
+  {
+    path: '/api/builder',
+    title: 'Builder',
+    contentHash:
+      '0d672433f0508771a61ec61b0feaef7bb6392980dcc0068ec24004f94f256874',
+  },
+  {
+    path: '/api/builder-ref',
+    title: 'Builder Ref',
+    contentHash:
+      'f8e2fa7a4d3ebf3b0986aa21504d646d4205c50e2f7bc4867bc5dc09427d935a',
+  },
+  {
+    path: '/api/fields',
+    title: 'Fields',
+    contentHash:
+      'dd4bee69aea884dd93871ebf6b43ebfabf24317157d2f9b527a9662f07facfa5',
+  },
+  {
+    path: '/api/data',
+    title: 'Data',
+    contentHash:
+      'df216a0b146000d22225af18454481852b47ce222bb4d57a1071d47db0785df8',
+  },
+  {
+    path: '/api/components',
+    title: 'Components',
+    contentHash:
+      'a2c2c72e9ee40eda72e57ef0968a403ca9f1f4e63e88e1402bc24e2789f1134a',
+  },
+  {
+    path: '/api/adapters',
+    title: 'Adapters',
+    contentHash:
+      'c65e0be121685c17fadb4706567c0fce8c1ac6d8244b7c6e625743d0e2d2131f',
+  },
+  {
+    path: '/api/adapters/mui',
+    title: 'MUI',
+    contentHash:
+      '21a901d354a34d00f53b5d5000cffe38f7778720e2de92e9567fb8b11b50d6d5',
+  },
+  {
+    path: '/api/adapters/antd',
+    title: 'ANTD',
+    contentHash:
+      '6e4ca182f47a0aff4c273eea527ac0bc8403b1072cd00a595ca8a6ba8707d3d4',
+  },
+  {
+    path: '/api/adapters/fluentui',
+    title: 'Fluent UI',
+    contentHash:
+      '9199200eef8b5300a81c1ef1b97aaa60d4bf51fff4eeb4bef305456e85cd0e39',
+  },
+  {
+    path: '/api/adapters/mantine',
+    title: 'Mantine',
+    contentHash:
+      '0b8af2c6e902fb802f6d3c5db155abbe5ff016a946387c57272e87b20ec2afd7',
+  },
+  {
+    path: '/api/adapters/bootstrap',
+    title: 'Bootstrap',
+    contentHash:
+      'f588ca36fd5bc3f5844e12d8249177a63923688408e80734377683c398c9de32',
+  },
+  {
+    path: '/api/adapters/radix',
+    title: 'Radix',
+    contentHash:
+      '495f69109cb6361c49b6039a7efea978d4f91231f5f688d88d9bb5c7488ac08c',
+  },
+  {
+    path: '/api/theming',
+    title: 'Theming',
+    contentHash:
+      '9d5cb90f8da7ffdab0a8e80ec778e198a85bbe62a2c14ccbd912b189f1a48dbf',
+  },
+  {
+    path: '/api/format-query',
+    title: 'formatQuery',
+    contentHash:
+      'b12d3427eebcd9a952b80c80953df7a16a6fd4484915acebc898acc922fd146b',
+  },
+  {
+    path: '/api/parse-query',
+    title: 'parseQuery',
+    contentHash:
+      '7d9bbe550fe0b80f1c8c2190f7668adf73dbb8b6775b6f66f8431158ffbcdba9',
+  },
+];

--- a/example/src/v2/pages/api-page/constants/api-groups.ts
+++ b/example/src/v2/pages/api-page/constants/api-groups.ts
@@ -1,0 +1,20 @@
+import type { IApiGroup } from '../types/api-group';
+import { apiPages } from './api-pages';
+
+export const apiGroups: IApiGroup[] = [
+  {
+    key: 'core',
+    title: 'Core API',
+    pages: apiPages.filter((page) => page.sectionKey === 'core'),
+  },
+  {
+    key: 'customization',
+    title: 'Customization',
+    pages: apiPages.filter((page) => page.sectionKey === 'customization'),
+  },
+  {
+    key: 'exports',
+    title: 'Query Conversion',
+    pages: apiPages.filter((page) => page.sectionKey === 'exports'),
+  },
+];

--- a/example/src/v2/pages/api-page/constants/api-pages.tsx
+++ b/example/src/v2/pages/api-page/constants/api-pages.tsx
@@ -1,0 +1,219 @@
+import * as React from 'react';
+import { OverviewApiContent } from '../components/overview-api-content';
+import { BuilderApiContent } from '../components/builder-api-content';
+import { BuilderRefApiContent } from '../components/builder-ref-api-content';
+import { FieldsApiContent } from '../components/fields-api-content';
+import { DataApiContent } from '../components/data-api-content';
+import { ComponentsApiContent } from '../components/components-api-content';
+import { AdaptersApiContent } from '../components/adapters-api-content';
+import { AdaptersMuiApiContent } from '../components/adapters-mui-api-content';
+import { AdaptersAntdApiContent } from '../components/adapters-antd-api-content';
+import { AdaptersFluentuiApiContent } from '../components/adapters-fluentui-api-content';
+import { AdaptersMantineApiContent } from '../components/adapters-mantine-api-content';
+import { AdaptersBootstrapApiContent } from '../components/adapters-bootstrap-api-content';
+import { AdaptersRadixApiContent } from '../components/adapters-radix-api-content';
+import { ThemingApiContent } from '../components/theming-api-content';
+import { FormatQueryApiContent } from '../components/format-query-api-content';
+import { ParseQueryApiContent } from '../components/parse-query-api-content';
+import type { IApiPage } from '../types/api-page';
+
+export const apiPages: IApiPage[] = [
+  {
+    path: '/api',
+    title: 'API Overview',
+    sectionKey: 'overview',
+    sectionTitle: 'API',
+    summary: '',
+    description:
+      'API overview covering core builder types, customization points, and query conversion exports.',
+    searchText:
+      'API overview builder props fields data components adapters bootstrap formatQuery parseQuery exports types shapes reference',
+    content: <OverviewApiContent />,
+  },
+  {
+    path: '/api/builder',
+    title: 'Builder',
+    sectionKey: 'core',
+    sectionTitle: 'Core API',
+    summary: '',
+    description:
+      'Builder component API reference for IBuilderProps, controlled data flow, validation, editing options, and field-to-field comparisons.',
+    searchText:
+      'Builder component IBuilderProps onChange controlled component defaults strings components validator history state change undo redo canUndo canRedo newNodePlacement append prepend allowFieldComparisons field comparison valueSource valueField',
+    content: <BuilderApiContent />,
+  },
+  {
+    path: '/api/builder-ref',
+    title: 'Builder Ref',
+    sectionKey: 'core',
+    sectionTitle: 'Core API',
+    summary: '',
+    description:
+      'API reference for useBuilderRef, IBuilderRef, and the imperative builder methods for node operations and history access.',
+    searchText:
+      'useBuilderRef useBuilderRuleDependencies bindRuleOptions IBuilderRef BuilderRef BuilderRefListener BuilderRuleDependenciesListener imperative ref subscribe subscribeToRuleDependencies cloneNode deleteNode replaceNode updateNode insertNodes addNode addGroup addRule moveNode setNodeLock lockNode unlockNode getNodeById getNearestField getNodes getData getHistory setHistory undo redo isFieldInUse getFieldOptionState getRuleOptionState setFieldOptions setRuleOptions setFieldOptionsStatus setRuleOptionsStatus invalidateFieldOptions invalidateRuleOptions reloadFieldOptions reloadRuleOptions clearFieldOptions clearRuleOptions',
+    content: <BuilderRefApiContent />,
+  },
+  {
+    path: '/api/fields',
+    title: 'Fields',
+    sectionKey: 'core',
+    sectionTitle: 'Core API',
+    summary: '',
+    description:
+      'Field definition API reference for IBuilderFieldProps, field types, operators, usageLimit, validation metadata, and field-comparison configuration.',
+    searchText:
+      'IBuilderFieldProps field label type value operators usageLimit validation fieldComparison comparableFields BOOLEAN TEXT DATE NUMBER STATEMENT LIST MULTI_LIST GROUP BuilderFieldOption BuilderFieldOptionsStatus IBuilderFieldOptionState INearestFieldMatch IBuilderFieldChange dynamic field options',
+    content: <FieldsApiContent />,
+  },
+  {
+    path: '/api/data',
+    title: 'Data',
+    sectionKey: 'core',
+    sectionTitle: 'Core API',
+    summary: '',
+    description:
+      'Query data API reference for denormalized rule and group shapes, literal versus field-reference values, and read-only semantics.',
+    searchText:
+      'DenormalizedQuery DenormalizedNode IDenormalizedRuleNode IDenormalizedGroupNode QueryRuleValue QueryRuleValueSource valueSource valueField QueryGroupValue readOnly id parent',
+    content: <DataApiContent />,
+  },
+  {
+    path: '/api/components',
+    title: 'Components',
+    sectionKey: 'customization',
+    sectionTitle: 'Customization',
+    summary: '',
+    description:
+      'Component override API reference for replacing built-in builder controls, containers, and popovers.',
+    searchText:
+      'IBuilderComponentsProps Select SelectMulti Switch Input Remove Add Rule Group GroupHeaderOption Text DropZone EmptyGroupDropZone Popover PopoverItem',
+    content: <ComponentsApiContent />,
+  },
+  {
+    path: '/api/adapters',
+    title: 'Adapters',
+    sectionKey: 'customization',
+    sectionTitle: 'Customization',
+    summary: '',
+    description:
+      'API overview for packaged UI adapter entrypoints, shared exports, and how adapters map onto the components override surface.',
+    searchText:
+      'Adapters API mui material ui antd ant design bootstrap mantine fluent ui radix themes components object adapter entrypoints customization shared exports',
+    content: <AdaptersApiContent />,
+  },
+  {
+    path: '/api/adapters/mui',
+    title: 'MUI',
+    depth: 1,
+    sectionKey: 'customization',
+    sectionTitle: 'Customization',
+    summary: '',
+    description:
+      'API reference for the Material UI adapter entrypoints, exports, and createMuiComponents helper.',
+    searchText:
+      'MUI adapter API material ui mui v9 mui v7 createMuiComponents components',
+    content: <AdaptersMuiApiContent />,
+  },
+  {
+    path: '/api/adapters/antd',
+    title: 'ANTD',
+    depth: 1,
+    sectionKey: 'customization',
+    sectionTitle: 'Customization',
+    summary: '',
+    description:
+      'API reference for the Ant Design adapter entrypoints, exports, and createAntdComponents helper.',
+    searchText:
+      'ANTD adapter API ant design antd v6 antd v5 createAntdComponents components',
+    content: <AdaptersAntdApiContent />,
+  },
+  {
+    path: '/api/adapters/fluentui',
+    title: 'Fluent UI',
+    depth: 1,
+    sectionKey: 'customization',
+    sectionTitle: 'Customization',
+    summary: '',
+    description:
+      'API reference for the Fluent UI adapter entrypoint, exports, and createFluentUiComponents helper.',
+    searchText:
+      'Fluent UI adapter API fluentui v8 createFluentUiComponents components',
+    content: <AdaptersFluentuiApiContent />,
+  },
+  {
+    path: '/api/adapters/mantine',
+    title: 'Mantine',
+    depth: 1,
+    sectionKey: 'customization',
+    sectionTitle: 'Customization',
+    summary: '',
+    description:
+      'API reference for the Mantine adapter entrypoints, exports, and createMantineComponents helper.',
+    searchText:
+      'Mantine adapter API mantine v9 mantine v8 createMantineComponents components',
+    content: <AdaptersMantineApiContent />,
+  },
+  {
+    path: '/api/adapters/bootstrap',
+    title: 'Bootstrap',
+    depth: 1,
+    sectionKey: 'customization',
+    sectionTitle: 'Customization',
+    summary: '',
+    description:
+      'API reference for the Bootstrap adapter entrypoint, exports, and createBootstrapComponents helper.',
+    searchText:
+      'Bootstrap adapter API bootstrap v5 createBootstrapComponents components',
+    content: <AdaptersBootstrapApiContent />,
+  },
+  {
+    path: '/api/adapters/radix',
+    title: 'Radix',
+    depth: 1,
+    sectionKey: 'customization',
+    sectionTitle: 'Customization',
+    summary: '',
+    description:
+      'API reference for the Radix Themes adapter entrypoint, exports, and createRadixComponents helper.',
+    searchText:
+      'Radix adapter API radix themes radix v1 createRadixComponents components',
+    content: <AdaptersRadixApiContent />,
+  },
+  {
+    path: '/api/theming',
+    title: 'Theming',
+    sectionKey: 'customization',
+    sectionTitle: 'Customization',
+    summary: '',
+    description:
+      'Theming API reference for ThemeProvider, IThemeProviderProps, IColors, and exported color tokens.',
+    searchText:
+      'ThemeProvider IThemeProviderProps IThemeProps IColors colors primary secondary grey white theme customization',
+    content: <ThemingApiContent />,
+  },
+  {
+    path: '/api/format-query',
+    title: 'formatQuery',
+    sectionKey: 'exports',
+    sectionTitle: 'Query Conversion',
+    summary: '',
+    description:
+      'API reference for formatQuery, including supported formats, shared or format-specific options, and field-to-field serialization behavior.',
+    searchText:
+      'formatQuery signature parameters value format options fields wrapWhereClause wrapFilterClause wrapQueryClause variableName rootlessCombinator modifierlessGroupCombinator field comparison valueSource valueField',
+    content: <FormatQueryApiContent />,
+  },
+  {
+    path: '/api/parse-query',
+    title: 'parseQuery',
+    sectionKey: 'exports',
+    sectionTitle: 'Query Conversion',
+    summary: '',
+    description:
+      'API reference for parseQuery, including supported input formats, the parse result shape, and field-to-field inference.',
+    searchText:
+      'parseQuery signature parameters value format IParseQueryResult fields data QueryFormat field comparison valueSource valueField',
+    content: <ParseQueryApiContent />,
+  },
+];

--- a/example/src/v2/pages/api-page/constants/bootstrap-adapter-snippet.ts
+++ b/example/src/v2/pages/api-page/constants/bootstrap-adapter-snippet.ts
@@ -1,0 +1,10 @@
+export const bootstrapAdapterSnippet = `import 'bootstrap/dist/css/bootstrap.min.css';
+import 'bootstrap-icons/font/bootstrap-icons.css';
+import { components } from '@vojtechportes/react-query-builder/bootstrap/v5';
+
+<Builder
+  fields={fields}
+  data={data}
+  components={components}
+  onChange={setData}
+/>;`;

--- a/example/src/v2/pages/api-page/constants/bootstrap-create-components-snippet.ts
+++ b/example/src/v2/pages/api-page/constants/bootstrap-create-components-snippet.ts
@@ -1,0 +1,30 @@
+export const bootstrapCreateComponentsSnippet = `import {
+  Builder,
+  type DenormalizedQuery,
+} from '@vojtechportes/react-query-builder';
+import 'bootstrap/dist/css/bootstrap.min.css';
+import 'bootstrap-icons/font/bootstrap-icons.css';
+import {
+  createBootstrapComponents,
+  components as bootstrapComponents,
+} from '@vojtechportes/react-query-builder/bootstrap/v5';
+
+const components = createBootstrapComponents(bootstrapComponents, {
+  form: {
+    Input: MyInput,
+  },
+  Add: MyAddButton,
+});
+
+export const MyBootstrapBuilder = () => {
+  const [data, setData] = useState<DenormalizedQuery>(initialData);
+
+  return (
+    <Builder
+      fields={fields}
+      data={data}
+      components={components}
+      onChange={setData}
+    />
+  );
+};`;

--- a/example/src/v2/pages/api-page/constants/bootstrap-v5-snippet.ts
+++ b/example/src/v2/pages/api-page/constants/bootstrap-v5-snippet.ts
@@ -1,0 +1,1 @@
+export const bootstrapV5Snippet = `import { components } from '@vojtechportes/react-query-builder/bootstrap/v5';`;

--- a/example/src/v2/pages/api-page/constants/builder-field-comparison-snippet.ts
+++ b/example/src/v2/pages/api-page/constants/builder-field-comparison-snippet.ts
@@ -1,0 +1,22 @@
+export const builderFieldComparisonSnippet = `const data: DenormalizedQuery = [
+  {
+    type: 'GROUP',
+    value: 'AND',
+    isNegated: false,
+    children: [
+      {
+        field: 'ORDER_TOTAL',
+        operator: 'LARGER_EQUAL',
+        valueSource: 'field',
+        valueField: 'ORDER_APPROVAL_LIMIT',
+      },
+    ],
+  },
+];
+
+<Builder
+  allowFieldComparisons
+  fields={fields}
+  data={data}
+  onChange={setData}
+/>;`;

--- a/example/src/v2/pages/api-page/constants/builder-ref-signature.ts
+++ b/example/src/v2/pages/api-page/constants/builder-ref-signature.ts
@@ -1,0 +1,125 @@
+export const builderRefSignature = `export interface IBuilderRef {
+  cloneNode: (nodeId: string) => boolean;
+  deleteNode: (nodeId: string) => boolean;
+  replaceNode: (nodeId: string, node: NormalizedNode) => boolean;
+  updateNode: (
+    nodeId: string,
+    updater: (node: NormalizedNode) => NormalizedNode
+  ) => boolean;
+  insertNodes: (
+    nodes: NormalizedQuery,
+    index: number,
+    parentId?: string
+  ) => boolean;
+  addNode: (node: NormalizedNode, parentId?: string, index?: number) => boolean;
+  addGroup: (
+    groupType?: QueryGroupType,
+    parentId?: string,
+    index?: number
+  ) => boolean;
+  addRule: (
+    rule?: Partial<INormalizedRuleNode>,
+    parentId?: string,
+    index?: number
+  ) => boolean;
+  moveNode: (nodeId: string, index: number, parentId?: string) => boolean;
+  setNodeLock: (
+    nodeId: string,
+    state: 'unlocked' | 'self' | 'all'
+  ) => boolean;
+  lockNode: (nodeId: string, state?: 'self' | 'all') => boolean;
+  unlockNode: (nodeId: string) => boolean;
+  getNodeById: (nodeId: string) => NormalizedNode | undefined;
+  getNearestField: (
+    currentNodeId: string,
+    targetFieldName: string
+  ) => INearestFieldMatch | undefined;
+  isFieldInUse: (field: string) => boolean;
+  getFieldOptionState: (field: string) => IBuilderFieldOptionState;
+  getRuleOptionState: (ruleId: string) => IBuilderFieldOptionState;
+  subscribeToFieldOptionState: (
+    field: string,
+    listener: BuilderFieldOptionStateListener
+  ) => () => void;
+  subscribeToRuleOptionState: (
+    ruleId: string,
+    listener: BuilderFieldOptionStateListener
+  ) => () => void;
+  setFieldOptions: (
+    field: string,
+    options:
+      | BuilderFieldOption[]
+      | ((current: BuilderFieldOption[]) => BuilderFieldOption[])
+  ) => void;
+  setRuleOptions: (
+    ruleId: string,
+    options:
+      | BuilderFieldOption[]
+      | ((current: BuilderFieldOption[]) => BuilderFieldOption[])
+  ) => void;
+  setFieldOptionsStatus: (
+    field: string,
+    status: BuilderFieldOptionsStatus
+  ) => void;
+  setRuleOptionsStatus: (
+    ruleId: string,
+    status: BuilderFieldOptionsStatus
+  ) => void;
+  invalidateFieldOptions: (field: string) => void;
+  reloadFieldOptions: (field: string) => void;
+  clearFieldOptions: (field: string) => void;
+  invalidateRuleOptions: (ruleId: string) => void;
+  reloadRuleOptions: (ruleId: string) => void;
+  clearRuleOptions: (ruleId: string) => void;
+  reconcileRuleValueWithOptions: (
+    ruleId: string,
+    config: IBuilderRuleValueReconciliationConfig
+  ) => boolean;
+  getNodes: () => NormalizedQuery;
+  getData: () => DenormalizedQuery;
+  getHistory: () => IBuilderHistoryState;
+  setHistory: (history: IBuilderHistoryState) => void;
+  undo: () => void;
+  redo: () => void;
+}
+
+export type BuilderRefListener = (builder: IBuilderRef | null) => void;
+export type BuilderRuleDependenciesListener = (
+  entries: IBuilderRuleDependencyEntry[]
+) => void;
+export type BuilderFieldDependenciesListener = BuilderRuleDependenciesListener;
+export type BuilderFieldOptionStateListener = (
+  state: IBuilderFieldOptionState
+) => void;
+
+export type BuilderRef = React.MutableRefObject<IBuilderRef | null> & {
+  subscribe: (listener: BuilderRefListener) => () => void;
+  bindRuleOptions: (
+    field: string,
+    config: IBuilderRuleOptionsBindingConfig
+  ) => () => void;
+  subscribeToRuleDependencies: (
+    field: string,
+    dependencyFields: string[],
+    listener: BuilderRuleDependenciesListener
+  ) => () => void;
+  subscribeToFieldDependencies: (
+    field: string,
+    dependencyFields: string[],
+    listener: BuilderFieldDependenciesListener
+  ) => () => void;
+  subscribeToFieldOptionState: (
+    field: string,
+    listener: BuilderFieldOptionStateListener
+  ) => () => void;
+  subscribeToRuleOptionState: (
+    ruleId: string,
+    listener: BuilderFieldOptionStateListener
+  ) => () => void;
+  reconcileRuleValueWithOptions: (
+    ruleId: string,
+    config: IBuilderRuleValueReconciliationConfig
+  ) => boolean;
+};
+
+export const useBuilderRef = (): BuilderRef;`;

--- a/example/src/v2/pages/api-page/constants/builder-rule-dependencies-hook-signature.ts
+++ b/example/src/v2/pages/api-page/constants/builder-rule-dependencies-hook-signature.ts
@@ -1,0 +1,5 @@
+export const builderRuleDependenciesHookSignature = `export const useBuilderRuleDependencies = (
+  builderRef: BuilderRef,
+  field: string,
+  dependencyFields: string[]
+): IBuilderRuleDependencyEntry[];`;

--- a/example/src/v2/pages/api-page/constants/builder-rule-options-binding-signature.ts
+++ b/example/src/v2/pages/api-page/constants/builder-rule-options-binding-signature.ts
@@ -1,0 +1,26 @@
+export const builderRuleOptionsBindingSignature = `export interface IBuilderRuleOptionsResolverContext {
+  ruleId: string;
+  field: string;
+  dependencies: Record<string, INearestFieldMatch | undefined>;
+  signal: AbortSignal;
+}
+
+export interface IBuilderRuleOptionsBindingConfig {
+  dependencies: string[];
+  resolve: (
+    context: IBuilderRuleOptionsResolverContext
+  ) => Promise<BuilderFieldOption[]>;
+  onError?: (
+    error: unknown,
+    context: Omit<IBuilderRuleOptionsResolverContext, 'signal'>
+  ) => void;
+  onOptionsResolved?: (
+    context: {
+      ruleId: string;
+      field: string;
+      dependencies: Record<string, INearestFieldMatch | undefined>;
+      options: BuilderFieldOption[];
+    }
+  ) => void;
+  clearOnMissingDependencies?: boolean;
+}`;

--- a/example/src/v2/pages/api-page/constants/builder-signature.ts
+++ b/example/src/v2/pages/api-page/constants/builder-signature.ts
@@ -1,0 +1,26 @@
+export const builderSignature = `export interface IBuilderProps {
+  fields: IBuilderFieldProps[];
+  data: DenormalizedQuery;
+  components?: IBuilderComponentsProps;
+  strings?: IStrings;
+  textMode?: boolean | IBuilderTextModeConfig;
+  defaultMode?: BuilderDefaultMode;
+  readOnly?: boolean;
+  readOnlyProtectsDelete?: boolean;
+  lockable?: boolean;
+  cloneable?: boolean;
+  draggable?: boolean;
+  allowGroupNegation?: boolean;
+  allowFieldComparisons?: boolean;
+  singleRootGroup?: boolean;
+  groupTypes?: 'with-modifiers' | 'without-modifiers' | 'both';
+  newNodePlacement?: 'append' | 'prepend';
+  validator?: IBuilderValidator;
+  onStateChange?: (state: IBuilderStateChange) => void;
+  onFieldOptionsReload?: (field: string) => void;
+  onRuleOptionsReload?: (ruleId: string) => void;
+  onFieldChange?: (change: IBuilderFieldChange) => void;
+  showValidation?: boolean;
+  history?: boolean | IBuilderHistoryConfig;
+  onChange?: (data: DenormalizedQuery) => any;
+}`;

--- a/example/src/v2/pages/api-page/constants/clone-button-signature.ts
+++ b/example/src/v2/pages/api-page/constants/clone-button-signature.ts
@@ -1,0 +1,8 @@
+export const cloneButtonSignature = `export interface ICloneButtonProps {
+  nodeType: 'rule' | 'group';
+  disabled?: boolean;
+  onClick?: () => void;
+  className?: string;
+  title?: string;
+  'data-test'?: string;
+}`;

--- a/example/src/v2/pages/api-page/constants/colors-signature.ts
+++ b/example/src/v2/pages/api-page/constants/colors-signature.ts
@@ -1,0 +1,27 @@
+export const colorsSignature = `export interface IColorVariant {
+  light: string;
+  dark: string;
+  default: string;
+  contrastText: string;
+}
+
+export interface IGreyColorVariant {
+  100: string;
+  200: string;
+  300: string;
+  400: string;
+  500: string;
+  600: string;
+  700: string;
+  800: string;
+  900: string;
+}
+
+export interface IColors {
+  primary: IColorVariant;
+  secondary: IColorVariant;
+  grey: IGreyColorVariant;
+  white: string;
+}
+
+export const colors: IColors;`;

--- a/example/src/v2/pages/api-page/constants/components-signature.ts
+++ b/example/src/v2/pages/api-page/constants/components-signature.ts
@@ -1,0 +1,26 @@
+export const componentsSignature = `export interface IBuilderComponentsProps {
+  Alert?: React.ComponentType<IAlertProps>;
+  form?: {
+    Select?: React.ComponentType<ISelectProps>;
+    SelectMulti?: React.ComponentType<ISelectMultiProps>;
+    Switch?: React.ComponentType<ISwitchProps>;
+    Input?: React.ComponentType<IInputProps>;
+  };
+  Remove?: React.ComponentType<IButtonProps>;
+  Add?: React.ComponentType<IButtonProps>;
+  OutlinedButton?: React.ComponentType<IButtonProps>;
+  TextModeToggleContent?: React.ComponentType<ITextModeToggleContentProps>;
+  TextModeEditor?: React.ComponentType<ITextModeEditorProps>;
+  TextModeInput?: React.ComponentType<ITextModeInputProps>;
+  CloneButton?: React.ComponentType<ICloneButtonProps>;
+  LockToggle?: React.ComponentType<ILockToggleProps>;
+  HistoryControls?: React.ComponentType<IHistoryControlsProps>;
+  Rule?: React.ComponentType<IRuleContainerProps>;
+  Group?: React.ComponentType<IGroupContainerProps>;
+  GroupHeaderOption?: React.ComponentType<IGroupHeaderOptionProps>;
+  Text?: React.ComponentType<React.ComponentProps<typeof Text>>;
+  DropZone?: React.ComponentType<IDropZoneProps>;
+  EmptyGroupDropZone?: React.ComponentType<IEmptyGroupDropZoneProps>;
+  Popover?: React.ComponentType<IPopoverProps>;
+  PopoverItem?: React.ComponentType<IPopoverItemProps>;
+}`;

--- a/example/src/v2/pages/api-page/constants/data-field-comparison-snippet.ts
+++ b/example/src/v2/pages/api-page/constants/data-field-comparison-snippet.ts
@@ -1,0 +1,6 @@
+export const dataFieldComparisonSnippet = `const rule: IDenormalizedRuleNode = {
+  field: 'ORDER_TOTAL',
+  operator: 'LARGER_EQUAL',
+  valueSource: 'field',
+  valueField: 'ORDER_APPROVAL_LIMIT',
+};`;

--- a/example/src/v2/pages/api-page/constants/field-base-signature.ts
+++ b/example/src/v2/pages/api-page/constants/field-base-signature.ts
@@ -1,0 +1,10 @@
+export const fieldBaseSignature = `interface IBuilderFieldBase<TType, TValue, TValidation> {
+  field: string;
+  label: string;
+  value?: TValue;
+  type: TType;
+  operators?: BuilderFieldOperator[];
+  usageLimit?: IBuilderFieldUsageLimit;
+  validation?: TValidation;
+  fieldComparison?: IBuilderFieldComparisonConfig;
+}`;

--- a/example/src/v2/pages/api-page/constants/field-comparison-config-signature.ts
+++ b/example/src/v2/pages/api-page/constants/field-comparison-config-signature.ts
@@ -1,0 +1,10 @@
+export const fieldComparisonConfigSignature = `export type BuilderFieldComparisonType =
+  | 'string'
+  | 'number'
+  | 'date'
+  | 'boolean';
+
+export interface IBuilderFieldComparisonConfig {
+  type?: BuilderFieldComparisonType;
+  comparableFields?: string[];
+}`;

--- a/example/src/v2/pages/api-page/constants/field-option-types-signature.ts
+++ b/example/src/v2/pages/api-page/constants/field-option-types-signature.ts
@@ -1,0 +1,47 @@
+export const fieldOptionTypesSignature = `export type BuilderFieldOption = {
+  value: string | number;
+  label: string;
+};
+
+export type BuilderFieldOptionsStatus =
+  | 'idle'
+  | 'loading'
+  | 'success'
+  | 'error';
+
+export interface IBuilderFieldOptionState {
+  options: BuilderFieldOption[];
+  status: BuilderFieldOptionsStatus;
+}
+
+export interface IBuilderRuleValueReconciliationConfig {
+  strategy: 'clear-if-missing';
+}
+
+export interface IBuilderRuleDependencyEntry {
+  ruleId: string;
+  dependencies: Record<string, INearestFieldMatch | undefined>;
+}
+
+export type IBuilderFieldDependencyEntry = IBuilderRuleDependencyEntry;
+
+export interface INearestFieldMatch {
+  nodeId: string;
+  field: string;
+  valueSource?: QueryRuleValueSource;
+  value: QueryRuleValue | undefined;
+  valueField?: string;
+  operator?: QueryOperator;
+}
+
+export interface IBuilderFieldChange {
+  nodeId: string;
+  field: string;
+  previousValueSource?: QueryRuleValueSource;
+  previousValue: QueryRuleValue | undefined;
+  previousValueField?: string;
+  valueSource?: QueryRuleValueSource;
+  value: QueryRuleValue | undefined;
+  valueField?: string;
+  data: DenormalizedQuery;
+};`;

--- a/example/src/v2/pages/api-page/constants/field-types-signature.ts
+++ b/example/src/v2/pages/api-page/constants/field-types-signature.ts
@@ -1,0 +1,19 @@
+export const fieldTypesSignature = `export type BuilderFieldType =
+  | 'BOOLEAN'
+  | 'TEXT'
+  | 'DATE'
+  | 'NUMBER'
+  | 'STATEMENT'
+  | 'LIST'
+  | 'MULTI_LIST'
+  | 'GROUP';
+
+export type IBuilderFieldProps =
+  | IBooleanFieldProps
+  | ITextFieldProps
+  | IDateFieldProps
+  | INumberFieldProps
+  | IStatementFieldProps
+  | IListFieldProps
+  | IMultiListFieldProps
+  | IGroupFieldProps;`;

--- a/example/src/v2/pages/api-page/constants/field-usage-limit-signature.ts
+++ b/example/src/v2/pages/api-page/constants/field-usage-limit-signature.ts
@@ -1,0 +1,8 @@
+export const fieldUsageLimitSignature = `export type BuilderFieldUsageLimitScope = 'global' | 'parent';
+
+export interface IBuilderFieldUsageLimit {
+  key?: string;
+  max: number;
+  scope?: BuilderFieldUsageLimitScope;
+  message?: BuilderValidationMessage;
+}`;

--- a/example/src/v2/pages/api-page/constants/fields-field-comparison-snippet.ts
+++ b/example/src/v2/pages/api-page/constants/fields-field-comparison-snippet.ts
@@ -1,0 +1,22 @@
+export const fieldsFieldComparisonSnippet = `const fields: IBuilderFieldProps[] = [
+  {
+    field: 'CUSTOMER_COUNTRY',
+    label: 'Customer country',
+    type: 'LIST',
+    operators: ['EQUAL'],
+    value: [
+      { value: 'CZ', label: 'Czech Republic' },
+      { value: 'SK', label: 'Slovakia' },
+    ],
+    fieldComparison: {
+      type: 'string',
+      comparableFields: ['DELIVERY_COUNTRY_CODE'],
+    },
+  },
+  {
+    field: 'DELIVERY_COUNTRY_CODE',
+    label: 'Delivery country code',
+    type: 'TEXT',
+    operators: ['EQUAL'],
+  },
+];`;

--- a/example/src/v2/pages/api-page/constants/fluent-ui-adapter-snippet.ts
+++ b/example/src/v2/pages/api-page/constants/fluent-ui-adapter-snippet.ts
@@ -1,0 +1,8 @@
+export const fluentUiAdapterSnippet = `import { components } from '@vojtechportes/react-query-builder/fluentui/v8';
+
+<Builder
+  fields={fields}
+  data={data}
+  components={components}
+  onChange={setData}
+/>;`;

--- a/example/src/v2/pages/api-page/constants/fluent-ui-create-components-snippet.ts
+++ b/example/src/v2/pages/api-page/constants/fluent-ui-create-components-snippet.ts
@@ -1,0 +1,28 @@
+export const fluentUiCreateComponentsSnippet = `import {
+  Builder,
+  type DenormalizedQuery,
+} from '@vojtechportes/react-query-builder';
+import {
+  createFluentUiComponents,
+  components as fluentUiComponents,
+} from '@vojtechportes/react-query-builder/fluentui/v8';
+
+const components = createFluentUiComponents(fluentUiComponents, {
+  form: {
+    Input: MyInput,
+  },
+  Add: MyAddButton,
+});
+
+export const MyFluentUiBuilder = () => {
+  const [data, setData] = useState<DenormalizedQuery>(initialData);
+
+  return (
+    <Builder
+      fields={fields}
+      data={data}
+      components={components}
+      onChange={setData}
+    />
+  );
+};`;

--- a/example/src/v2/pages/api-page/constants/fluent-ui-v8-snippet.ts
+++ b/example/src/v2/pages/api-page/constants/fluent-ui-v8-snippet.ts
@@ -1,0 +1,1 @@
+export const fluentUiV8Snippet = `import { components } from '@vojtechportes/react-query-builder/fluentui/v8';`;

--- a/example/src/v2/pages/api-page/constants/format-options-signature.ts
+++ b/example/src/v2/pages/api-page/constants/format-options-signature.ts
@@ -1,0 +1,26 @@
+export const formatOptionsSignature = `export interface IFormatQueryBaseOptions {
+  rootlessCombinator?: 'AND' | 'OR';
+  modifierlessGroupCombinator?: 'AND' | 'OR';
+  fields?: IBuilderFieldProps[];
+}
+
+export interface IFormatSqlOptions extends IFormatQueryBaseOptions {
+  wrapWhereClause?: boolean;
+}
+
+export interface IFormatAqlOptions extends IFormatQueryBaseOptions {
+  wrapFilterClause?: boolean;
+  variableName?: string;
+}
+
+export interface IFormatElasticsearchOptions extends IFormatQueryBaseOptions {
+  wrapQueryClause?: boolean;
+}
+
+export interface IFormatPrismaOptions extends IFormatQueryBaseOptions {
+  wrapWhereClause?: boolean;
+}
+
+export interface IFormatODataOptions extends IFormatQueryBaseOptions {
+  wrapFilterClause?: boolean;
+}`;

--- a/example/src/v2/pages/api-page/constants/format-query-field-comparison-snippet.ts
+++ b/example/src/v2/pages/api-page/constants/format-query-field-comparison-snippet.ts
@@ -1,0 +1,6 @@
+export const formatQueryFieldComparisonSnippet = `const sql = formatQuery(data, 'SQL', {
+  fields,
+  wrapWhereClause: true,
+});
+
+// WHERE ORDER_TOTAL >= ORDER_APPROVAL_LIMIT`;

--- a/example/src/v2/pages/api-page/constants/format-query-signature.ts
+++ b/example/src/v2/pages/api-page/constants/format-query-signature.ts
@@ -1,0 +1,18 @@
+export const formatQuerySignature = `export const formatQuery = (
+  value: DenormalizedQuery,
+  format: QueryFormat,
+  options?:
+    | IFormatSqlOptions
+    | IFormatMongoOptions
+    | IFormatAqlOptions
+    | IFormatJsonataOptions
+    | IFormatJsonLogicOptions
+    | IFormatCelOptions
+    | IFormatDjangoOptions
+    | IFormatDynamoOptions
+    | IFormatElasticsearchOptions
+    | IFormatSpelOptions
+    | IFormatPrismaOptions
+    | IFormatODataOptions
+    | IFormatRsqlOptions
+) => string;`;

--- a/example/src/v2/pages/api-page/constants/history-config-signature.ts
+++ b/example/src/v2/pages/api-page/constants/history-config-signature.ts
@@ -1,0 +1,4 @@
+export const historyConfigSignature = `export interface IBuilderHistoryConfig {
+  maxEntries?: number;
+  controls?: boolean;
+}`;

--- a/example/src/v2/pages/api-page/constants/history-controls-signature.ts
+++ b/example/src/v2/pages/api-page/constants/history-controls-signature.ts
@@ -1,0 +1,9 @@
+export const historyControlsSignature = `export interface IHistoryControlsProps {
+  undoButton: React.ReactNode;
+  redoButton: React.ReactNode;
+  canUndo: boolean;
+  canRedo: boolean;
+  onUndo: () => void;
+  onRedo: () => void;
+  className?: string;
+}`;

--- a/example/src/v2/pages/api-page/constants/lock-toggle-signature.ts
+++ b/example/src/v2/pages/api-page/constants/lock-toggle-signature.ts
@@ -1,0 +1,11 @@
+export const lockToggleSignature = `export type BuilderLockState = 'unlocked' | 'self' | 'all';
+
+export interface ILockToggleProps {
+  state: BuilderLockState;
+  nodeType: 'rule' | 'group';
+  disabled?: boolean;
+  onChange?: (nextState: BuilderLockState) => void;
+  className?: string;
+  title?: string;
+  'data-test'?: string;
+}`;

--- a/example/src/v2/pages/api-page/constants/mantine-adapter-snippet.ts
+++ b/example/src/v2/pages/api-page/constants/mantine-adapter-snippet.ts
@@ -1,0 +1,12 @@
+export const mantineAdapterSnippet = `import '@mantine/core/styles.css';
+import { MantineProvider } from '@mantine/core';
+import { components } from '@vojtechportes/react-query-builder/mantine/v9';
+
+<MantineProvider>
+  <Builder
+    fields={fields}
+    data={data}
+    components={components}
+    onChange={setData}
+  />
+</MantineProvider>;`;

--- a/example/src/v2/pages/api-page/constants/mantine-create-components-snippet.ts
+++ b/example/src/v2/pages/api-page/constants/mantine-create-components-snippet.ts
@@ -1,0 +1,32 @@
+export const mantineCreateComponentsSnippet = `import {
+  Builder,
+  type DenormalizedQuery,
+} from '@vojtechportes/react-query-builder';
+import '@mantine/core/styles.css';
+import { MantineProvider } from '@mantine/core';
+import {
+  createMantineComponents,
+  components as mantineComponents,
+} from '@vojtechportes/react-query-builder/mantine/v9';
+
+const components = createMantineComponents(mantineComponents, {
+  form: {
+    Input: MyInput,
+  },
+  Add: MyAddButton,
+});
+
+export const MyMantineBuilder = () => {
+  const [data, setData] = useState<DenormalizedQuery>(initialData);
+
+  return (
+    <MantineProvider>
+      <Builder
+        fields={fields}
+        data={data}
+        components={components}
+        onChange={setData}
+      />
+    </MantineProvider>
+  );
+};`;

--- a/example/src/v2/pages/api-page/constants/mantine-v8-snippet.ts
+++ b/example/src/v2/pages/api-page/constants/mantine-v8-snippet.ts
@@ -1,0 +1,1 @@
+export const mantineV8Snippet = `import { components } from '@vojtechportes/react-query-builder/mantine/v8';`;

--- a/example/src/v2/pages/api-page/constants/monaco-components-snippet.ts
+++ b/example/src/v2/pages/api-page/constants/monaco-components-snippet.ts
@@ -1,0 +1,12 @@
+export const monacoComponentsSnippet = `import { createMonacoComponents } from '@vojtechportes/react-query-builder/monaco';
+import { components as muiComponents } from '@vojtechportes/react-query-builder/mui/v9';
+
+const components = createMonacoComponents(muiComponents);
+
+<Builder
+  fields={fields}
+  data={data}
+  textMode
+  components={components}
+  onChange={setData}
+/>;`;

--- a/example/src/v2/pages/api-page/constants/mui-adapter-snippet.ts
+++ b/example/src/v2/pages/api-page/constants/mui-adapter-snippet.ts
@@ -1,0 +1,8 @@
+export const muiAdapterSnippet = `import { components } from '@vojtechportes/react-query-builder/mui/v9';
+
+<Builder
+  fields={fields}
+  data={data}
+  components={components}
+  onChange={setData}
+/>;`;

--- a/example/src/v2/pages/api-page/constants/mui-create-components-snippet.ts
+++ b/example/src/v2/pages/api-page/constants/mui-create-components-snippet.ts
@@ -1,0 +1,28 @@
+export const muiCreateComponentsSnippet = `import {
+  Builder,
+  type DenormalizedQuery,
+} from '@vojtechportes/react-query-builder';
+import {
+  createMuiComponents,
+  components as muiComponents,
+} from '@vojtechportes/react-query-builder/mui/v9';
+
+const components = createMuiComponents(muiComponents, {
+  form: {
+    Input: MyInput,
+  },
+  Add: MyAddButton,
+});
+
+export const MyMuiBuilder = () => {
+  const [data, setData] = useState<DenormalizedQuery>(initialData);
+
+  return (
+    <Builder
+      fields={fields}
+      data={data}
+      components={components}
+      onChange={setData}
+    />
+  );
+};`;

--- a/example/src/v2/pages/api-page/constants/mui-v7-snippet.ts
+++ b/example/src/v2/pages/api-page/constants/mui-v7-snippet.ts
@@ -1,0 +1,1 @@
+export const muiV7Snippet = `import { components } from '@vojtechportes/react-query-builder/mui/v7';`;

--- a/example/src/v2/pages/api-page/constants/parse-query-field-comparison-snippet.ts
+++ b/example/src/v2/pages/api-page/constants/parse-query-field-comparison-snippet.ts
@@ -1,0 +1,19 @@
+export const parseQueryFieldComparisonSnippet = `const result = parseQuery(
+  'WHERE ORDER_TOTAL >= ORDER_APPROVAL_LIMIT',
+  'SQL'
+);
+
+console.log(result.data[0]);
+// {
+//   type: 'GROUP',
+//   value: 'AND',
+//   isNegated: false,
+//   children: [
+//     {
+//       field: 'ORDER_TOTAL',
+//       operator: 'LARGER_EQUAL',
+//       valueSource: 'field',
+//       valueField: 'ORDER_APPROVAL_LIMIT',
+//     },
+//   ],
+// }`;

--- a/example/src/v2/pages/api-page/constants/parse-query-signature.ts
+++ b/example/src/v2/pages/api-page/constants/parse-query-signature.ts
@@ -1,0 +1,4 @@
+export const parseQuerySignature = `export const parseQuery = (
+  value: string,
+  format: QueryFormat
+): IParseQueryResult;`;

--- a/example/src/v2/pages/api-page/constants/parse-result-signature.ts
+++ b/example/src/v2/pages/api-page/constants/parse-result-signature.ts
@@ -1,0 +1,4 @@
+export const parseResultSignature = `export interface IParseQueryResult {
+  fields: IBuilderFieldProps[];
+  data: DenormalizedQuery;
+}`;

--- a/example/src/v2/pages/api-page/constants/query-format-signature.ts
+++ b/example/src/v2/pages/api-page/constants/query-format-signature.ts
@@ -1,0 +1,14 @@
+export const queryFormatSignature = `export type QueryFormat =
+  | 'SQL'
+  | 'Mongo'
+  | 'AQL'
+  | 'JSONata'
+  | 'JsonLogic'
+  | 'CEL'
+  | 'Elasticsearch'
+  | 'SpEL'
+  | 'Prisma'
+  | 'OData'
+  | 'RSQL'
+  | 'Dynamo'
+  | 'Django';`;

--- a/example/src/v2/pages/api-page/constants/query-tree-signature.ts
+++ b/example/src/v2/pages/api-page/constants/query-tree-signature.ts
@@ -1,0 +1,59 @@
+export const queryTreeSignature = `export type QueryGroupValue = 'AND' | 'OR';
+export type QueryGroupType = 'with-modifiers' | 'without-modifiers';
+export type GroupReadOnlyTarget = 'negation' | 'combinator';
+export type RuleReadOnlyTarget = 'field' | 'operator' | 'value';
+export type QueryRuleValueSource = 'value' | 'field';
+
+export interface IGroupReadOnlyConfig {
+  enabled: boolean;
+  targets?: GroupReadOnlyTarget[];
+  inheritToChildren?: boolean;
+}
+
+export interface IRuleReadOnlyConfig {
+  enabled: boolean;
+  targets?: RuleReadOnlyTarget[];
+}
+
+export type QueryRuleValue =
+  | string
+  | number
+  | string[]
+  | number[]
+  | boolean;
+
+export interface ILiteralRuleNode {
+  id?: string;
+  parent?: string;
+  field: string;
+  valueSource?: 'value';
+  value?: QueryRuleValue;
+  valueField?: undefined;
+  operator?: QueryOperator;
+  operators?: QueryOperator[];
+  readOnly?: boolean | IRuleReadOnlyConfig;
+}
+
+export interface IFieldReferenceRuleNode {
+  id?: string;
+  parent?: string;
+  field: string;
+  valueSource: 'field';
+  value?: undefined;
+  valueField: string;
+  operator?: QueryOperator;
+  operators?: QueryOperator[];
+  readOnly?: boolean | IRuleReadOnlyConfig;
+}
+
+export type IDenormalizedRuleNode = ILiteralRuleNode | IFieldReferenceRuleNode;
+
+export interface IDenormalizedGroupNodeBase {
+  id?: string;
+  parent?: string;
+  type: 'GROUP';
+  children: DenormalizedNode[];
+  readOnly?: boolean | IGroupReadOnlyConfig;
+}
+
+export type DenormalizedQuery = DenormalizedNode[];`;

--- a/example/src/v2/pages/api-page/constants/radix-adapter-snippet.ts
+++ b/example/src/v2/pages/api-page/constants/radix-adapter-snippet.ts
@@ -1,0 +1,12 @@
+export const radixAdapterSnippet = `import '@radix-ui/themes/styles.css';
+import { Theme } from '@radix-ui/themes';
+import { components } from '@vojtechportes/react-query-builder/radix/v1';
+
+<Theme>
+  <Builder
+    fields={fields}
+    data={data}
+    components={components}
+    onChange={setData}
+  />
+</Theme>;`;

--- a/example/src/v2/pages/api-page/constants/radix-create-components-snippet.ts
+++ b/example/src/v2/pages/api-page/constants/radix-create-components-snippet.ts
@@ -1,0 +1,32 @@
+export const radixCreateComponentsSnippet = `import {
+  Builder,
+  type DenormalizedQuery,
+} from '@vojtechportes/react-query-builder';
+import '@radix-ui/themes/styles.css';
+import { Theme } from '@radix-ui/themes';
+import {
+  createRadixComponents,
+  components as radixComponents,
+} from '@vojtechportes/react-query-builder/radix/v1';
+
+const components = createRadixComponents(radixComponents, {
+  form: {
+    Input: MyInput,
+  },
+  Add: MyAddButton,
+});
+
+export const MyRadixBuilder = () => {
+  const [data, setData] = useState<DenormalizedQuery>(initialData);
+
+  return (
+    <Theme>
+      <Builder
+        fields={fields}
+        data={data}
+        components={components}
+        onChange={setData}
+      />
+    </Theme>
+  );
+};`;

--- a/example/src/v2/pages/api-page/constants/radix-v1-snippet.ts
+++ b/example/src/v2/pages/api-page/constants/radix-v1-snippet.ts
@@ -1,0 +1,1 @@
+export const radixV1Snippet = `import { components } from '@vojtechportes/react-query-builder/radix/v1';`;

--- a/example/src/v2/pages/api-page/constants/related-recipes-by-path.ts
+++ b/example/src/v2/pages/api-page/constants/related-recipes-by-path.ts
@@ -1,0 +1,40 @@
+export const relatedRecipesByPath: Record<
+  string,
+  { path: string; label: string }[]
+> = {
+  '/api/fields': [
+    {
+      path: '/recipes/dynamic-operators-by-field-type',
+      label: 'Dynamic operators by field type',
+    },
+  ],
+  '/api/components': [
+    {
+      path: '/recipes/ag-grid-query-builder',
+      label: 'AG Grid query builder panel',
+    },
+    {
+      path: '/recipes/react-hook-form-query-builder',
+      label: 'React Hook Form integration',
+    },
+  ],
+  '/api/adapters/mui': [
+    {
+      path: '/recipes/mui-datagrid-advanced-filtering',
+      label: 'MUI DataGrid advanced filtering',
+    },
+  ],
+  '/api/format-query': [
+    { path: '/recipes/export-to-mongodb-query', label: 'Export to MongoDB' },
+    {
+      path: '/recipes/export-to-prisma-where-clause',
+      label: 'Export to Prisma',
+    },
+  ],
+  '/api/parse-query': [
+    {
+      path: '/recipes/sql-where-to-react-query-builder',
+      label: 'SQL WHERE to builder data',
+    },
+  ],
+};

--- a/example/src/v2/pages/api-page/constants/text-mode-config-signature.ts
+++ b/example/src/v2/pages/api-page/constants/text-mode-config-signature.ts
@@ -1,0 +1,6 @@
+export const textModeConfigSignature = `export interface IBuilderTextModeConfig {
+  format?: 'SQL';
+  defaultMode?: BuilderDefaultMode;
+}
+
+export type BuilderDefaultMode = 'builder' | 'text';`;

--- a/example/src/v2/pages/api-page/constants/text-mode-editor-signature.ts
+++ b/example/src/v2/pages/api-page/constants/text-mode-editor-signature.ts
@@ -1,0 +1,21 @@
+export const textModeEditorSignature = `export interface ITextModeEditorProps {
+  value: string;
+  diagnostics: ITextModeDiagnostic[];
+  protectedRanges?: ITextModeProtectedRange[];
+  protectedRangesMessage?: string | null;
+  protectedRangeHoverMessage?: string | null;
+  errorMessage: string | null;
+  readOnly?: boolean;
+  onChange: (value: string) => void;
+}
+
+export interface ITextModeInputProps {
+  value: string;
+  onChange: (value: string) => void;
+  className?: string;
+  inputClassName?: string;
+  disabled?: boolean;
+  readOnly?: boolean;
+  spellCheck?: boolean;
+  inputDataTest?: string;
+}`;

--- a/example/src/v2/pages/api-page/constants/theme-provider-signature.ts
+++ b/example/src/v2/pages/api-page/constants/theme-provider-signature.ts
@@ -1,0 +1,9 @@
+export const themeProviderSignature = `export interface IThemeProps {
+  colors?: IColors;
+}
+
+export interface IThemeProviderProps extends IThemeProps {
+  children?: React.ReactNode;
+}
+
+export const ThemeProvider: React.FC<IThemeProviderProps>;`;

--- a/example/src/v2/pages/api-page/types/api-group.ts
+++ b/example/src/v2/pages/api-page/types/api-group.ts
@@ -1,0 +1,7 @@
+import type { IApiPage } from './api-page';
+
+export interface IApiGroup {
+  key: string;
+  title: string;
+  pages: IApiPage[];
+}

--- a/example/src/v2/pages/api-page/types/api-page.ts
+++ b/example/src/v2/pages/api-page/types/api-page.ts
@@ -1,0 +1,13 @@
+import type * as React from 'react';
+
+export interface IApiPage {
+  path: string;
+  title: string;
+  depth?: number;
+  sectionKey: string;
+  sectionTitle: string;
+  summary: string;
+  description: string;
+  searchText: string;
+  content: React.ReactNode;
+}

--- a/example/src/v2/pages/api-page/utils/find-api-page.util.ts
+++ b/example/src/v2/pages/api-page/utils/find-api-page.util.ts
@@ -1,0 +1,7 @@
+import { apiPages } from '../constants/api-pages';
+
+export const findApiPage = (pathname: string) => {
+  const normalizedPath = pathname.replace(/\/+$/, '') || '/';
+
+  return apiPages.find((page) => page.path === normalizedPath) ?? apiPages[0];
+};

--- a/example/src/v2/pages/api-page/utils/hash-api-content.util.ts
+++ b/example/src/v2/pages/api-page/utils/hash-api-content.util.ts
@@ -1,0 +1,10 @@
+export const hashApiContent = async (content: string) => {
+  const digest = await crypto.subtle.digest(
+    'SHA-256',
+    new TextEncoder().encode(content)
+  );
+
+  return Array.from(new Uint8Array(digest), (byte) =>
+    byte.toString(16).padStart(2, '0')
+  ).join('');
+};


### PR DESCRIPTION
- Added v2-owned API pages, signatures, navigation, adapter references, and examples
- Bound documented APIs and adapter entries to the local v2 package target
- Added route, content, SSR, package-binding, and ownership coverage
- Split API content into slim, focused section components
- Preserved v1 API and shared SEO and search inputs