### PR TITLE
feat: Created independent v2 navigation and route manifests

### DIFF
--- a/.codex/TASKS.md
+++ b/.codex/TASKS.md
@@ -1043,7 +1043,7 @@ v1.
 
 ### T023 - Create independent v2 navigation and route manifests
 
-**Status:** `[ ]` Not started
+**Status:** `[x]` Done
 
 **Depends on:** T015, T017, T019, and T021
 

--- a/.codex/t023-create-independent-v2-navigation-and-route-manifests-tasks.md
+++ b/.codex/t023-create-independent-v2-navigation-and-route-manifests-tasks.md
@@ -1,0 +1,12 @@
+# T023 - Create independent v2 navigation and route manifests
+
+- [x] Define granular v2 route/navigation types and public-path utilities.
+- [x] Add canonical, legacy redirect, fallback, breadcrumb, related-link, source-link, top-navigation, and sidebar data from v2-owned registries.
+- [x] Add v2-owned App/AppRoutes and versioned basename wiring.
+- [x] Inject v2-owned navigation into slim shared shell primitives without shared content ownership.
+- [x] Update v2 pages to consume v2 navigation, breadcrumb, and related-link records.
+- [x] Add manifest, prefix, route coverage, navigation, legacy/fallback, source-link, and SSR tests.
+- [x] Run v2 typecheck, tests, and build and resolve regressions.
+- [x] Run Prettier on every modified code file.
+- [x] Complete the required review agent and resolve all findings.
+- [x] Mark T023 done after verification and review.

--- a/example/src/v2/app/constants/v2-breadcrumb-titles-by-path.ts
+++ b/example/src/v2/app/constants/v2-breadcrumb-titles-by-path.ts
@@ -1,0 +1,12 @@
+import { v2RouteDefinitions } from './v2-route-definitions';
+
+export const v2BreadcrumbTitlesByPath = new Map(
+  v2RouteDefinitions.map(({ path, title }) => [
+    path,
+    path === '/api'
+      ? 'API'
+      : path === '/documentation'
+        ? 'Documentation'
+        : title,
+  ])
+);

--- a/example/src/v2/app/constants/v2-fallback-route.ts
+++ b/example/src/v2/app/constants/v2-fallback-route.ts
@@ -1,0 +1,8 @@
+import type { IV2FallbackRoute } from '../types/v2-fallback-route';
+import { createV2PublicPath } from '../utils/create-v2-public-path.util';
+
+export const v2FallbackRoute: IV2FallbackRoute = {
+  path: '*',
+  to: '/',
+  publicTo: createV2PublicPath('/'),
+};

--- a/example/src/v2/app/constants/v2-legacy-route-redirects.ts
+++ b/example/src/v2/app/constants/v2-legacy-route-redirects.ts
@@ -1,0 +1,33 @@
+import type { IV2RouteRedirect } from '../types/v2-route-redirect';
+import { createV2PublicPath } from '../utils/create-v2-public-path.util';
+
+export const v2LegacyRouteRedirects: IV2RouteRedirect[] = [
+  { from: '/api/builder-props', to: '/api/builder' },
+  {
+    from: '/documentation/parsing-and-formatting/sql',
+    to: '/documentation/parsing-and-formatting/supported-formats',
+  },
+  {
+    from: '/documentation/parsing-and-formatting/mongo',
+    to: '/documentation/parsing-and-formatting/supported-formats',
+  },
+  {
+    from: '/documentation/parsing-and-formatting/other-formats',
+    to: '/documentation/parsing-and-formatting/supported-formats',
+  },
+  { from: '/documentation/configuration/fields', to: '/api/fields' },
+  { from: '/documentation/configuration/data', to: '/api/data' },
+  {
+    from: '/documentation/configuration/builder-props',
+    to: '/api/builder',
+  },
+  {
+    from: '/documentation/configuration/components',
+    to: '/documentation/components',
+  },
+].map(({ from, to }) => ({
+  from,
+  publicFrom: createV2PublicPath(from),
+  to,
+  publicTo: createV2PublicPath(to),
+}));

--- a/example/src/v2/app/constants/v2-route-definitions.ts
+++ b/example/src/v2/app/constants/v2-route-definitions.ts
@@ -1,0 +1,25 @@
+import { apiPages } from '../../pages/api-page/constants/api-pages';
+import { documentationPages } from '../../pages/documentation-page/constants/documentation-pages';
+import { recipes } from '../../pages/recipes-page/pages/recipes-content';
+import type { IV2RouteDefinition } from '../types/v2-route-definition';
+
+export const v2RouteDefinitions: IV2RouteDefinition[] = [
+  { path: '/', title: 'Home', section: 'Home' },
+  ...documentationPages.map(({ path, title }) => ({
+    path,
+    title,
+    section: 'Documentation' as const,
+  })),
+  ...apiPages.map(({ path, title }) => ({
+    path,
+    title,
+    section: 'API' as const,
+  })),
+  { path: '/demo', title: 'Demo', section: 'Demo' },
+  { path: '/recipes', title: 'Recipes', section: 'Recipes' },
+  ...recipes.map(({ path, title }) => ({
+    path,
+    title,
+    section: 'Recipes' as const,
+  })),
+];

--- a/example/src/v2/app/constants/v2-route-manifest.ts
+++ b/example/src/v2/app/constants/v2-route-manifest.ts
@@ -1,0 +1,20 @@
+import type { IV2RouteRecord } from '../types/v2-route-record';
+import { createV2Breadcrumbs } from '../utils/create-v2-breadcrumbs.util';
+import { createV2PublicPath } from '../utils/create-v2-public-path.util';
+import { createV2RelatedLinks } from '../utils/create-v2-related-links.util';
+import { createV2SourceLink } from '../utils/create-v2-source-link.util';
+import { getV2RouteSourcePath } from '../utils/get-v2-route-source-path.util';
+import { v2BreadcrumbTitlesByPath } from './v2-breadcrumb-titles-by-path';
+import { v2RouteDefinitions } from './v2-route-definitions';
+
+export const v2RouteManifest: IV2RouteRecord[] = v2RouteDefinitions.map(
+  ({ path, title, section }) => ({
+    path,
+    publicPath: createV2PublicPath(path),
+    title,
+    section,
+    breadcrumbs: createV2Breadcrumbs(path, v2BreadcrumbTitlesByPath),
+    relatedLinks: createV2RelatedLinks(path, section),
+    sourceLink: createV2SourceLink(getV2RouteSourcePath(path, section)),
+  })
+);

