### PR TITLE
feat: Created independent v1 navigation and route manifests

### DIFF
--- a/.codex/TASKS.md
+++ b/.codex/TASKS.md
@@ -1020,7 +1020,7 @@ v1.
 
 ### T022 - Create independent v1 navigation and route manifests
 
-**Status:** `[ ]` Not started
+**Status:** `[x]` Done
 
 **Depends on:** T014, T016, T018, and T020
 

--- a/.codex/t022-create-independent-v1-navigation-and-route-manifests-tasks.md
+++ b/.codex/t022-create-independent-v1-navigation-and-route-manifests-tasks.md
@@ -1,0 +1,12 @@
+# T022 - Create independent v1 navigation and route manifests
+
+- [x] Define granular v1 route/navigation types and public-path utilities.
+- [x] Add canonical, legacy redirect, fallback, breadcrumb, related-link, source-link, top-navigation, and sidebar data from v1-owned registries.
+- [x] Add v1-owned App/AppRoutes and versioned basename wiring.
+- [x] Inject v1-owned navigation into slim shared shell primitives without shared content ownership.
+- [x] Update v1 pages to consume v1 navigation, breadcrumb, and related-link records.
+- [x] Add manifest, prefix, route coverage, navigation, legacy/fallback, source-link, and SSR tests.
+- [x] Run v1 typecheck, tests, and build and resolve regressions.
+- [x] Run Prettier on every modified code file.
+- [x] Complete the required review agent and resolve all findings.
+- [x] Mark T022 done after verification and review.

--- a/example/src/app/app-routes.tsx
+++ b/example/src/app/app-routes.tsx
@@ -2,6 +2,7 @@ import * as React from 'react';
 import { Navigate, Route, Routes } from 'react-router-dom';
 import { SiteShell } from '../components/site-shell';
 import { canonicalSeoPages } from '../constants/seo-pages';