--- a/example/src/v2/app/constants/v2-source-base-url.ts
+++ b/example/src/v2/app/constants/v2-source-base-url.ts
@@ -1,0 +1,2 @@
+export const V2_SOURCE_BASE_URL =
+  'https://github.com/vojtechportes/react-query-builder/blob/master';

--- a/example/src/v2/app/types/v2-breadcrumb.ts
+++ b/example/src/v2/app/types/v2-breadcrumb.ts
@@ -1,0 +1,5 @@
+export interface IV2Breadcrumb {
+  label: string;
+  path: string;
+  publicPath: string;
+}

--- a/example/src/v2/app/types/v2-fallback-route.ts
+++ b/example/src/v2/app/types/v2-fallback-route.ts
@@ -1,0 +1,5 @@
+export interface IV2FallbackRoute {
+  path: '*';
+  to: string;
+  publicTo: string;
+}

--- a/example/src/v2/app/types/v2-navigation-item.ts
+++ b/example/src/v2/app/types/v2-navigation-item.ts
@@ -1,0 +1,5 @@
+export interface IV2NavigationItem {
+  label: string;
+  path: string;
+  publicPath: string;
+}

--- a/example/src/v2/app/types/v2-related-link.ts
+++ b/example/src/v2/app/types/v2-related-link.ts
@@ -1,0 +1,6 @@
+export interface IV2RelatedLink {
+  label: string;
+  path: string;
+  publicPath?: string;
+  external: boolean;
+}

--- a/example/src/v2/app/types/v2-route-definition.ts
+++ b/example/src/v2/app/types/v2-route-definition.ts
@@ -1,0 +1,7 @@
+import type { V2RouteSection } from './v2-route-section';
+
+export interface IV2RouteDefinition {
+  path: string;
+  title: string;
+  section: V2RouteSection;
+}

--- a/example/src/v2/app/types/v2-route-record.ts
+++ b/example/src/v2/app/types/v2-route-record.ts
@@ -1,0 +1,14 @@
+import type { IV2Breadcrumb } from './v2-breadcrumb';
+import type { IV2RelatedLink } from './v2-related-link';
+import type { V2RouteSection } from './v2-route-section';
+import type { IV2SourceLink } from './v2-source-link';
+
+export interface IV2RouteRecord {
+  path: string;
+  publicPath: string;
+  title: string;
+  section: V2RouteSection;
+  breadcrumbs: IV2Breadcrumb[];
+  relatedLinks: IV2RelatedLink[];
+  sourceLink: IV2SourceLink;
+}

--- a/example/src/v2/app/types/v2-route-redirect.ts
+++ b/example/src/v2/app/types/v2-route-redirect.ts
@@ -1,0 +1,6 @@
+export interface IV2RouteRedirect {
+  from: string;
+  publicFrom: string;
+  to: string;
+  publicTo: string;
+}

--- a/example/src/v2/app/types/v2-route-section.ts
+++ b/example/src/v2/app/types/v2-route-section.ts
@@ -1,0 +1,6 @@
+export type V2RouteSection =
+  | 'Home'
+  | 'Documentation'
+  | 'API'
+  | 'Demo'
+  | 'Recipes';

--- a/example/src/v2/app/types/v2-source-link.ts
+++ b/example/src/v2/app/types/v2-source-link.ts
@@ -1,0 +1,4 @@
+export interface IV2SourceLink {
+  path: string;
+  href: string;
+}

--- a/example/src/v2/app/utils/create-v2-breadcrumbs.util.ts
+++ b/example/src/v2/app/utils/create-v2-breadcrumbs.util.ts
@@ -1,0 +1,19 @@
+import type { IV2Breadcrumb } from '../types/v2-breadcrumb';
+import { createV2PublicPath } from './create-v2-public-path.util';
+
+export const createV2Breadcrumbs = (
+  path: string,
+  titlesByPath: ReadonlyMap<string, string>
+): IV2Breadcrumb[] => {
+  const segments = path.split('/').filter(Boolean);
+  const paths = [
+    '/',
+    ...segments.map((_, index) => `/${segments.slice(0, index + 1).join('/')}`),
+  ];
+
+  return paths.map((breadcrumbPath) => ({
+    label: titlesByPath.get(breadcrumbPath) ?? breadcrumbPath,
+    path: breadcrumbPath,
+    publicPath: createV2PublicPath(breadcrumbPath),
+  }));
+};

--- a/example/src/v2/app/utils/create-v2-page-metadata-options.util.ts
+++ b/example/src/v2/app/utils/create-v2-page-metadata-options.util.ts
@@ -1,0 +1,14 @@
+import type { ISeoPage } from '../../../constants/seo-pages';
+import type { IV2RouteRecord } from '../types/v2-route-record';
+
+export const createV2PageMetadataOptions = (
+  seoPage: ISeoPage,
+  route: IV2RouteRecord
+) => ({
+  ...seoPage,
+  path: route.publicPath,
+  breadcrumbs: route.breadcrumbs.map(({ label, publicPath }) => ({
+    name: label,
+    path: publicPath,
+  })),
+});

--- a/example/src/v2/app/utils/create-v2-public-path.util.ts
+++ b/example/src/v2/app/utils/create-v2-public-path.util.ts
@@ -1,0 +1,4 @@
+import { addVersionPrefix } from '../../../shared/versioned-url';
+
+export const createV2PublicPath = (url: string, basename?: string): string =>
+  addVersionPrefix(url, 'v2', basename);

--- a/example/src/v2/app/utils/create-v2-related-links.util.ts
+++ b/example/src/v2/app/utils/create-v2-related-links.util.ts
@@ -1,0 +1,64 @@
+import { relatedRecipesByPath as apiRelatedRecipesByPath } from '../../pages/api-page/constants/related-recipes-by-path';
+import { documentationPages } from '../../pages/documentation-page/constants/documentation-pages';
+import { relatedRecipesByPath as documentationRelatedRecipesByPath } from '../../pages/documentation-page/constants/related-recipes-by-path';
+import { recipes } from '../../pages/recipes-page/pages/recipes-content';
+import type { IV2RelatedLink } from '../types/v2-related-link';
+import type { V2RouteSection } from '../types/v2-route-section';
+import { createV2PublicPath } from './create-v2-public-path.util';
+
+export const createV2RelatedLinks = (
+  path: string,
+  section: V2RouteSection
+): IV2RelatedLink[] => {
+  const pageLinks =
+    section === 'Documentation'
+      ? documentationRelatedRecipesByPath[path]
+      : section === 'API'
+        ? apiRelatedRecipesByPath[path]
+        : undefined;
+
+  if (pageLinks) {
+    return pageLinks.map((link) => ({
+      label: link.label,
+      path: link.path,
+      publicPath: createV2PublicPath(link.path),
+      external: false,
+    }));
+  }
+
+  if (section !== 'Recipes' || path === '/recipes') {
+    return [];
+  }
+
+  const recipe = recipes.find((candidate) => candidate.path === path);
+
+  if (!recipe) {
+    return [];
+  }
+
+  const internalLinks = [
+    ...recipe.relatedDocPaths.map((relatedPath) => ({
+      label:
+        documentationPages.find((page) => page.path === relatedPath)?.title ??
+        relatedPath,
+      path: relatedPath,
+      publicPath: createV2PublicPath(relatedPath),
+      external: false,
+    })),
+    ...recipe.relatedRecipePaths.map((relatedPath) => ({
+      label:
+        recipes.find((candidate) => candidate.path === relatedPath)?.title ??
+        relatedPath,
+      path: relatedPath,
+      publicPath: createV2PublicPath(relatedPath),
+      external: false,
+    })),
+  ];
+  const externalLinks = (recipe.externalReferences ?? []).map((reference) => ({
+    label: reference.label,
+    path: reference.href,
+    external: true,
+  }));
+
+  return [...internalLinks, ...externalLinks];
+};

--- a/example/src/v2/app/utils/create-v2-source-link.util.ts
+++ b/example/src/v2/app/utils/create-v2-source-link.util.ts
@@ -1,0 +1,7 @@
+import type { IV2SourceLink } from '../types/v2-source-link';
+import { V2_SOURCE_BASE_URL } from '../constants/v2-source-base-url';
+
+export const createV2SourceLink = (path: string): IV2SourceLink => ({
+  path,
+  href: `${V2_SOURCE_BASE_URL}/${path}`,
+});

--- a/example/src/v2/app/utils/find-v2-route-record.util.ts
+++ b/example/src/v2/app/utils/find-v2-route-record.util.ts
@@ -1,0 +1,11 @@
+import { v2RouteManifest } from '../constants/v2-route-manifest';
+import type { IV2RouteRecord } from '../types/v2-route-record';
+
+export const findV2RouteRecord = (pathname: string): IV2RouteRecord => {
+  const normalizedPath = pathname.replace(/\/+$/, '') || '/';
+
+  return (
+    v2RouteManifest.find((route) => route.path === normalizedPath) ??
+    v2RouteManifest[0]
+  );
+};

--- a/example/src/v2/app/utils/get-v2-route-source-path.util.ts
+++ b/example/src/v2/app/utils/get-v2-route-source-path.util.ts
@@ -1,0 +1,34 @@
+import type { V2RouteSection } from '../types/v2-route-section';
+
+export const getV2RouteSourcePath = (
+  path: string,
+  section: V2RouteSection
+): string => {
+  if (section === 'Home') {
+    return 'example/src/v2/pages/home-page/home-page.tsx';
+  }
+
+  if (section === 'Demo') {
+    return 'example/src/v2/pages/demo-page/demo-page.tsx';
+  }
+
+  if (section === 'Recipes') {
+    const recipeName = path.split('/').filter(Boolean)[1];
+
+    return recipeName
+      ? `example/src/v2/pages/recipes-page/pages/${recipeName}.recipe.ts`
+      : 'example/src/v2/pages/recipes-page/recipes-page.tsx';
+  }
+
+  const routeName = path.split('/').filter(Boolean).slice(1).join('-');
+
+  if (section === 'API') {
+    const contentName = routeName || 'overview';
+
+    return `example/src/v2/pages/api-page/components/${contentName}-api-content.tsx`;
+  }
+
+  const pageName = `${routeName || 'overview'}-documentation-page`;
+
+  return `example/src/v2/pages/documentation-page/pages/${pageName}/${pageName}.tsx`;
+};

--- a/example/src/v2/app/utils/get-v2-router-basename.util.ts
+++ b/example/src/v2/app/utils/get-v2-router-basename.util.ts
@@ -1,0 +1,4 @@
+import { createV2PublicPath } from './create-v2-public-path.util';
+
+export const getV2RouterBasename = (basename?: string): string =>
+  createV2PublicPath('/', basename);