+import { TOP_LEVEL_NAV } from '../constants/site-constants';
 import type { IAppContentPages } from './types/app-content-pages';
 
 const redirects = [
@@ -47,7 +48,17 @@ export const AppRoutes: React.FC<IAppContentPages> = ({
 
   return (
     <Routes>
-      <Route element={<SiteShell />}>
+      <Route
+        element={
+          <SiteShell
+            versionLabel="Docs v1"
+            topNavigation={TOP_LEVEL_NAV.map((item) => ({
+              label: item.label,
+              path: item.to,
+            }))}
+          />
+        }
+      >
         {canonicalSeoPages.map((page) => (
           <Route
             key={page.path}

--- a/example/src/components/site-shell.tsx
+++ b/example/src/components/site-shell.tsx
@@ -2,12 +2,7 @@ import * as React from 'react';
 import styled, { createGlobalStyle } from 'styled-components';
 import { NavLink, Outlet, useLocation } from 'react-router-dom';
 import { colors } from '@vojtechportes/react-query-builder';
-import {
-  GITHUB_URL,
-  NPM_URL,
-  SITE_NAME,
-  TOP_LEVEL_NAV,
-} from '../constants/site-constants';
+import { GITHUB_URL, NPM_URL } from '../constants/site-constants';
 import { siteTheme } from '../constants/site-theme';
 import { CloseIcon, GithubIcon, MenuIcon, NpmIcon } from './icons';
 import { HeaderSearch } from './header-search';
@@ -336,7 +331,15 @@ const Footer = styled.footer`
   }
 `;
 
-export const SiteShell: React.FC = () => {
+export interface ISiteShellProps {
+  versionLabel: string;
+  topNavigation: readonly { label: string; path: string }[];
+}
+
+export const SiteShell: React.FC<ISiteShellProps> = ({
+  versionLabel,
+  topNavigation,
+}) => {
   const [mobileMenuOpen, setMobileMenuOpen] = React.useState(false);
   const location = useLocation();
   const year = new Date().getFullYear();
@@ -361,15 +364,19 @@ export const SiteShell: React.FC = () => {
               <QueryBuilderText>Query Builder</QueryBuilderText>
             </BrandText>
             <VersionBadge aria-label="Documentation version">
-              Docs v1
+              {versionLabel}
             </VersionBadge>
           </Brand>
 
           <Right>
             <DesktopOnly>
               <Nav>
-                {TOP_LEVEL_NAV.map((item) => (
-                  <NavItem key={item.to} to={item.to} end={item.to === '/'}>
+                {topNavigation.map((item) => (
+                  <NavItem
+                    key={item.path}
+                    to={item.path}
+                    end={item.path === '/'}
+                  >
                     {item.label}
                   </NavItem>
                 ))}
@@ -456,8 +463,12 @@ export const SiteShell: React.FC = () => {
             <HeaderSearch />
           </MobileSearchWrap>
           <MobileNav>
-            {TOP_LEVEL_NAV.map((item) => (
-              <MobileNavItem key={item.to} to={item.to} end={item.to === '/'}>
+            {topNavigation.map((item) => (
+              <MobileNavItem
+                key={item.path}
+                to={item.path}
+                end={item.path === '/'}
+              >
                 {item.label}
               </MobileNavItem>
             ))}

--- a/example/src/v1/app/constants/v1-breadcrumb-titles-by-path.ts
+++ b/example/src/v1/app/constants/v1-breadcrumb-titles-by-path.ts
@@ -1,0 +1,12 @@
+import { v1RouteDefinitions } from './v1-route-definitions';
+
+export const v1BreadcrumbTitlesByPath = new Map(
+  v1RouteDefinitions.map(({ path, title }) => [
+    path,
+    path === '/api'
+      ? 'API'
+      : path === '/documentation'
+        ? 'Documentation'
+        : title,
+  ])
+);

--- a/example/src/v1/app/constants/v1-fallback-route.ts
+++ b/example/src/v1/app/constants/v1-fallback-route.ts
@@ -1,0 +1,8 @@
+import type { IV1FallbackRoute } from '../types/v1-fallback-route';
+import { createV1PublicPath } from '../utils/create-v1-public-path.util';
+
+export const v1FallbackRoute: IV1FallbackRoute = {
+  path: '*',
+  to: '/',
+  publicTo: createV1PublicPath('/'),
+};

--- a/example/src/v1/app/constants/v1-legacy-route-redirects.ts
+++ b/example/src/v1/app/constants/v1-legacy-route-redirects.ts
@@ -1,0 +1,33 @@
+import type { IV1RouteRedirect } from '../types/v1-route-redirect';
+import { createV1PublicPath } from '../utils/create-v1-public-path.util';
+
+export const v1LegacyRouteRedirects: IV1RouteRedirect[] = [
+  { from: '/api/builder-props', to: '/api/builder' },
+  {
+    from: '/documentation/parsing-and-formatting/sql',
+    to: '/documentation/parsing-and-formatting/supported-formats',
+  },
+  {
+    from: '/documentation/parsing-and-formatting/mongo',
+    to: '/documentation/parsing-and-formatting/supported-formats',
+  },
+  {
+    from: '/documentation/parsing-and-formatting/other-formats',
+    to: '/documentation/parsing-and-formatting/supported-formats',
+  },
+  { from: '/documentation/configuration/fields', to: '/api/fields' },
+  { from: '/documentation/configuration/data', to: '/api/data' },
+  {
+    from: '/documentation/configuration/builder-props',
+    to: '/api/builder',
+  },
+  {
+    from: '/documentation/configuration/components',
+    to: '/documentation/components',
+  },
+].map(({ from, to }) => ({
+  from,
+  publicFrom: createV1PublicPath(from),
+  to,
+  publicTo: createV1PublicPath(to),
+}));

--- a/example/src/v1/app/constants/v1-route-definitions.ts
+++ b/example/src/v1/app/constants/v1-route-definitions.ts
@@ -1,0 +1,25 @@
+import { apiPages } from '../../pages/api-page/constants/api-pages';
+import { documentationPages } from '../../pages/documentation-page/constants/documentation-pages';
+import { recipes } from '../../pages/recipes-page/pages/recipes-content';
+import type { IV1RouteDefinition } from '../types/v1-route-definition';
+
+export const v1RouteDefinitions: IV1RouteDefinition[] = [
+  { path: '/', title: 'Home', section: 'Home' },
+  ...documentationPages.map(({ path, title }) => ({
+    path,
+    title,
+    section: 'Documentation' as const,
+  })),
+  ...apiPages.map(({ path, title }) => ({
+    path,
+    title,
+    section: 'API' as const,
+  })),
+  { path: '/demo', title: 'Demo', section: 'Demo' },
+  { path: '/recipes', title: 'Recipes', section: 'Recipes' },
+  ...recipes.map(({ path, title }) => ({
+    path,
+    title,
+    section: 'Recipes' as const,
+  })),
+];

--- a/example/src/v1/app/constants/v1-route-manifest.ts
+++ b/example/src/v1/app/constants/v1-route-manifest.ts
@@ -1,0 +1,20 @@
+import type { IV1RouteRecord } from '../types/v1-route-record';
+import { createV1Breadcrumbs } from '../utils/create-v1-breadcrumbs.util';
+import { createV1PublicPath } from '../utils/create-v1-public-path.util';
+import { createV1RelatedLinks } from '../utils/create-v1-related-links.util';
+import { createV1SourceLink } from '../utils/create-v1-source-link.util';
+import { getV1RouteSourcePath } from '../utils/get-v1-route-source-path.util';
+import { v1BreadcrumbTitlesByPath } from './v1-breadcrumb-titles-by-path';
+import { v1RouteDefinitions } from './v1-route-definitions';
+
+export const v1RouteManifest: IV1RouteRecord[] = v1RouteDefinitions.map(
+  ({ path, title, section }) => ({
+    path,
+    publicPath: createV1PublicPath(path),
+    title,
+    section,
+    breadcrumbs: createV1Breadcrumbs(path, v1BreadcrumbTitlesByPath),
+    relatedLinks: createV1RelatedLinks(path, section),
+    sourceLink: createV1SourceLink(getV1RouteSourcePath(path, section)),
+  })
+);

--- a/example/src/v1/app/constants/v1-source-base-url.ts
+++ b/example/src/v1/app/constants/v1-source-base-url.ts
@@ -1,0 +1,2 @@
+export const V1_SOURCE_BASE_URL =
+  'https://github.com/vojtechportes/react-query-builder/blob/master';

--- a/example/src/v1/app/types/v1-breadcrumb.ts
+++ b/example/src/v1/app/types/v1-breadcrumb.ts
@@ -1,0 +1,5 @@
+export interface IV1Breadcrumb {
+  label: string;
+  path: string;
+  publicPath: string;
+}

--- a/example/src/v1/app/types/v1-fallback-route.ts
+++ b/example/src/v1/app/types/v1-fallback-route.ts
@@ -1,0 +1,5 @@
+export interface IV1FallbackRoute {
+  path: '*';
+  to: string;
+  publicTo: string;
+}

--- a/example/src/v1/app/types/v1-navigation-item.ts
+++ b/example/src/v1/app/types/v1-navigation-item.ts
@@ -1,0 +1,5 @@
+export interface IV1NavigationItem {
+  label: string;
+  path: string;
+  publicPath: string;
+}

--- a/example/src/v1/app/types/v1-related-link.ts
+++ b/example/src/v1/app/types/v1-related-link.ts
@@ -1,0 +1,6 @@
+export interface IV1RelatedLink {
+  label: string;
+  path: string;
+  publicPath?: string;
+  external: boolean;
+}

--- a/example/src/v1/app/types/v1-route-definition.ts
+++ b/example/src/v1/app/types/v1-route-definition.ts
@@ -1,0 +1,7 @@
+import type { V1RouteSection } from './v1-route-section';
+
+export interface IV1RouteDefinition {
+  path: string;
+  title: string;
+  section: V1RouteSection;
+}

--- a/example/src/v1/app/types/v1-route-record.ts
+++ b/example/src/v1/app/types/v1-route-record.ts
@@ -1,0 +1,14 @@
+import type { IV1Breadcrumb } from './v1-breadcrumb';
+import type { IV1RelatedLink } from './v1-related-link';
+import type { V1RouteSection } from './v1-route-section';
+import type { IV1SourceLink } from './v1-source-link';
+
+export interface IV1RouteRecord {
+  path: string;
+  publicPath: string;
+  title: string;
+  section: V1RouteSection;
+  breadcrumbs: IV1Breadcrumb[];
+  relatedLinks: IV1RelatedLink[];
+  sourceLink: IV1SourceLink;
+}

--- a/example/src/v1/app/types/v1-route-redirect.ts
+++ b/example/src/v1/app/types/v1-route-redirect.ts
@@ -1,0 +1,6 @@
+export interface IV1RouteRedirect {
+  from: string;
+  publicFrom: string;
+  to: string;
+  publicTo: string;
+}

--- a/example/src/v1/app/types/v1-route-section.ts
+++ b/example/src/v1/app/types/v1-route-section.ts
@@ -1,0 +1,6 @@
+export type V1RouteSection =
+  | 'Home'
+  | 'Documentation'
+  | 'API'
+  | 'Demo'
+  | 'Recipes';

--- a/example/src/v1/app/types/v1-source-link.ts
+++ b/example/src/v1/app/types/v1-source-link.ts
@@ -1,0 +1,4 @@
+export interface IV1SourceLink {
+  path: string;
+  href: string;
+}

--- a/example/src/v1/app/utils/create-v1-breadcrumbs.util.ts
+++ b/example/src/v1/app/utils/create-v1-breadcrumbs.util.ts
@@ -1,0 +1,19 @@
+import type { IV1Breadcrumb } from '../types/v1-breadcrumb';
+import { createV1PublicPath } from './create-v1-public-path.util';
+
+export const createV1Breadcrumbs = (
+  path: string,
+  titlesByPath: ReadonlyMap<string, string>
+): IV1Breadcrumb[] => {
+  const segments = path.split('/').filter(Boolean);
+  const paths = [
+    '/',
+    ...segments.map((_, index) => `/${segments.slice(0, index + 1).join('/')}`),
+  ];
+
+  return paths.map((breadcrumbPath) => ({
+    label: titlesByPath.get(breadcrumbPath) ?? breadcrumbPath,
+    path: breadcrumbPath,
+    publicPath: createV1PublicPath(breadcrumbPath),
+  }));
+};

--- a/example/src/v1/app/utils/create-v1-page-metadata-options.util.ts
+++ b/example/src/v1/app/utils/create-v1-page-metadata-options.util.ts
@@ -1,0 +1,14 @@
+import type { ISeoPage } from '../../../constants/seo-pages';
+import type { IV1RouteRecord } from '../types/v1-route-record';
+
+export const createV1PageMetadataOptions = (
+  seoPage: ISeoPage,
+  route: IV1RouteRecord
+) => ({
+  ...seoPage,
+  path: route.publicPath,
+  breadcrumbs: route.breadcrumbs.map(({ label, publicPath }) => ({
+    name: label,
+    path: publicPath,
+  })),
+});

--- a/example/src/v1/app/utils/create-v1-public-path.util.ts
+++ b/example/src/v1/app/utils/create-v1-public-path.util.ts
@@ -1,0 +1,4 @@
+import { addVersionPrefix } from '../../../shared/versioned-url';
+
+export const createV1PublicPath = (url: string, basename?: string): string =>
+  addVersionPrefix(url, 'v1', basename);

--- a/example/src/v1/app/utils/create-v1-related-links.util.ts
+++ b/example/src/v1/app/utils/create-v1-related-links.util.ts
@@ -1,0 +1,64 @@
+import { relatedRecipesByPath as apiRelatedRecipesByPath } from '../../pages/api-page/constants/related-recipes-by-path';
+import { documentationPages } from '../../pages/documentation-page/constants/documentation-pages';
+import { relatedRecipesByPath as documentationRelatedRecipesByPath } from '../../pages/documentation-page/constants/related-recipes-by-path';
+import { recipes } from '../../pages/recipes-page/pages/recipes-content';
+import type { IV1RelatedLink } from '../types/v1-related-link';
+import type { V1RouteSection } from '../types/v1-route-section';
+import { createV1PublicPath } from './create-v1-public-path.util';
+
+export const createV1RelatedLinks = (
+  path: string,
+  section: V1RouteSection
+): IV1RelatedLink[] => {
+  const pageLinks =
+    section === 'Documentation'
+      ? documentationRelatedRecipesByPath[path]
+      : section === 'API'
+        ? apiRelatedRecipesByPath[path]
+        : undefined;
+
+  if (pageLinks) {
+    return pageLinks.map((link) => ({
+      label: link.label,
+      path: link.path,
+      publicPath: createV1PublicPath(link.path),
+      external: false,
+    }));
+  }
+
+  if (section !== 'Recipes' || path === '/recipes') {
+    return [];
+  }
+
+  const recipe = recipes.find((candidate) => candidate.path === path);
+
+  if (!recipe) {
+    return [];
+  }
+
+  const internalLinks = [
+    ...recipe.relatedDocPaths.map((relatedPath) => ({
+      label:
+        documentationPages.find((page) => page.path === relatedPath)?.title ??
+        relatedPath,
+      path: relatedPath,
+      publicPath: createV1PublicPath(relatedPath),
+      external: false,
+    })),
+    ...recipe.relatedRecipePaths.map((relatedPath) => ({
+      label:
+        recipes.find((candidate) => candidate.path === relatedPath)?.title ??
+        relatedPath,
+      path: relatedPath,
+      publicPath: createV1PublicPath(relatedPath),
+      external: false,
+    })),
+  ];
+  const externalLinks = (recipe.externalReferences ?? []).map((reference) => ({
+    label: reference.label,
+    path: reference.href,
+    external: true,
+  }));
+
+  return [...internalLinks, ...externalLinks];
+};

--- a/example/src/v1/app/utils/create-v1-source-link.util.ts
+++ b/example/src/v1/app/utils/create-v1-source-link.util.ts
@@ -1,0 +1,7 @@
+import type { IV1SourceLink } from '../types/v1-source-link';
+import { V1_SOURCE_BASE_URL } from '../constants/v1-source-base-url';
+
+export const createV1SourceLink = (path: string): IV1SourceLink => ({
+  path,
+  href: `${V1_SOURCE_BASE_URL}/${path}`,
+});

--- a/example/src/v1/app/utils/find-v1-route-record.util.ts
+++ b/example/src/v1/app/utils/find-v1-route-record.util.ts
@@ -1,0 +1,11 @@
+import { v1RouteManifest } from '../constants/v1-route-manifest';
+import type { IV1RouteRecord } from '../types/v1-route-record';
+
+export const findV1RouteRecord = (pathname: string): IV1RouteRecord => {
+  const normalizedPath = pathname.replace(/\/+$/, '') || '/';
+
+  return (
+    v1RouteManifest.find((route) => route.path === normalizedPath) ??
+    v1RouteManifest[0]
+  );
+};

--- a/example/src/v1/app/utils/get-v1-route-source-path.util.ts
+++ b/example/src/v1/app/utils/get-v1-route-source-path.util.ts
@@ -1,0 +1,34 @@
+import type { V1RouteSection } from '../types/v1-route-section';
+
+export const getV1RouteSourcePath = (
+  path: string,
+  section: V1RouteSection
+): string => {
+  if (section === 'Home') {
+    return 'example/src/v1/pages/home-page/home-page.tsx';
+  }
+
+  if (section === 'Demo') {
+    return 'example/src/v1/pages/demo-page/demo-page.tsx';
+  }
+
+  if (section === 'Recipes') {
+    const recipeName = path.split('/').filter(Boolean)[1];
+
+    return recipeName
+      ? `example/src/v1/pages/recipes-page/pages/${recipeName}.recipe.ts`
+      : 'example/src/v1/pages/recipes-page/recipes-page.tsx';
+  }
+
+  const routeName = path.split('/').filter(Boolean).slice(1).join('-');
+
+  if (section === 'API') {
+    const contentName = routeName || 'overview';
+
+    return `example/src/v1/pages/api-page/components/${contentName}-api-content.tsx`;
+  }
+
+  const pageName = `${routeName || 'overview'}-documentation-page`;
+
+  return `example/src/v1/pages/documentation-page/pages/${pageName}/${pageName}.tsx`;
+};

--- a/example/src/v1/app/utils/get-v1-router-basename.util.ts
+++ b/example/src/v1/app/utils/get-v1-router-basename.util.ts
@@ -1,0 +1,4 @@
+import { createV1PublicPath } from './create-v1-public-path.util';
+
+export const getV1RouterBasename = (basename?: string): string =>
+  createV1PublicPath('/', basename);

--- a/example/src/v1/app/v1-app-routes.test.tsx
+++ b/example/src/v1/app/v1-app-routes.test.tsx
@@ -1,0 +1,116 @@
+/* @vitest-environment jsdom */
+
+import * as React from 'react';
+import { cleanup, render, screen, waitFor } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import { afterEach, beforeAll, describe, expect, it, vi } from 'vitest';
+import { renderApp } from '../../shared/ssr/render-app.util';
+import { V1AppRoutes } from './v1-app-routes';
+import { getV1RouterBasename } from './utils/get-v1-router-basename.util';
+
+beforeAll(() => {
+  window.scrollTo = vi.fn();
+});
+
+afterEach(() => {
+  cleanup();
+});
+
+const renderClientRoute = (path: string) =>
+  render(
+    <MemoryRouter basename="/v1" initialEntries={[`/v1${path}`]}>
+      <V1AppRoutes />
+    </MemoryRouter>
+  );
+
+describe('v1 app routes', () => {
+  it('renders v1-prefixed top navigation and nested sidebar links', () => {
+    const page = renderApp(
+      '/documentation/adapters/mui',
+      getV1RouterBasename(),
+      <V1AppRoutes />
+    );
+
+    expect(page.html).toContain('href="/v1"');
+    expect(page.html).toContain('href="/v1/documentation"');
+    expect(page.html).toContain('href="/v1/api"');
+    expect(page.html).toContain('href="/v1/demo"');
+    expect(page.html).toContain('href="/v1/recipes"');
+    expect(page.html).toContain('href="/v1/documentation/adapters/mui"');
+  });
+
+  it('renders links under a repository deployment basename', () => {
+    const page = renderApp(
+      '/api/adapters/mui',
+      getV1RouterBasename('/react-query-builder/'),
+      <V1AppRoutes />
+    );
+
+    expect(page.html).toContain('href="/react-query-builder/v1"');
+    expect(page.html).toContain('href="/react-query-builder/v1/documentation"');
+    expect(page.html).toContain(
+      'href="/react-query-builder/v1/api/adapters/mui"'
+    );
+    expect(page.html).not.toContain('/v1/v1');
+  });
+
+  it('renders v1-prefixed related links', () => {
+    const page = renderApp(
+      '/documentation/dynamic-field-options',
+      getV1RouterBasename(),
+      <V1AppRoutes />
+    );
+
+    expect(page.html).toContain(
+      'href="/v1/recipes/dynamic-operators-by-field-type"'
+    );
+  });
+
+  it('uses public v1 paths in client metadata and breadcrumbs', async () => {
+    renderClientRoute('/api/builder');
+
+    await waitFor(() => {
+      expect(
+        document.head.querySelector<HTMLLinkElement>('link[rel="canonical"]')
+          ?.href
+      ).toContain('/v1/api/builder');
+    });
+
+    const structuredData = JSON.parse(
+      document.head.querySelector<HTMLScriptElement>(
+        'script#structured-data-page'
+      )?.textContent ?? '[]'
+    ) as {
+      '@type': string;
+      itemListElement?: { item: string }[];
+    }[];
+    const breadcrumbs = structuredData.find(
+      (record) => record['@type'] === 'BreadcrumbList'
+    );
+
+    expect(breadcrumbs?.itemListElement?.map((item) => item.item)).toEqual([
+      expect.stringContaining('/v1'),
+      expect.stringContaining('/v1/api'),
+      expect.stringContaining('/v1/api/builder'),
+    ]);
+  });
+
+  it('redirects a legacy v1 route to its owned canonical destination', async () => {
+    renderClientRoute('/api/builder-props');
+
+    expect(
+      await screen.findByRole('heading', { level: 1, name: 'Builder' })
+    ).toBeDefined();
+  });
+
+  it('handles an unknown v1 route by returning to the v1 Home page', async () => {
+    renderClientRoute('/route-not-owned-by-v1');
+
+    expect(
+      await screen.findByRole('heading', {
+        level: 1,
+        name: 'React Query Builder',
+      })
+    ).toBeDefined();
+  });
+});

--- a/example/src/v1/app/v1-app-routes.tsx
+++ b/example/src/v1/app/v1-app-routes.tsx
@@ -1,0 +1,51 @@
+import * as React from 'react';
+import { Navigate, Route, Routes } from 'react-router-dom';
+import { SiteShell } from '../../components/site-shell';
+import { v1TopNavigation } from '../navigation/constants/v1-top-navigation';
+import { ApiPage } from '../pages/api-page/api-page';
+import { DemoPage } from '../pages/demo-page/demo-page';
+import { DocumentationPage } from '../pages/documentation-page/documentation-page';
+import { HomePage } from '../pages/home-page/home-page';
+import { RecipesPage } from '../pages/recipes-page/recipes-page';
+import { v1FallbackRoute } from './constants/v1-fallback-route';
+import { v1LegacyRouteRedirects } from './constants/v1-legacy-route-redirects';
+import { v1RouteManifest } from './constants/v1-route-manifest';
+
+export const V1AppRoutes: React.FC = () => {
+  const pageElements = {
+    API: <ApiPage />,
+    Demo: <DemoPage />,
+    Documentation: <DocumentationPage />,
+    Home: <HomePage />,
+    Recipes: <RecipesPage />,
+  };
+
+  return (
+    <Routes>
+      <Route
+        element={
+          <SiteShell versionLabel="Docs v1" topNavigation={v1TopNavigation} />
+        }
+      >
+        {v1RouteManifest.map((route) => (
+          <Route
+            key={route.path}
+            path={route.path}
+            element={pageElements[route.section]}
+          />
+        ))}
+        {v1LegacyRouteRedirects.map((redirect) => (
+          <Route
+            key={redirect.from}
+            path={redirect.from}
+            element={<Navigate to={redirect.to} replace />}
+          />
+        ))}
+        <Route
+          path={v1FallbackRoute.path}
+          element={<Navigate to={v1FallbackRoute.to} replace />}
+        />
+      </Route>
+    </Routes>
+  );
+};

--- a/example/src/v1/app/v1-app.tsx
+++ b/example/src/v1/app/v1-app.tsx
@@ -1,0 +1,10 @@
+import * as React from 'react';
+import { BrowserRouter } from 'react-router-dom';
+import { V1AppRoutes } from './v1-app-routes';
+import { v1RouterBasename } from './v1-router-basename';
+
+export const V1App: React.FC = () => (
+  <BrowserRouter basename={v1RouterBasename}>
+    <V1AppRoutes />
+  </BrowserRouter>
+);

--- a/example/src/v1/app/v1-route-manifest.test.ts
+++ b/example/src/v1/app/v1-route-manifest.test.ts
@@ -1,0 +1,159 @@
+import { describe, expect, it } from 'vitest';
+import { v1TopNavigation } from '../navigation/constants/v1-top-navigation';
+import { v1ApiSidebar } from '../navigation/constants/v1-api-sidebar';
+import { v1DocumentationSidebar } from '../navigation/constants/v1-documentation-sidebar';
+import { v1RecipesSidebar } from '../navigation/constants/v1-recipes-sidebar';
+import { apiPages } from '../pages/api-page/constants/api-pages';
+import { documentationPages } from '../pages/documentation-page/constants/documentation-pages';
+import { recipes } from '../pages/recipes-page/pages/recipes-content';
+import { v1FallbackRoute } from './constants/v1-fallback-route';
+import { v1LegacyRouteRedirects } from './constants/v1-legacy-route-redirects';
+import { v1RouteManifest } from './constants/v1-route-manifest';
+import { createV1PublicPath } from './utils/create-v1-public-path.util';
+import { findV1RouteRecord } from './utils/find-v1-route-record.util';
+import { getV1RouterBasename } from './utils/get-v1-router-basename.util';
+
+const v1SourcePaths = new Set(
+  Object.keys(
+    import.meta.glob([
+      '/src/v1/pages/home-page/home-page.tsx',
+      '/src/v1/pages/demo-page/demo-page.tsx',
+      '/src/v1/pages/api-page/components/*-api-content.tsx',
+      '/src/v1/pages/documentation-page/pages/*/*.tsx',
+      '/src/v1/pages/recipes-page/pages/*.recipe.ts',
+      '/src/v1/pages/recipes-page/recipes-page.tsx',
+    ])
+  ).map((path) => `example${path}`)
+);
+const expectedCanonicalPaths = [
+  '/',
+  ...documentationPages.map((page) => page.path),
+  ...apiPages.map((page) => page.path),
+  '/demo',
+  '/recipes',
+  ...recipes.map((page) => page.path),
+];
+
+const getSidebarPaths = (sidebar: {
+  overviewPage: { path: string };
+  groups: { pages: { path: string }[] }[];
+}) => [
+  sidebar.overviewPage.path,
+  ...sidebar.groups.flatMap((group) => group.pages.map((page) => page.path)),
+];
+
+describe('v1 route manifest', () => {
+  it('owns the complete canonical v1 route set exactly once', () => {
+    const manifestPaths = v1RouteManifest.map((route) => route.path);
+
+    expect(manifestPaths).toHaveLength(55);
+    expect(new Set(manifestPaths).size).toBe(manifestPaths.length);
+    expect(new Set(manifestPaths)).toEqual(new Set(expectedCanonicalPaths));
+  });
+
+  it('provides v1 public paths, breadcrumbs, related links, and source links', () => {
+    const manifestPaths = new Set(v1RouteManifest.map((route) => route.path));
+
+    for (const route of v1RouteManifest) {
+      expect(route.publicPath).toBe(createV1PublicPath(route.path));
+      expect(route.breadcrumbs[0]).toEqual({
+        label: 'Home',
+        path: '/',
+        publicPath: '/v1',
+      });
+      expect(route.breadcrumbs.at(-1)?.path).toBe(route.path);
+      expect(route.sourceLink.path).toMatch(/^example\/src\/v1\//);
+      expect(route.sourceLink.href).toBe(
+        `https://github.com/vojtechportes/react-query-builder/blob/master/${route.sourceLink.path}`
+      );
+      expect(v1SourcePaths.has(route.sourceLink.path)).toBe(true);
+
+      for (const relatedLink of route.relatedLinks) {
+        if (relatedLink.external) {
+          expect(relatedLink.path).toMatch(/^https?:\/\//);
+          expect(relatedLink.publicPath).toBeUndefined();
+        } else {
+          expect(manifestPaths.has(relatedLink.path)).toBe(true);
+          expect(relatedLink.publicPath).toBe(
+            createV1PublicPath(relatedLink.path)
+          );
+        }
+      }
+    }
+  });
+
+  it('creates the expected top navigation and complete section sidebars', () => {
+    expect(v1TopNavigation).toEqual([
+      { label: 'Home', path: '/', publicPath: '/v1' },
+      {
+        label: 'Documentation',
+        path: '/documentation',
+        publicPath: '/v1/documentation',
+      },
+      { label: 'API', path: '/api', publicPath: '/v1/api' },
+      { label: 'Demo', path: '/demo', publicPath: '/v1/demo' },
+      { label: 'Recipes', path: '/recipes', publicPath: '/v1/recipes' },
+    ]);
+    expect(getSidebarPaths(v1DocumentationSidebar)).toEqual(
+      documentationPages.map((page) => page.path)
+    );
+    expect(getSidebarPaths(v1ApiSidebar)).toEqual(
+      apiPages.map((page) => page.path)
+    );
+    expect(getSidebarPaths(v1RecipesSidebar)).toEqual([
+      '/recipes',
+      ...recipes.map((page) => page.path),
+    ]);
+  });
+
+  it('defines all legacy destinations and the unknown-route fallback within v1', () => {
+    const canonicalPaths = new Set(v1RouteManifest.map((route) => route.path));
+
+    expect(v1LegacyRouteRedirects).toHaveLength(8);
+    expect(
+      new Set(v1LegacyRouteRedirects.map((route) => route.from)).size
+    ).toBe(8);
+
+    for (const redirect of v1LegacyRouteRedirects) {
+      expect(canonicalPaths.has(redirect.to)).toBe(true);
+      expect(redirect.publicFrom).toBe(createV1PublicPath(redirect.from));
+      expect(redirect.publicTo).toBe(createV1PublicPath(redirect.to));
+    }
+
+    expect(v1FallbackRoute).toEqual({
+      path: '*',
+      to: '/',
+      publicTo: '/v1',
+    });
+    expect(findV1RouteRecord('/not-owned-by-v1')).toBe(v1RouteManifest[0]);
+    expect(findV1RouteRecord('/api/builder/').path).toBe('/api/builder');
+  });
+
+  it.each([
+    ['/', undefined, '/v1'],
+    ['/documentation/usage', undefined, '/v1/documentation/usage'],
+    [
+      '/documentation/usage?tab=api#example',
+      undefined,
+      '/v1/documentation/usage?tab=api#example',
+    ],
+    ['/', '/react-query-builder/', '/react-query-builder/v1'],
+    [
+      '/api/adapters/mui?tab=props#theme',
+      '/react-query-builder/',
+      '/react-query-builder/v1/api/adapters/mui?tab=props#theme',
+    ],
+  ] as const)(
+    'prefixes %s with deployment basename %s',
+    (path, base, expected) => {
+      expect(createV1PublicPath(path, base)).toBe(expected);
+    }
+  );
+
+  it('creates root and repository deployment router basenames', () => {
+    expect(getV1RouterBasename()).toBe('/v1');
+    expect(getV1RouterBasename('/react-query-builder/')).toBe(
+      '/react-query-builder/v1'
+    );
+  });
+});

--- a/example/src/v1/app/v1-router-basename.ts
+++ b/example/src/v1/app/v1-router-basename.ts
@@ -1,0 +1,4 @@
+import { routerBasename } from '../../app/router-basename';
+import { getV1RouterBasename } from './utils/get-v1-router-basename.util';
+
+export const v1RouterBasename = getV1RouterBasename(routerBasename);

--- a/example/src/v1/entry-client.tsx
+++ b/example/src/v1/entry-client.tsx
@@ -1,18 +1,5 @@
 import * as React from 'react';
-import { App } from '../app/app';
 import { hydrateApp } from '../shared/client/hydrate-app.util';
-import { ApiPage } from './pages/api-page/api-page';
-import { DemoPage } from './pages/demo-page/demo-page';
-import { HomePage } from './pages/home-page/home-page';
-import { RecipesPage } from './pages/recipes-page/recipes-page';
-import { DocumentationPage } from './pages/documentation-page/documentation-page';
+import { V1App } from './app/v1-app';
 
-hydrateApp(
-  <App
-    apiPage={<ApiPage />}
-    demoPage={<DemoPage />}
-    documentationPage={<DocumentationPage />}
-    homePage={<HomePage />}
-    recipesPage={<RecipesPage />}
-  />
-);
+hydrateApp(<V1App />);

--- a/example/src/v1/entry-server.tsx
+++ b/example/src/v1/entry-server.tsx
@@ -1,22 +1,7 @@
 import * as React from 'react';
-import { AppRoutes } from '../app/app-routes';
-import { routerBasename } from '../app/router-basename';
 import { renderApp } from '../shared/ssr/render-app.util';
-import { ApiPage } from './pages/api-page/api-page';
-import { DemoPage } from './pages/demo-page/demo-page';
-import { HomePage } from './pages/home-page/home-page';
-import { RecipesPage } from './pages/recipes-page/recipes-page';
-import { DocumentationPage } from './pages/documentation-page/documentation-page';
+import { V1AppRoutes } from './app/v1-app-routes';
+import { v1RouterBasename } from './app/v1-router-basename';
 
 export const renderPage = (pathname: string) =>
-  renderApp(
-    pathname,
-    routerBasename,
-    <AppRoutes
-      apiPage={<ApiPage />}
-      demoPage={<DemoPage />}
-      documentationPage={<DocumentationPage />}
-      homePage={<HomePage />}
-      recipesPage={<RecipesPage />}
-    />
-  );
+  renderApp(pathname, v1RouterBasename, <V1AppRoutes />);

--- a/example/src/v1/navigation/constants/v1-api-sidebar.ts
+++ b/example/src/v1/navigation/constants/v1-api-sidebar.ts
@@ -1,0 +1,8 @@
+import { apiGroups } from '../../pages/api-page/constants/api-groups';
+import { apiPages } from '../../pages/api-page/constants/api-pages';
+
+export const v1ApiSidebar = {
+  title: 'API',
+  overviewPage: apiPages[0],
+  groups: apiGroups,
+};

--- a/example/src/v1/navigation/constants/v1-documentation-sidebar.ts
+++ b/example/src/v1/navigation/constants/v1-documentation-sidebar.ts
@@ -1,0 +1,8 @@
+import { documentationGroups } from '../../pages/documentation-page/constants/documentation-groups';
+import { documentationPages } from '../../pages/documentation-page/constants/documentation-pages';
+
+export const v1DocumentationSidebar = {
+  title: 'Documentation',
+  overviewPage: documentationPages[0],
+  groups: documentationGroups,
+};

--- a/example/src/v1/navigation/constants/v1-recipes-sidebar.ts
+++ b/example/src/v1/navigation/constants/v1-recipes-sidebar.ts
@@ -1,0 +1,8 @@
+import { recipeGroups } from '../../pages/recipes-page/constants/recipe-groups';
+import { recipesOverviewPage } from '../../pages/recipes-page/constants/recipes-overview-page';
+
+export const v1RecipesSidebar = {
+  title: 'Recipes',
+  overviewPage: recipesOverviewPage,
+  groups: recipeGroups,
+};

--- a/example/src/v1/navigation/constants/v1-top-level-paths.ts
+++ b/example/src/v1/navigation/constants/v1-top-level-paths.ts
@@ -1,0 +1,7 @@
+export const v1TopLevelPaths = [
+  '/',
+  '/documentation',
+  '/api',
+  '/demo',
+  '/recipes',
+] as const;

--- a/example/src/v1/navigation/constants/v1-top-navigation.ts
+++ b/example/src/v1/navigation/constants/v1-top-navigation.ts
@@ -1,0 +1,15 @@
+import { v1RouteManifest } from '../../app/constants/v1-route-manifest';
+import type { IV1NavigationItem } from '../../app/types/v1-navigation-item';
+import { v1TopLevelPaths } from './v1-top-level-paths';
+
+export const v1TopNavigation: IV1NavigationItem[] = v1TopLevelPaths.map(
+  (path) => {
+    const route = v1RouteManifest.find((candidate) => candidate.path === path)!;
+
+    return {
+      label: route.section,
+      path: route.path,
+      publicPath: route.publicPath,
+    };
+  }
+);

--- a/example/src/v1/pages/api-page/api-page.tsx
+++ b/example/src/v1/pages/api-page/api-page.tsx
@@ -1,14 +1,14 @@
 import * as React from 'react';
-import styled from 'styled-components';
 import { useLocation } from 'react-router-dom';
+import styled from 'styled-components';
 import { ContentArticle } from '../../../components/content-article';
 import { DocumentationSidebar } from '../../../components/documentation-sidebar';
 import { RelatedRecipes } from '../../../components/related-recipes';
-import { relatedRecipesByPath } from './constants/related-recipes-by-path';
 import { findSeoPage } from '../../../constants/seo-pages';
 import { usePageMetadata } from '../../../hooks/use-page-metadata';
-import { apiGroups } from './constants/api-groups';
-import { apiPages } from './constants/api-pages';
+import { createV1PageMetadataOptions } from '../../app/utils/create-v1-page-metadata-options.util';
+import { findV1RouteRecord } from '../../app/utils/find-v1-route-record.util';
+import { v1ApiSidebar } from '../../navigation/constants/v1-api-sidebar';
 import { findApiPage } from './utils/find-api-page.util';
 
 const Layout = styled.div`
@@ -42,22 +42,24 @@ const Summary = styled.p`
 export const ApiPage: React.FC = () => {
   const location = useLocation();
   const page = findApiPage(location.pathname);
+  const route = findV1RouteRecord(page.path);
   const seoPage = findSeoPage(page.path);
-  usePageMetadata(seoPage.title, seoPage.description, seoPage);
+
+  usePageMetadata(
+    seoPage.title,
+    seoPage.description,
+    createV1PageMetadataOptions(seoPage, route)
+  );
 
   return (
     <Layout>
-      <DocumentationSidebar
-        title="API"
-        overviewPage={apiPages[0]}
-        groups={apiGroups}
-      />
+      <DocumentationSidebar {...v1ApiSidebar} />
       <ContentArticle>
         <SectionLabel>{page.sectionTitle}</SectionLabel>
         <Title>{page.title}</Title>
         {page.summary ? <Summary>{page.summary}</Summary> : null}
         {page.content}
-        <RelatedRecipes links={relatedRecipesByPath[page.path]} />
+        <RelatedRecipes links={route.relatedLinks} />
       </ContentArticle>
     </Layout>
   );

--- a/example/src/v1/pages/demo-page/demo-page.tsx
+++ b/example/src/v1/pages/demo-page/demo-page.tsx
@@ -3,6 +3,8 @@ import styled from 'styled-components';
 import { ClientOnly } from '../../../components/client-only';
 import { findSeoPage } from '../../../constants/seo-pages';
 import { usePageMetadata } from '../../../hooks/use-page-metadata';
+import { findV1RouteRecord } from '../../app/utils/find-v1-route-record.util';
+import { createV1PageMetadataOptions } from '../../app/utils/create-v1-page-metadata-options.util';
 import { loadDemoPlayground } from './load-demo-playground';
 
 const Root = styled.section`
@@ -16,9 +18,14 @@ const Title = styled.h1`
 `;
 
 const seoPage = findSeoPage('/demo');
+const route = findV1RouteRecord('/demo');
 
 export const DemoPage: React.FC = () => {
-  usePageMetadata(seoPage.title, seoPage.description, seoPage);
+  usePageMetadata(
+    seoPage.title,
+    seoPage.description,
+    createV1PageMetadataOptions(seoPage, route)
+  );
 
   return (
     <Root>

--- a/example/src/v1/pages/documentation-page/documentation-page.tsx
+++ b/example/src/v1/pages/documentation-page/documentation-page.tsx
@@ -7,9 +7,9 @@ import { DocumentationSidebar } from '../../../components/documentation-sidebar'
 import { RelatedRecipes } from '../../../components/related-recipes';
 import { findSeoPage } from '../../../constants/seo-pages';
 import { usePageMetadata } from '../../../hooks/use-page-metadata';
-import { documentationGroups } from './constants/documentation-groups';
-import { documentationPages } from './constants/documentation-pages';
-import { relatedRecipesByPath } from './constants/related-recipes-by-path';
+import { createV1PageMetadataOptions } from '../../app/utils/create-v1-page-metadata-options.util';
+import { findV1RouteRecord } from '../../app/utils/find-v1-route-record.util';
+import { v1DocumentationSidebar } from '../../navigation/constants/v1-documentation-sidebar';
 import { findDocumentationPage } from './utils/find-documentation-page.util';
 import { loadParsingSandbox } from './utils/load-parsing-sandbox.util';
 
@@ -44,23 +44,24 @@ const Summary = styled.p`
 export const DocumentationPage: React.FC = () => {
   const location = useLocation();
   const page = findDocumentationPage(location.pathname);
+  const route = findV1RouteRecord(page.path);
   const seoPage = findSeoPage(page.path);
 
-  usePageMetadata(seoPage.title, seoPage.description, seoPage);
+  usePageMetadata(
+    seoPage.title,
+    seoPage.description,
+    createV1PageMetadataOptions(seoPage, route)
+  );
 
   return (
     <Layout>
-      <DocumentationSidebar
-        title="Documentation"
-        overviewPage={documentationPages[0]}
-        groups={documentationGroups}
-      />
+      <DocumentationSidebar {...v1DocumentationSidebar} />
       <ContentArticle>
         <SectionLabel>{page.sectionTitle}</SectionLabel>
         <Title>{page.title}</Title>
         {page.summary ? <Summary>{page.summary}</Summary> : null}
         {page.content}
-        <RelatedRecipes links={relatedRecipesByPath[page.path]} />
+        <RelatedRecipes links={route.relatedLinks} />
         {page.path === '/documentation/parsing-and-formatting' ? (
           <ClientOnly
             loader={loadParsingSandbox}

--- a/example/src/v1/pages/home-page/home-page.tsx
+++ b/example/src/v1/pages/home-page/home-page.tsx
@@ -4,6 +4,8 @@ import { Link } from 'react-router-dom';
 import { siteTheme } from '../../../constants/site-theme';
 import { findSeoPage } from '../../../constants/seo-pages';
 import { usePageMetadata } from '../../../hooks/use-page-metadata';
+import { createV1PageMetadataOptions } from '../../app/utils/create-v1-page-metadata-options.util';
+import { findV1RouteRecord } from '../../app/utils/find-v1-route-record.util';
 
 const Hero = styled.section`
   display: grid;
@@ -127,9 +129,14 @@ const Code = styled.code`
 `;
 
 const seoPage = findSeoPage('/');
+const route = findV1RouteRecord('/');
 
 export const HomePage: React.FC = () => {
-  usePageMetadata(seoPage.title, seoPage.description, seoPage);
+  usePageMetadata(
+    seoPage.title,
+    seoPage.description,
+    createV1PageMetadataOptions(seoPage, route)
+  );
 
   return (
     <Hero>

--- a/example/src/v1/pages/recipes-page/components/recipe-article.tsx
+++ b/example/src/v1/pages/recipes-page/components/recipe-article.tsx
@@ -2,6 +2,7 @@ import * as React from 'react';
 import { AlertBox } from '../../../../components/alert-box';
 import { CodeBlock } from '../../../../components/code-block';
 import { List, SectionTitle } from '../../../../components/docs-primitives';
+import type { IV1RelatedLink } from '../../../app/types/v1-related-link';
 import type { IRecipePage } from '../types/recipe-page';
 import { RecipeFaq } from './recipe-faq';
 import { RecipeLiveDemo } from './recipe-live-demo';
@@ -9,12 +10,12 @@ import { RecipeRelatedLinks } from './recipe-related-links';
 
 export interface IRecipeArticleProps {
   page: IRecipePage;
-  pagesByPath: Map<string, IRecipePage>;
+  relatedLinks: IV1RelatedLink[];
 }
 
 export const RecipeArticle: React.FC<IRecipeArticleProps> = ({
   page,
-  pagesByPath,
+  relatedLinks,
 }) => (
   <>
     {page.illustrative ? (
@@ -64,7 +65,7 @@ export const RecipeArticle: React.FC<IRecipeArticleProps> = ({
         <li key={item}>{item}</li>
       ))}
     </List>
-    <RecipeRelatedLinks page={page} pagesByPath={pagesByPath} />
+    <RecipeRelatedLinks links={relatedLinks} />
     <RecipeFaq faqs={page.faqs} />
   </>
 );

--- a/example/src/v1/pages/recipes-page/components/recipe-related-links.tsx
+++ b/example/src/v1/pages/recipes-page/components/recipe-related-links.tsx
@@ -1,34 +1,21 @@
 import * as React from 'react';
 import { Link, SectionTitle } from '../../../../components/docs-primitives';
-import type { IRecipePage } from '../types/recipe-page';
-import { formatPathLabel } from '../utils/format-path-label.util';
+import type { IV1RelatedLink } from '../../../app/types/v1-related-link';
 
 export interface IRecipeRelatedLinksProps {
-  page: IRecipePage;
-  pagesByPath: Map<string, IRecipePage>;
+  links: IV1RelatedLink[];
 }
 
 export const RecipeRelatedLinks: React.FC<IRecipeRelatedLinksProps> = ({
-  page,
-  pagesByPath,
+  links,
 }) => (
   <section>
     <SectionTitle>Related guides</SectionTitle>
     <ul>
-      {page.relatedDocPaths.map((path) => (
-        <li key={path}>
-          <Link to={path}>{formatPathLabel(path)}</Link>
-        </li>
-      ))}
-      {page.relatedRecipePaths.map((path) => (
-        <li key={path}>
-          <Link to={path}>{pagesByPath.get(path)?.title ?? path}</Link>
-        </li>
-      ))}
-      {page.externalReferences?.map((reference) => (
-        <li key={reference.href}>
-          <Link to={reference.href} external>
-            {reference.label}
+      {links.map((link) => (
+        <li key={link.path}>
+          <Link to={link.path} external={link.external}>
+            {link.label}
           </Link>
         </li>
       ))}

--- a/example/src/v1/pages/recipes-page/recipes-page.tsx
+++ b/example/src/v1/pages/recipes-page/recipes-page.tsx
@@ -5,11 +5,11 @@ import { ContentArticle } from '../../../components/content-article';
 import { DocumentationSidebar } from '../../../components/documentation-sidebar';
 import { findSeoPage } from '../../../constants/seo-pages';
 import { usePageMetadata } from '../../../hooks/use-page-metadata';
+import { createV1PageMetadataOptions } from '../../app/utils/create-v1-page-metadata-options.util';
+import { findV1RouteRecord } from '../../app/utils/find-v1-route-record.util';
+import { v1RecipesSidebar } from '../../navigation/constants/v1-recipes-sidebar';
 import { RecipeArticle } from './components/recipe-article';
 import { RecipesOverview } from './components/recipes-overview';
-import { recipeGroups } from './constants/recipe-groups';
-import { recipesOverviewPage } from './constants/recipes-overview-page';
-import { recipes } from './pages/recipes-content';
 import { findRecipePage } from './utils/find-recipe-page.util';
 
 const Layout = styled.div`
@@ -39,34 +39,20 @@ const Summary = styled.p`
   margin-top: 0.55rem;
 `;
 
-const pagesByPath = new Map(recipes.map((page) => [page.path, page]));
-
 export const RecipesPage: React.FC = () => {
   const { pathname } = useLocation();
   const page = findRecipePage(pathname);
-  const seoPage = findSeoPage(page?.path ?? '/recipes');
+  const route = findV1RouteRecord(page?.path ?? '/recipes');
+  const seoPage = findSeoPage(route.path);
+
   usePageMetadata(seoPage.title, seoPage.description, {
-    ...seoPage,
-    breadcrumbs: page
-      ? [
-          { name: 'Home', path: '/' },
-          { name: 'Recipes', path: '/recipes' },
-          { name: page.title, path: page.path },
-        ]
-      : [
-          { name: 'Home', path: '/' },
-          { name: 'Recipes', path: '/recipes' },
-        ],
+    ...createV1PageMetadataOptions(seoPage, route),
     faqs: page?.faqs,
   });
 
   return (
     <Layout>
-      <DocumentationSidebar
-        title="Recipes"
-        overviewPage={recipesOverviewPage}
-        groups={recipeGroups}
-      />
+      <DocumentationSidebar {...v1RecipesSidebar} />
       <ContentArticle>
         <SectionLabel>Recipes</SectionLabel>
         <Title>{page?.title ?? 'React Query Builder Recipes'}</Title>
@@ -78,10 +64,10 @@ export const RecipesPage: React.FC = () => {
           <RecipeArticle
             key={page.path}
             page={page}
-            pagesByPath={pagesByPath}
+            relatedLinks={route.relatedLinks}
           />
         ) : (
-          <RecipesOverview groups={recipeGroups} />
+          <RecipesOverview groups={v1RecipesSidebar.groups} />
         )}
       </ContentArticle>
     </Layout>

--- a/example/src/v1/pages/recipes-page/utils/serialize-recipe-content.util.ts
+++ b/example/src/v1/pages/recipes-page/utils/serialize-recipe-content.util.ts
@@ -3,4 +3,4 @@ import type { IRecipePage } from '../types/recipe-page';
 export const serializeRecipeContent = ({
   demoLoader: _demoLoader,
   ...content
-}: IRecipePage) => JSON.stringify(content);
+}: IRecipePage) => JSON.stringify(content).replace(/\\r\\n/g, '\\n');

--- a/example/src/v2/pages/recipes-page/utils/serialize-recipe-content.util.ts
+++ b/example/src/v2/pages/recipes-page/utils/serialize-recipe-content.util.ts
@@ -3,4 +3,4 @@ import type { IRecipePage } from '../types/recipe-page';
 export const serializeRecipeContent = ({
   demoLoader: _demoLoader,
   ...content
-}: IRecipePage) => JSON.stringify(content);
+}: IRecipePage) => JSON.stringify(content).replace(/\\r\\n/g, '\\n');


### PR DESCRIPTION
- Added v1-owned canonical routes, redirects, fallbacks, breadcrumbs, related links, and source links
- Added independent top navigation and sidebar manifests
- Wired version-prefixed v1 client and server routing
- Updated v1 pages to consume manifest-owned navigation and metadata
- Added route, rendering, ownership, redirect, fallback, and source-link tests
- Stabilized recipe content hashes across line endings
- Marked T022 as completed