--- a/example/src/v2/app/v2-app-routes.test.tsx
+++ b/example/src/v2/app/v2-app-routes.test.tsx
@@ -1,0 +1,116 @@
+/* @vitest-environment jsdom */
+
+import * as React from 'react';
+import { cleanup, render, screen, waitFor } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import { afterEach, beforeAll, describe, expect, it, vi } from 'vitest';
+import { renderApp } from '../../shared/ssr/render-app.util';
+import { V2AppRoutes } from './v2-app-routes';
+import { getV2RouterBasename } from './utils/get-v2-router-basename.util';
+
+beforeAll(() => {
+  window.scrollTo = vi.fn();
+});
+
+afterEach(() => {
+  cleanup();
+});
+
+const renderClientRoute = (path: string) =>
+  render(
+    <MemoryRouter basename="/v2" initialEntries={[`/v2${path}`]}>
+      <V2AppRoutes />
+    </MemoryRouter>
+  );
+
+describe('v2 app routes', () => {
+  it('renders v2-prefixed top navigation and nested sidebar links', () => {
+    const page = renderApp(
+      '/documentation/adapters/mui',
+      getV2RouterBasename(),
+      <V2AppRoutes />
+    );
+
+    expect(page.html).toContain('href="/v2"');
+    expect(page.html).toContain('href="/v2/documentation"');
+    expect(page.html).toContain('href="/v2/api"');
+    expect(page.html).toContain('href="/v2/demo"');
+    expect(page.html).toContain('href="/v2/recipes"');
+    expect(page.html).toContain('href="/v2/documentation/adapters/mui"');
+  });
+
+  it('renders links under a repository deployment basename', () => {
+    const page = renderApp(
+      '/api/adapters/mui',
+      getV2RouterBasename('/react-query-builder/'),
+      <V2AppRoutes />
+    );
+
+    expect(page.html).toContain('href="/react-query-builder/v2"');
+    expect(page.html).toContain('href="/react-query-builder/v2/documentation"');
+    expect(page.html).toContain(
+      'href="/react-query-builder/v2/api/adapters/mui"'
+    );
+    expect(page.html).not.toContain('/v2/v2');
+  });
+
+  it('renders v2-prefixed related links', () => {
+    const page = renderApp(
+      '/documentation/dynamic-field-options',
+      getV2RouterBasename(),
+      <V2AppRoutes />
+    );
+
+    expect(page.html).toContain(
+      'href="/v2/recipes/dynamic-operators-by-field-type"'
+    );
+  });
+
+  it('uses public v2 paths in client metadata and breadcrumbs', async () => {
+    renderClientRoute('/api/builder');
+
+    await waitFor(() => {
+      expect(
+        document.head.querySelector<HTMLLinkElement>('link[rel="canonical"]')
+          ?.href
+      ).toContain('/v2/api/builder');
+    });
+
+    const structuredData = JSON.parse(
+      document.head.querySelector<HTMLScriptElement>(
+        'script#structured-data-page'
+      )?.textContent ?? '[]'
+    ) as {
+      '@type': string;
+      itemListElement?: { item: string }[];
+    }[];
+    const breadcrumbs = structuredData.find(
+      (record) => record['@type'] === 'BreadcrumbList'
+    );
+
+    expect(breadcrumbs?.itemListElement?.map((item) => item.item)).toEqual([
+      expect.stringContaining('/v2'),
+      expect.stringContaining('/v2/api'),
+      expect.stringContaining('/v2/api/builder'),
+    ]);
+  });
+
+  it('redirects a legacy v2 route to its owned canonical destination', async () => {
+    renderClientRoute('/api/builder-props');
+
+    expect(
+      await screen.findByRole('heading', { level: 1, name: 'Builder' })
+    ).toBeDefined();
+  });
+
+  it('handles an unknown v2 route by returning to the v2 Home page', async () => {
+    renderClientRoute('/route-not-owned-by-v2');
+
+    expect(
+      await screen.findByRole('heading', {
+        level: 1,
+        name: 'React Query Builder',
+      })
+    ).toBeDefined();
+  });
+});

--- a/example/src/v2/app/v2-app-routes.tsx
+++ b/example/src/v2/app/v2-app-routes.tsx
@@ -1,0 +1,51 @@
+import * as React from 'react';
+import { Navigate, Route, Routes } from 'react-router-dom';
+import { SiteShell } from '../../components/site-shell';
+import { v2TopNavigation } from '../navigation/constants/v2-top-navigation';
+import { ApiPage } from '../pages/api-page/api-page';
+import { DemoPage } from '../pages/demo-page/demo-page';
+import { DocumentationPage } from '../pages/documentation-page/documentation-page';
+import { HomePage } from '../pages/home-page/home-page';
+import { RecipesPage } from '../pages/recipes-page/recipes-page';
+import { v2FallbackRoute } from './constants/v2-fallback-route';
+import { v2LegacyRouteRedirects } from './constants/v2-legacy-route-redirects';
+import { v2RouteManifest } from './constants/v2-route-manifest';
+
+export const V2AppRoutes: React.FC = () => {
+  const pageElements = {
+    API: <ApiPage />,
+    Demo: <DemoPage />,
+    Documentation: <DocumentationPage />,
+    Home: <HomePage />,
+    Recipes: <RecipesPage />,
+  };
+
+  return (
+    <Routes>
+      <Route
+        element={
+          <SiteShell versionLabel="Docs v2" topNavigation={v2TopNavigation} />
+        }
+      >
+        {v2RouteManifest.map((route) => (
+          <Route
+            key={route.path}
+            path={route.path}
+            element={pageElements[route.section]}
+          />
+        ))}
+        {v2LegacyRouteRedirects.map((redirect) => (
+          <Route
+            key={redirect.from}
+            path={redirect.from}
+            element={<Navigate to={redirect.to} replace />}
+          />
+        ))}
+        <Route
+          path={v2FallbackRoute.path}
+          element={<Navigate to={v2FallbackRoute.to} replace />}
+        />
+      </Route>
+    </Routes>
+  );
+};

--- a/example/src/v2/app/v2-app.tsx
+++ b/example/src/v2/app/v2-app.tsx
@@ -1,0 +1,10 @@
+import * as React from 'react';
+import { BrowserRouter } from 'react-router-dom';
+import { V2AppRoutes } from './v2-app-routes';
+import { v2RouterBasename } from './v2-router-basename';
+
+export const V2App: React.FC = () => (
+  <BrowserRouter basename={v2RouterBasename}>
+    <V2AppRoutes />
+  </BrowserRouter>
+);

--- a/example/src/v2/app/v2-route-manifest.test.ts
+++ b/example/src/v2/app/v2-route-manifest.test.ts
@@ -1,0 +1,159 @@
+import { describe, expect, it } from 'vitest';
+import { v2TopNavigation } from '../navigation/constants/v2-top-navigation';
+import { v2ApiSidebar } from '../navigation/constants/v2-api-sidebar';
+import { v2DocumentationSidebar } from '../navigation/constants/v2-documentation-sidebar';
+import { v2RecipesSidebar } from '../navigation/constants/v2-recipes-sidebar';
+import { apiPages } from '../pages/api-page/constants/api-pages';
+import { documentationPages } from '../pages/documentation-page/constants/documentation-pages';
+import { recipes } from '../pages/recipes-page/pages/recipes-content';
+import { v2FallbackRoute } from './constants/v2-fallback-route';
+import { v2LegacyRouteRedirects } from './constants/v2-legacy-route-redirects';
+import { v2RouteManifest } from './constants/v2-route-manifest';
+import { createV2PublicPath } from './utils/create-v2-public-path.util';
+import { findV2RouteRecord } from './utils/find-v2-route-record.util';
+import { getV2RouterBasename } from './utils/get-v2-router-basename.util';
+
+const v2SourcePaths = new Set(
+  Object.keys(
+    import.meta.glob([
+      '/src/v2/pages/home-page/home-page.tsx',
+      '/src/v2/pages/demo-page/demo-page.tsx',
+      '/src/v2/pages/api-page/components/*-api-content.tsx',
+      '/src/v2/pages/documentation-page/pages/*/*.tsx',
+      '/src/v2/pages/recipes-page/pages/*.recipe.ts',
+      '/src/v2/pages/recipes-page/recipes-page.tsx',
+    ])
+  ).map((path) => `example${path}`)
+);
+const expectedCanonicalPaths = [
+  '/',
+  ...documentationPages.map((page) => page.path),
+  ...apiPages.map((page) => page.path),
+  '/demo',
+  '/recipes',
+  ...recipes.map((page) => page.path),
+];
+
+const getSidebarPaths = (sidebar: {
+  overviewPage: { path: string };
+  groups: { pages: { path: string }[] }[];
+}) => [
+  sidebar.overviewPage.path,
+  ...sidebar.groups.flatMap((group) => group.pages.map((page) => page.path)),
+];
+
+describe('v2 route manifest', () => {
+  it('owns the complete canonical v2 route set exactly once', () => {
+    const manifestPaths = v2RouteManifest.map((route) => route.path);
+
+    expect(manifestPaths).toHaveLength(55);
+    expect(new Set(manifestPaths).size).toBe(manifestPaths.length);
+    expect(new Set(manifestPaths)).toEqual(new Set(expectedCanonicalPaths));
+  });
+
+  it('provides v2 public paths, breadcrumbs, related links, and source links', () => {
+    const manifestPaths = new Set(v2RouteManifest.map((route) => route.path));
+
+    for (const route of v2RouteManifest) {
+      expect(route.publicPath).toBe(createV2PublicPath(route.path));
+      expect(route.breadcrumbs[0]).toEqual({
+        label: 'Home',
+        path: '/',
+        publicPath: '/v2',
+      });
+      expect(route.breadcrumbs.at(-1)?.path).toBe(route.path);
+      expect(route.sourceLink.path).toMatch(/^example\/src\/v2\//);
+      expect(route.sourceLink.href).toBe(
+        `https://github.com/vojtechportes/react-query-builder/blob/master/${route.sourceLink.path}`
+      );
+      expect(v2SourcePaths.has(route.sourceLink.path)).toBe(true);
+
+      for (const relatedLink of route.relatedLinks) {
+        if (relatedLink.external) {
+          expect(relatedLink.path).toMatch(/^https?:\/\//);
+          expect(relatedLink.publicPath).toBeUndefined();
+        } else {
+          expect(manifestPaths.has(relatedLink.path)).toBe(true);
+          expect(relatedLink.publicPath).toBe(
+            createV2PublicPath(relatedLink.path)
+          );
+        }
+      }
+    }
+  });
+
+  it('creates the expected top navigation and complete section sidebars', () => {
+    expect(v2TopNavigation).toEqual([
+      { label: 'Home', path: '/', publicPath: '/v2' },
+      {
+        label: 'Documentation',
+        path: '/documentation',
+        publicPath: '/v2/documentation',
+      },
+      { label: 'API', path: '/api', publicPath: '/v2/api' },
+      { label: 'Demo', path: '/demo', publicPath: '/v2/demo' },
+      { label: 'Recipes', path: '/recipes', publicPath: '/v2/recipes' },
+    ]);
+    expect(getSidebarPaths(v2DocumentationSidebar)).toEqual(
+      documentationPages.map((page) => page.path)
+    );
+    expect(getSidebarPaths(v2ApiSidebar)).toEqual(
+      apiPages.map((page) => page.path)
+    );
+    expect(getSidebarPaths(v2RecipesSidebar)).toEqual([
+      '/recipes',
+      ...recipes.map((page) => page.path),
+    ]);
+  });
+
+  it('defines all legacy destinations and the unknown-route fallback within v2', () => {
+    const canonicalPaths = new Set(v2RouteManifest.map((route) => route.path));
+
+    expect(v2LegacyRouteRedirects).toHaveLength(8);
+    expect(
+      new Set(v2LegacyRouteRedirects.map((route) => route.from)).size
+    ).toBe(8);
+
+    for (const redirect of v2LegacyRouteRedirects) {
+      expect(canonicalPaths.has(redirect.to)).toBe(true);
+      expect(redirect.publicFrom).toBe(createV2PublicPath(redirect.from));
+      expect(redirect.publicTo).toBe(createV2PublicPath(redirect.to));
+    }
+
+    expect(v2FallbackRoute).toEqual({
+      path: '*',
+      to: '/',
+      publicTo: '/v2',
+    });
+    expect(findV2RouteRecord('/not-owned-by-v2')).toBe(v2RouteManifest[0]);
+    expect(findV2RouteRecord('/api/builder/').path).toBe('/api/builder');
+  });
+
+  it.each([
+    ['/', undefined, '/v2'],
+    ['/documentation/usage', undefined, '/v2/documentation/usage'],
+    [
+      '/documentation/usage?tab=api#example',
+      undefined,
+      '/v2/documentation/usage?tab=api#example',
+    ],
+    ['/', '/react-query-builder/', '/react-query-builder/v2'],
+    [
+      '/api/adapters/mui?tab=props#theme',
+      '/react-query-builder/',
+      '/react-query-builder/v2/api/adapters/mui?tab=props#theme',
+    ],
+  ] as const)(
+    'prefixes %s with deployment basename %s',
+    (path, base, expected) => {
+      expect(createV2PublicPath(path, base)).toBe(expected);
+    }
+  );
+
+  it('creates root and repository deployment router basenames', () => {
+    expect(getV2RouterBasename()).toBe('/v2');
+    expect(getV2RouterBasename('/react-query-builder/')).toBe(
+      '/react-query-builder/v2'
+    );
+  });
+});

--- a/example/src/v2/app/v2-router-basename.ts
+++ b/example/src/v2/app/v2-router-basename.ts
@@ -1,0 +1,4 @@
+import { routerBasename } from '../../app/router-basename';
+import { getV2RouterBasename } from './utils/get-v2-router-basename.util';
+
+export const v2RouterBasename = getV2RouterBasename(routerBasename);

--- a/example/src/v2/entry-client.tsx
+++ b/example/src/v2/entry-client.tsx
@@ -1,18 +1,5 @@
 import * as React from 'react';
-import { App } from '../app/app';
-import { DemoPage } from './pages/demo-page/demo-page';
-import { HomePage } from './pages/home-page/home-page';
-import { RecipesPage } from './pages/recipes-page/recipes-page';
-import { DocumentationPage } from './pages/documentation-page/documentation-page';
 import { hydrateApp } from '../shared/client/hydrate-app.util';
-import { ApiPage } from './pages/api-page/api-page';
+import { V2App } from './app/v2-app';
 
-hydrateApp(
-  <App
-    apiPage={<ApiPage />}
-    demoPage={<DemoPage />}
-    documentationPage={<DocumentationPage />}
-    homePage={<HomePage />}
-    recipesPage={<RecipesPage />}
-  />
-);
+hydrateApp(<V2App />);

--- a/example/src/v2/entry-server.tsx
+++ b/example/src/v2/entry-server.tsx
@@ -1,22 +1,7 @@
 import * as React from 'react';
-import { AppRoutes } from '../app/app-routes';
-import { routerBasename } from '../app/router-basename';
-import { DemoPage } from './pages/demo-page/demo-page';
-import { HomePage } from './pages/home-page/home-page';
-import { RecipesPage } from './pages/recipes-page/recipes-page';
-import { DocumentationPage } from './pages/documentation-page/documentation-page';
 import { renderApp } from '../shared/ssr/render-app.util';
-import { ApiPage } from './pages/api-page/api-page';
+import { V2AppRoutes } from './app/v2-app-routes';
+import { v2RouterBasename } from './app/v2-router-basename';
 
 export const renderPage = (pathname: string) =>
-  renderApp(
-    pathname,
-    routerBasename,
-    <AppRoutes
-      apiPage={<ApiPage />}
-      demoPage={<DemoPage />}
-      documentationPage={<DocumentationPage />}
-      homePage={<HomePage />}
-      recipesPage={<RecipesPage />}
-    />
-  );
+  renderApp(pathname, v2RouterBasename, <V2AppRoutes />);

--- a/example/src/v2/navigation/constants/v2-api-sidebar.ts
+++ b/example/src/v2/navigation/constants/v2-api-sidebar.ts
@@ -1,0 +1,8 @@
+import { apiGroups } from '../../pages/api-page/constants/api-groups';
+import { apiPages } from '../../pages/api-page/constants/api-pages';
+
+export const v2ApiSidebar = {
+  title: 'API',
+  overviewPage: apiPages[0],
+  groups: apiGroups,
+};

--- a/example/src/v2/navigation/constants/v2-documentation-sidebar.ts
+++ b/example/src/v2/navigation/constants/v2-documentation-sidebar.ts
@@ -1,0 +1,8 @@
+import { documentationGroups } from '../../pages/documentation-page/constants/documentation-groups';
+import { documentationPages } from '../../pages/documentation-page/constants/documentation-pages';
+
+export const v2DocumentationSidebar = {
+  title: 'Documentation',
+  overviewPage: documentationPages[0],
+  groups: documentationGroups,
+};

--- a/example/src/v2/navigation/constants/v2-recipes-sidebar.ts
+++ b/example/src/v2/navigation/constants/v2-recipes-sidebar.ts
@@ -1,0 +1,8 @@
+import { recipeGroups } from '../../pages/recipes-page/constants/recipe-groups';
+import { recipesOverviewPage } from '../../pages/recipes-page/constants/recipes-overview-page';
+
+export const v2RecipesSidebar = {
+  title: 'Recipes',
+  overviewPage: recipesOverviewPage,
+  groups: recipeGroups,
+};

--- a/example/src/v2/navigation/constants/v2-top-level-paths.ts
+++ b/example/src/v2/navigation/constants/v2-top-level-paths.ts
@@ -1,0 +1,7 @@
+export const v2TopLevelPaths = [
+  '/',
+  '/documentation',
+  '/api',
+  '/demo',
+  '/recipes',
+] as const;

--- a/example/src/v2/navigation/constants/v2-top-navigation.ts
+++ b/example/src/v2/navigation/constants/v2-top-navigation.ts
@@ -1,0 +1,15 @@
+import { v2RouteManifest } from '../../app/constants/v2-route-manifest';
+import type { IV2NavigationItem } from '../../app/types/v2-navigation-item';
+import { v2TopLevelPaths } from './v2-top-level-paths';
+
+export const v2TopNavigation: IV2NavigationItem[] = v2TopLevelPaths.map(
+  (path) => {
+    const route = v2RouteManifest.find((candidate) => candidate.path === path)!;
+
+    return {
+      label: route.section,
+      path: route.path,
+      publicPath: route.publicPath,
+    };
+  }
+);

--- a/example/src/v2/pages/api-page/api-page.tsx
+++ b/example/src/v2/pages/api-page/api-page.tsx
@@ -1,14 +1,14 @@
 import * as React from 'react';
-import styled from 'styled-components';
 import { useLocation } from 'react-router-dom';
+import styled from 'styled-components';
 import { ContentArticle } from '../../../components/content-article';
 import { DocumentationSidebar } from '../../../components/documentation-sidebar';
 import { RelatedRecipes } from '../../../components/related-recipes';
-import { relatedRecipesByPath } from './constants/related-recipes-by-path';
 import { findSeoPage } from '../../../constants/seo-pages';
 import { usePageMetadata } from '../../../hooks/use-page-metadata';
-import { apiGroups } from './constants/api-groups';
-import { apiPages } from './constants/api-pages';
+import { createV2PageMetadataOptions } from '../../app/utils/create-v2-page-metadata-options.util';
+import { findV2RouteRecord } from '../../app/utils/find-v2-route-record.util';
+import { v2ApiSidebar } from '../../navigation/constants/v2-api-sidebar';
 import { findApiPage } from './utils/find-api-page.util';
 
 const Layout = styled.div`
@@ -42,22 +42,24 @@ const Summary = styled.p`
 export const ApiPage: React.FC = () => {
   const location = useLocation();
   const page = findApiPage(location.pathname);
+  const route = findV2RouteRecord(page.path);
   const seoPage = findSeoPage(page.path);
-  usePageMetadata(seoPage.title, seoPage.description, seoPage);
+
+  usePageMetadata(
+    seoPage.title,
+    seoPage.description,
+    createV2PageMetadataOptions(seoPage, route)
+  );
 
   return (
     <Layout>
-      <DocumentationSidebar
-        title="API"
-        overviewPage={apiPages[0]}
-        groups={apiGroups}
-      />
+      <DocumentationSidebar {...v2ApiSidebar} />
       <ContentArticle>
         <SectionLabel>{page.sectionTitle}</SectionLabel>
         <Title>{page.title}</Title>
         {page.summary ? <Summary>{page.summary}</Summary> : null}
         {page.content}
-        <RelatedRecipes links={relatedRecipesByPath[page.path]} />
+        <RelatedRecipes links={route.relatedLinks} />
       </ContentArticle>
     </Layout>
   );

--- a/example/src/v2/pages/demo-page/demo-page.tsx
+++ b/example/src/v2/pages/demo-page/demo-page.tsx
@@ -3,6 +3,8 @@ import styled from 'styled-components';
 import { ClientOnly } from '../../../components/client-only';
 import { findSeoPage } from '../../../constants/seo-pages';
 import { usePageMetadata } from '../../../hooks/use-page-metadata';
+import { findV2RouteRecord } from '../../app/utils/find-v2-route-record.util';
+import { createV2PageMetadataOptions } from '../../app/utils/create-v2-page-metadata-options.util';
 import { loadDemoPlayground } from './load-demo-playground';
 
 const Root = styled.section`
@@ -16,9 +18,14 @@ const Title = styled.h1`
 `;
 
 const seoPage = findSeoPage('/demo');
+const route = findV2RouteRecord('/demo');
 
 export const DemoPage: React.FC = () => {
-  usePageMetadata(seoPage.title, seoPage.description, seoPage);
+  usePageMetadata(
+    seoPage.title,
+    seoPage.description,
+    createV2PageMetadataOptions(seoPage, route)
+  );
 
   return (
     <Root>

--- a/example/src/v2/pages/documentation-page/documentation-page.tsx
+++ b/example/src/v2/pages/documentation-page/documentation-page.tsx
@@ -10,26 +10,27 @@ import { DocumentationSidebar } from '../../../components/documentation-sidebar'
 import { RelatedRecipes } from '../../../components/related-recipes';
 import { findSeoPage } from '../../../constants/seo-pages';
 import { usePageMetadata } from '../../../hooks/use-page-metadata';
-import { documentationGroups } from './constants/documentation-groups';
-import { documentationPages } from './constants/documentation-pages';
-import { relatedRecipesByPath } from './constants/related-recipes-by-path';
+import { createV2PageMetadataOptions } from '../../app/utils/create-v2-page-metadata-options.util';
+import { findV2RouteRecord } from '../../app/utils/find-v2-route-record.util';
+import { v2DocumentationSidebar } from '../../navigation/constants/v2-documentation-sidebar';
 import { findDocumentationPage } from './utils/find-documentation-page.util';
 import { loadParsingSandbox } from './utils/load-parsing-sandbox.util';
 
 export const DocumentationPage: React.FC = () => {
   const location = useLocation();
   const page = findDocumentationPage(location.pathname);
+  const route = findV2RouteRecord(page.path);
   const seoPage = findSeoPage(page.path);
 
-  usePageMetadata(seoPage.title, seoPage.description, seoPage);
+  usePageMetadata(
+    seoPage.title,
+    seoPage.description,
+    createV2PageMetadataOptions(seoPage, route)
+  );
 
   return (
     <DocumentationLayout>
-      <DocumentationSidebar
-        title="Documentation"
-        overviewPage={documentationPages[0]}
-        groups={documentationGroups}
-      />
+      <DocumentationSidebar {...v2DocumentationSidebar} />
       <ContentArticle>
         <DocumentationSectionLabel>
           {page.sectionTitle}
@@ -39,7 +40,7 @@ export const DocumentationPage: React.FC = () => {
           <DocumentationSummary>{page.summary}</DocumentationSummary>
         ) : null}
         {page.content}
-        <RelatedRecipes links={relatedRecipesByPath[page.path]} />
+        <RelatedRecipes links={route.relatedLinks} />
         {page.path === '/documentation/parsing-and-formatting' ? (
           <ClientOnly
             loader={loadParsingSandbox}

--- a/example/src/v2/pages/home-page/home-page.tsx
+++ b/example/src/v2/pages/home-page/home-page.tsx
@@ -4,6 +4,8 @@ import { Link } from 'react-router-dom';
 import { siteTheme } from '../../../constants/site-theme';
 import { findSeoPage } from '../../../constants/seo-pages';
 import { usePageMetadata } from '../../../hooks/use-page-metadata';
+import { createV2PageMetadataOptions } from '../../app/utils/create-v2-page-metadata-options.util';
+import { findV2RouteRecord } from '../../app/utils/find-v2-route-record.util';
 
 const Hero = styled.section`
   display: grid;
@@ -127,9 +129,14 @@ const Code = styled.code`
 `;
 
 const seoPage = findSeoPage('/');
+const route = findV2RouteRecord('/');
 
 export const HomePage: React.FC = () => {
-  usePageMetadata(seoPage.title, seoPage.description, seoPage);
+  usePageMetadata(
+    seoPage.title,
+    seoPage.description,
+    createV2PageMetadataOptions(seoPage, route)
+  );
 
   return (
     <Hero>

--- a/example/src/v2/pages/recipes-page/components/recipe-article.tsx
+++ b/example/src/v2/pages/recipes-page/components/recipe-article.tsx
@@ -2,6 +2,7 @@ import * as React from 'react';
 import { AlertBox } from '../../../../components/alert-box';
 import { CodeBlock } from '../../../../components/code-block';
 import { List, SectionTitle } from '../../../../components/docs-primitives';
+import type { IV2RelatedLink } from '../../../app/types/v2-related-link';
 import type { IRecipePage } from '../types/recipe-page';
 import { RecipeFaq } from './recipe-faq';
 import { RecipeLiveDemo } from './recipe-live-demo';
@@ -9,12 +10,12 @@ import { RecipeRelatedLinks } from './recipe-related-links';
 
 export interface IRecipeArticleProps {
   page: IRecipePage;
-  pagesByPath: Map<string, IRecipePage>;
+  relatedLinks: IV2RelatedLink[];
 }
 
 export const RecipeArticle: React.FC<IRecipeArticleProps> = ({
   page,
-  pagesByPath,
+  relatedLinks,
 }) => (
   <>
     {page.illustrative ? (
@@ -64,7 +65,7 @@ export const RecipeArticle: React.FC<IRecipeArticleProps> = ({
         <li key={item}>{item}</li>
       ))}
     </List>
-    <RecipeRelatedLinks page={page} pagesByPath={pagesByPath} />
+    <RecipeRelatedLinks links={relatedLinks} />
     <RecipeFaq faqs={page.faqs} />
   </>
 );

--- a/example/src/v2/pages/recipes-page/components/recipe-related-links.tsx
+++ b/example/src/v2/pages/recipes-page/components/recipe-related-links.tsx
@@ -1,34 +1,21 @@
 import * as React from 'react';
 import { Link, SectionTitle } from '../../../../components/docs-primitives';
-import type { IRecipePage } from '../types/recipe-page';
-import { formatPathLabel } from '../utils/format-path-label.util';
+import type { IV2RelatedLink } from '../../../app/types/v2-related-link';
 
 export interface IRecipeRelatedLinksProps {
-  page: IRecipePage;
-  pagesByPath: Map<string, IRecipePage>;
+  links: IV2RelatedLink[];
 }
 
 export const RecipeRelatedLinks: React.FC<IRecipeRelatedLinksProps> = ({
-  page,
-  pagesByPath,
+  links,
 }) => (
   <section>
     <SectionTitle>Related guides</SectionTitle>
     <ul>
-      {page.relatedDocPaths.map((path) => (
-        <li key={path}>
-          <Link to={path}>{formatPathLabel(path)}</Link>
-        </li>
-      ))}
-      {page.relatedRecipePaths.map((path) => (
-        <li key={path}>
-          <Link to={path}>{pagesByPath.get(path)?.title ?? path}</Link>
-        </li>
-      ))}
-      {page.externalReferences?.map((reference) => (
-        <li key={reference.href}>
-          <Link to={reference.href} external>
-            {reference.label}
+      {links.map((link) => (
+        <li key={link.path}>
+          <Link to={link.path} external={link.external}>
+            {link.label}
           </Link>
         </li>
       ))}

--- a/example/src/v2/pages/recipes-page/recipes-page.tsx
+++ b/example/src/v2/pages/recipes-page/recipes-page.tsx
@@ -5,11 +5,11 @@ import { ContentArticle } from '../../../components/content-article';
 import { DocumentationSidebar } from '../../../components/documentation-sidebar';
 import { findSeoPage } from '../../../constants/seo-pages';
 import { usePageMetadata } from '../../../hooks/use-page-metadata';
+import { createV2PageMetadataOptions } from '../../app/utils/create-v2-page-metadata-options.util';
+import { findV2RouteRecord } from '../../app/utils/find-v2-route-record.util';
+import { v2RecipesSidebar } from '../../navigation/constants/v2-recipes-sidebar';
 import { RecipeArticle } from './components/recipe-article';
 import { RecipesOverview } from './components/recipes-overview';
-import { recipeGroups } from './constants/recipe-groups';
-import { recipesOverviewPage } from './constants/recipes-overview-page';
-import { recipes } from './pages/recipes-content';
 import { findRecipePage } from './utils/find-recipe-page.util';
 
 const Layout = styled.div`
@@ -39,34 +39,20 @@ const Summary = styled.p`
   margin-top: 0.55rem;
 `;
 
-const pagesByPath = new Map(recipes.map((page) => [page.path, page]));
-
 export const RecipesPage: React.FC = () => {
   const { pathname } = useLocation();
   const page = findRecipePage(pathname);
-  const seoPage = findSeoPage(page?.path ?? '/recipes');
+  const route = findV2RouteRecord(page?.path ?? '/recipes');
+  const seoPage = findSeoPage(route.path);
+
   usePageMetadata(seoPage.title, seoPage.description, {
-    ...seoPage,
-    breadcrumbs: page
-      ? [
-          { name: 'Home', path: '/' },
-          { name: 'Recipes', path: '/recipes' },
-          { name: page.title, path: page.path },
-        ]
-      : [
-          { name: 'Home', path: '/' },
-          { name: 'Recipes', path: '/recipes' },
-        ],
+    ...createV2PageMetadataOptions(seoPage, route),
     faqs: page?.faqs,
   });
 
   return (
     <Layout>
-      <DocumentationSidebar
-        title="Recipes"
-        overviewPage={recipesOverviewPage}
-        groups={recipeGroups}
-      />
+      <DocumentationSidebar {...v2RecipesSidebar} />
       <ContentArticle>
         <SectionLabel>Recipes</SectionLabel>
         <Title>{page?.title ?? 'React Query Builder Recipes'}</Title>
@@ -78,10 +64,10 @@ export const RecipesPage: React.FC = () => {
           <RecipeArticle
             key={page.path}
             page={page}
-            pagesByPath={pagesByPath}
+            relatedLinks={route.relatedLinks}
           />
         ) : (
-          <RecipesOverview groups={recipeGroups} />
+          <RecipesOverview groups={v2RecipesSidebar.groups} />
         )}
       </ContentArticle>
     </Layout>


### PR DESCRIPTION
- Added v2-owned canonical, legacy, fallback, and nested route records
- Created versioned navigation, sidebars, breadcrumbs, related links, and source links
- Wired v2 client and server entries to independent application routes
- Updated v2 pages to consume version-owned route metadata
- Added manifest, routing, prefix, redirect, source-link, and SSR coverage
- Marked T023 as completed