### PR TITLE
feat: Added version-aware route redirects

### DIFF
--- a/.codex/TASKS.md
+++ b/.codex/TASKS.md
@@ -1090,7 +1090,7 @@ v1.
 
 ### T025 - Add unversioned-to-v2 and version-local legacy redirects
 
-**Status:** `[ ]` Not started
+**Status:** `[x]` Done
 
 **Depends on:** T022 and T023
 

--- a/.codex/t025-add-unversioned-to-v2-and-version-local-legacy-redirects-tasks.md
+++ b/.codex/t025-add-unversioned-to-v2-and-version-local-legacy-redirects-tasks.md
@@ -1,0 +1,32 @@
+# T025 - Add unversioned-to-v2 and version-local legacy redirects
+
+- [x] Define the redirect and unknown-route behavior at the T025/T030 boundary.
+- [x] Add content-agnostic redirect resolution and static document utilities.
+- [x] Add independently owned v1 and v2 redirect manifests.
+- [x] Preserve search/hash for version-local client redirects and fallbacks.
+- [x] Cover root and repository basenames with a full status/location matrix.
+- [x] Run typechecks, focused tests, import-boundary tests, and versioned builds.
+- [x] Run Prettier on every modified code file.
+- [x] Complete the required code-review-agent pass and resolve findings.
+- [x] Mark T025 done in `.codex/TASKS.md`.
+
+## Decisions
+
+- Known redirects use permanent HTTP status `308` in the deployment-facing contract.
+- Unversioned canonical routes redirect to the same logical v2 route.
+- Unversioned legacy routes redirect directly to their v2 canonical destination in one hop.
+- Versioned legacy routes stay within their current version.
+- Redirects preserve query strings and hashes byte-for-byte.
+- Unknown generated/static routes return `404` without a `Location`.
+- Unknown client routes fall back to the current version Home while preserving query/hash.
+- T030 owns final artifact assembly, hosting configuration, workflows, and deployment documents.
+
+## Verification
+
+- Both v1 and v2 typechecks passed.
+- T025-focused v1 and v2 redirect suites passed.
+- The full v2 suite passed with 273 tests.
+- The full v1 suite passed 272 of 273 tests; the unrelated Demo playground test hit its existing five-second timeout under full-suite load and passed all 12 tests when run in isolation.
+- Modified-file ESLint and Prettier checks passed.
+- v1 and v2 client and SSR production builds passed.
+- The code review agent found no implementation issues; its branch-name finding was resolved by using the full title-derived task name.

--- a/example/config/versioned-site/route-redirects.test.ts
+++ b/example/config/versioned-site/route-redirects.test.ts
@@ -1,0 +1,192 @@
+import { describe, expect, it } from 'vitest';
+import type { IRouteRedirectConfiguration } from '../../src/shared/route-redirect';
+import {
+  permanentRedirectStatus,
+  resolveRouteRequest,
+} from '../../src/shared/route-redirect';
+import { v1RouteRedirectManifest } from '../../src/v1/app/constants/v1-route-redirect-manifest';
+import { v2RouteRedirectManifest } from '../../src/v2/app/constants/v2-route-redirect-manifest';
+import { createDeploymentPath } from './utils/create-deployment-path.util';
+
+const configuration: IRouteRedirectConfiguration = {
+  latestVersion: 'v2',
+  manifests: {
+    v1: v1RouteRedirectManifest,
+    v2: v2RouteRedirectManifest,
+  },
+};
+
+const deploymentBasenames = ['', '/react-query-builder/'] as const;
+
+describe('versioned route redirect contract', () => {
+  it('uses an explicit permanent redirect status', () => {
+    expect(permanentRedirectStatus).toBe(308);
+  });
+
+  it.each(deploymentBasenames)(
+    'redirects every unversioned canonical route directly to v2 under basename %s',
+    (basename) => {
+      for (const path of v2RouteRedirectManifest.canonicalPaths) {
+        const source = createDeploymentPath(basename, path);
+        const destination = createDeploymentPath(
+          basename,
+          path === '/' ? '/v2' : `/v2${path}`
+        );
+
+        expect(
+          resolveRouteRequest(configuration, { basename, url: source })
+        ).toEqual({ status: 308, location: destination });
+      }
+    }
+  );
+
+  it.each(deploymentBasenames)(
+    'redirects every unversioned legacy route directly to its v2 canonical destination under basename %s',
+    (basename) => {
+      for (const redirect of v2RouteRedirectManifest.redirects) {
+        const source = createDeploymentPath(basename, redirect.from);
+        const destination = createDeploymentPath(basename, `/v2${redirect.to}`);
+
+        expect(
+          resolveRouteRequest(configuration, { basename, url: source })
+        ).toEqual({ status: 308, location: destination });
+      }
+    }
+  );
+
+  it.each(deploymentBasenames)(
+    'keeps every version-local redirect in its version under basename %s',
+    (basename) => {
+      for (const version of ['v1', 'v2'] as const) {
+        const manifest = configuration.manifests[version];
+
+        for (const redirect of manifest.redirects) {
+          const source = createDeploymentPath(
+            basename,
+            `/${version}${redirect.from}`
+          );
+          const destination = createDeploymentPath(
+            basename,
+            `/${version}${redirect.to}`
+          );
+
+          expect(
+            resolveRouteRequest(configuration, { basename, url: source })
+          ).toEqual({ status: 308, location: destination });
+        }
+      }
+    }
+  );
+
+  it.each(deploymentBasenames)(
+    'does not redirect any versioned canonical route under basename %s',
+    (basename) => {
+      for (const version of ['v1', 'v2'] as const) {
+        for (const path of configuration.manifests[version].canonicalPaths) {
+          const source = createDeploymentPath(
+            basename,
+            path === '/' ? `/${version}` : `/${version}${path}`
+          );
+
+          expect(
+            resolveRouteRequest(configuration, { basename, url: source })
+          ).toEqual({ status: 200 });
+        }
+      }
+    }
+  );
+
+  it.each(deploymentBasenames)(
+    'preserves query strings and hashes byte-for-byte under basename %s',
+    (basename) => {
+      const source = `${createDeploymentPath(
+        basename,
+        '/api/builder-props'
+      )}?q=a%2Fb&q=c&empty=#ref%201`;
+      const destination = `${createDeploymentPath(
+        basename,
+        '/v2/api/builder'
+      )}?q=a%2Fb&q=c&empty=#ref%201`;
+
+      expect(
+        resolveRouteRequest(configuration, { basename, url: source })
+      ).toEqual({ status: 308, location: destination });
+    }
+  );
+
+  it.each(deploymentBasenames)(
+    'returns 404 without a Location for unknown generated routes under basename %s',
+    (basename) => {
+      for (const path of [
+        '/route-not-owned',
+        '/v1/route-not-owned',
+        '/v2/route-not-owned',
+      ]) {
+        expect(
+          resolveRouteRequest(configuration, {
+            basename,
+            url: createDeploymentPath(basename, path),
+          })
+        ).toEqual({ status: 404 });
+      }
+    }
+  );
+
+  it('accepts the repository basename root with or without a trailing slash', () => {
+    for (const url of ['/react-query-builder', '/react-query-builder/']) {
+      expect(
+        resolveRouteRequest(configuration, {
+          basename: '/react-query-builder/',
+          url,
+        })
+      ).toEqual({ status: 308, location: '/react-query-builder/v2' });
+    }
+  });
+
+  it.each(deploymentBasenames)(
+    'preserves query strings and hashes for version-local redirects under basename %s',
+    (basename) => {
+      for (const version of ['v1', 'v2'] as const) {
+        const source = `${createDeploymentPath(
+          basename,
+          `/${version}/api/builder-props`
+        )}?q=a%2Fb&q=c#ref%201`;
+        const destination = `${createDeploymentPath(
+          basename,
+          `/${version}/api/builder`
+        )}?q=a%2Fb&q=c#ref%201`;
+
+        expect(
+          resolveRouteRequest(configuration, { basename, url: source })
+        ).toEqual({ status: 308, location: destination });
+      }
+    }
+  );
+  it('does not claim paths outside the configured basename or basename lookalikes', () => {
+    for (const url of [
+      '/documentation',
+      '/react-query-builderish/documentation',
+    ]) {
+      expect(
+        resolveRouteRequest(configuration, {
+          basename: '/react-query-builder',
+          url,
+        })
+      ).toEqual({ status: 404 });
+    }
+  });
+
+  it('keeps redirect sources distinct and every destination canonical', () => {
+    for (const manifest of Object.values(configuration.manifests)) {
+      const canonicalPaths = new Set(manifest.canonicalPaths);
+      const redirectSources = manifest.redirects.map(({ from }) => from);
+
+      expect(new Set(redirectSources).size).toBe(redirectSources.length);
+
+      for (const redirect of manifest.redirects) {
+        expect(canonicalPaths.has(redirect.from)).toBe(false);
+        expect(canonicalPaths.has(redirect.to)).toBe(true);
+      }
+    }
+  });
+});

--- a/example/config/versioned-site/utils/create-deployment-path.util.ts
+++ b/example/config/versioned-site/utils/create-deployment-path.util.ts
@@ -1,0 +1,8 @@
+export const createDeploymentPath = (
+  basename: string,
+  path: string
+): string => {
+  const normalizedBasename = basename.replace(/\/$/, '');
+
+  return `${normalizedBasename}${path}` || '/';
+};

--- a/example/src/shared/route-redirect/components/route-redirect.tsx
+++ b/example/src/shared/route-redirect/components/route-redirect.tsx
@@ -1,0 +1,9 @@
+import * as React from 'react';
+import { Navigate, useLocation } from 'react-router-dom';
+import type { IRouteRedirectProps } from '../types/route-redirect-props';
+
+export const RouteRedirect: React.FC<IRouteRedirectProps> = ({ to }) => {
+  const { search, hash } = useLocation();
+
+  return <Navigate replace to={{ pathname: to, search, hash }} />;
+};

--- a/example/src/shared/route-redirect/constants/permanent-redirect-status.ts
+++ b/example/src/shared/route-redirect/constants/permanent-redirect-status.ts
@@ -1,0 +1,1 @@
+export const permanentRedirectStatus = 308 as const;

--- a/example/src/shared/route-redirect/index.ts
+++ b/example/src/shared/route-redirect/index.ts
@@ -1,0 +1,8 @@
+export { RouteRedirect } from './components/route-redirect';
+export { permanentRedirectStatus } from './constants/permanent-redirect-status';
+export type { IRouteRedirectConfiguration } from './types/route-redirect-configuration';
+export type { IRouteRedirectManifest } from './types/route-redirect-manifest';
+export type { IRouteRedirect } from './types/route-redirect';
+export type { RouteRequestResolution } from './types/route-request-resolution';
+export { createRouteRedirectDocument } from './utils/create-route-redirect-document.util';
+export { resolveRouteRequest } from './utils/resolve-route-request.util';

--- a/example/src/shared/route-redirect/types/resolve-route-request-options.ts
+++ b/example/src/shared/route-redirect/types/resolve-route-request-options.ts
@@ -1,0 +1,4 @@
+export interface IResolveRouteRequestOptions {
+  basename?: string;
+  url: string;
+}

--- a/example/src/shared/route-redirect/types/route-redirect-configuration.ts
+++ b/example/src/shared/route-redirect/types/route-redirect-configuration.ts
@@ -1,0 +1,7 @@
+import type { SiteVersion } from '../../versioned-url';
+import type { IRouteRedirectManifest } from './route-redirect-manifest';
+
+export interface IRouteRedirectConfiguration {
+  latestVersion: SiteVersion;
+  manifests: Record<SiteVersion, IRouteRedirectManifest>;
+}

--- a/example/src/shared/route-redirect/types/route-redirect-manifest.ts
+++ b/example/src/shared/route-redirect/types/route-redirect-manifest.ts
@@ -1,0 +1,6 @@
+import type { IRouteRedirect } from './route-redirect';
+
+export interface IRouteRedirectManifest {
+  canonicalPaths: readonly string[];
+  redirects: readonly IRouteRedirect[];
+}

--- a/example/src/shared/route-redirect/types/route-redirect-props.ts
+++ b/example/src/shared/route-redirect/types/route-redirect-props.ts
@@ -1,0 +1,3 @@
+export interface IRouteRedirectProps {
+  to: string;
+}

--- a/example/src/shared/route-redirect/types/route-redirect.ts
+++ b/example/src/shared/route-redirect/types/route-redirect.ts
@@ -1,0 +1,4 @@
+export interface IRouteRedirect {
+  from: string;
+  to: string;
+}

--- a/example/src/shared/route-redirect/types/route-request-resolution.ts
+++ b/example/src/shared/route-redirect/types/route-request-resolution.ts
@@ -1,0 +1,4 @@
+export type RouteRequestResolution =
+  | { status: 200 }
+  | { status: 308; location: string }
+  | { status: 404 };

--- a/example/src/shared/route-redirect/utils/create-route-redirect-document.util.test.ts
+++ b/example/src/shared/route-redirect/utils/create-route-redirect-document.util.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from 'vitest';
+import { createRouteRedirectDocument } from './create-route-redirect-document.util';
+
+describe('createRouteRedirectDocument', () => {
+  it('creates a noindex redirect document with a static fallback', () => {
+    const document = createRouteRedirectDocument('/v2/documentation');
+
+    expect(document).toContain('<meta name="robots" content="noindex" />');
+    expect(document).toContain(
+      '<meta http-equiv="refresh" content="0;url=/v2/documentation" />'
+    );
+    expect(document).toContain('href="/v2/documentation"');
+  });
+
+  it('preserves runtime query strings and hashes', () => {
+    const document = createRouteRedirectDocument('/v2/api/builder');
+
+    expect(document).toContain(
+      'window.location.replace("/v2/api/builder" + window.location.search + window.location.hash);'
+    );
+  });
+
+  it('escapes destinations in HTML and script contexts', () => {
+    const document = createRouteRedirectDocument('/v2/docs?<unsafe>');
+
+    expect(document).toContain('/v2/docs?&lt;unsafe&gt;');
+    expect(document).toContain('"/v2/docs?\\u003cunsafe>"');
+    expect(document).not.toContain('"/v2/docs?<unsafe>"');
+  });
+});

--- a/example/src/shared/route-redirect/utils/create-route-redirect-document.util.ts
+++ b/example/src/shared/route-redirect/utils/create-route-redirect-document.util.ts
@@ -1,0 +1,25 @@
+export const createRouteRedirectDocument = (location: string): string => {
+  const escapedLocation = location
+    .replace(/&/g, '&amp;')
+    .replace(/"/g, '&quot;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;');
+  const serializedLocation = JSON.stringify(location).replace(/</g, '\\u003c');
+
+  return `<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="robots" content="noindex" />
+    <meta http-equiv="refresh" content="0;url=${escapedLocation}" />
+    <title>Redirecting</title>
+    <script>
+      window.location.replace(${serializedLocation} + window.location.search + window.location.hash);
+    </script>
+  </head>
+  <body>
+    <p>Redirecting to <a href="${escapedLocation}">${escapedLocation}</a>.</p>
+  </body>
+</html>
+`;
+};

--- a/example/src/shared/route-redirect/utils/resolve-route-request.util.ts
+++ b/example/src/shared/route-redirect/utils/resolve-route-request.util.ts
@@ -1,0 +1,55 @@
+import type { IRouteRedirectConfiguration } from '../types/route-redirect-configuration';
+import type { IResolveRouteRequestOptions } from '../types/resolve-route-request-options';
+import type { RouteRequestResolution } from '../types/route-request-resolution';
+import { formatVersionedUrl } from '../../versioned-url/utils/format-versioned-url.util';
+import { normalizeBasename } from '../../versioned-url/utils/normalize-basename.util';
+import { parseVersionedUrl } from '../../versioned-url/utils/parse-versioned-url.util';
+import { permanentRedirectStatus } from '../constants/permanent-redirect-status';
+
+export const resolveRouteRequest = (
+  configuration: IRouteRedirectConfiguration,
+  { basename, url }: IResolveRouteRequestOptions
+): RouteRequestResolution => {
+  const normalizedBasename = normalizeBasename(basename);
+  const pathname = url.split(/[?#]/, 1)[0] || '/';
+  const absolutePathname = pathname.startsWith('/') ? pathname : `/${pathname}`;
+  const isWithinBasename =
+    normalizedBasename === '' ||
+    absolutePathname === normalizedBasename ||
+    absolutePathname.startsWith(`${normalizedBasename}/`);
+
+  if (!isWithinBasename) {
+    return { status: 404 };
+  }
+
+  const parsedUrl = parseVersionedUrl(url, basename);
+  const targetVersion = parsedUrl.version ?? configuration.latestVersion;
+  const manifest = configuration.manifests[targetVersion];
+
+  if (manifest.canonicalPaths.includes(parsedUrl.pathname)) {
+    if (parsedUrl.version) {
+      return { status: 200 };
+    }
+
+    return {
+      status: permanentRedirectStatus,
+      location: formatVersionedUrl(parsedUrl, targetVersion),
+    };
+  }
+
+  const redirect = manifest.redirects.find(
+    ({ from }) => from === parsedUrl.pathname
+  );
+
+  if (!redirect) {
+    return { status: 404 };
+  }
+
+  return {
+    status: permanentRedirectStatus,
+    location: formatVersionedUrl(
+      { ...parsedUrl, pathname: redirect.to },
+      targetVersion
+    ),
+  };
+};

--- a/example/src/v1/app/constants/v1-route-redirect-manifest.ts
+++ b/example/src/v1/app/constants/v1-route-redirect-manifest.ts
@@ -1,0 +1,8 @@
+import type { IRouteRedirectManifest } from '../../../shared/route-redirect';
+import { v1LegacyRouteRedirects } from './v1-legacy-route-redirects';
+import { v1RouteDefinitions } from './v1-route-definitions';
+
+export const v1RouteRedirectManifest: IRouteRedirectManifest = {
+  canonicalPaths: v1RouteDefinitions.map(({ path }) => path),
+  redirects: v1LegacyRouteRedirects,
+};

--- a/example/src/v1/app/v1-app-routes.test.tsx
+++ b/example/src/v1/app/v1-app-routes.test.tsx
@@ -2,7 +2,7 @@
 
 import * as React from 'react';
 import { cleanup, render, screen, waitFor } from '@testing-library/react';
-import { MemoryRouter } from 'react-router-dom';
+import { createMemoryRouter, RouterProvider } from 'react-router-dom';
 import { afterEach, beforeAll, describe, expect, it, vi } from 'vitest';
 import { renderApp } from '../../shared/ssr/render-app.util';
 import { V1AppRoutes } from './v1-app-routes';
@@ -16,12 +16,16 @@ afterEach(() => {
   cleanup();
 });
 
-const renderClientRoute = (path: string) =>
-  render(
-    <MemoryRouter basename="/v1" initialEntries={[`/v1${path}`]}>
-      <V1AppRoutes />
-    </MemoryRouter>
-  );
+const renderClientRoute = (path: string) => {
+  const router = createMemoryRouter([{ path: '*', element: <V1AppRoutes /> }], {
+    basename: '/v1',
+    initialEntries: [`/v1${path}`],
+  });
+
+  render(<RouterProvider router={router} />);
+
+  return router;
+};
 
 describe('v1 app routes', () => {
   it('renders the version switcher outside the Brand link on all layouts', () => {
@@ -107,15 +111,21 @@ describe('v1 app routes', () => {
   });
 
   it('redirects a legacy v1 route to its owned canonical destination', async () => {
-    renderClientRoute('/api/builder-props');
+    const router = renderClientRoute(
+      '/api/builder-props?q=a%2Fb&q=c&empty=#ref%201'
+    );
 
     expect(
       await screen.findByRole('heading', { level: 1, name: 'Builder' })
     ).toBeDefined();
+    expect(router.state.location).toMatchObject({
+      pathname: '/v1/api/builder',
+      search: '?q=a%2Fb&q=c&empty=',
+      hash: '#ref%201',
+    });
   });
-
   it('handles an unknown v1 route by returning to the v1 Home page', async () => {
-    renderClientRoute('/route-not-owned-by-v1');
+    const router = renderClientRoute('/route-not-owned-by-v1?draft=#fallback');
 
     expect(
       await screen.findByRole('heading', {
@@ -123,5 +133,10 @@ describe('v1 app routes', () => {
         name: 'React Query Builder',
       })
     ).toBeDefined();
+    expect(router.state.location).toMatchObject({
+      pathname: '/v1',
+      search: '?draft=',
+      hash: '#fallback',
+    });
   });
 });

--- a/example/src/v1/app/v1-app-routes.tsx
+++ b/example/src/v1/app/v1-app-routes.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
-import { Navigate, Route, Routes } from 'react-router-dom';
+import { Route, Routes } from 'react-router-dom';
 import { SiteShell } from '../../components/site-shell';
+import { RouteRedirect } from '../../shared/route-redirect';
 import { v1TopNavigation } from '../navigation/constants/v1-top-navigation';
 import { ApiPage } from '../pages/api-page/api-page';
 import { DemoPage } from '../pages/demo-page/demo-page';
@@ -36,12 +37,12 @@ export const V1AppRoutes: React.FC = () => {
           <Route
             key={redirect.from}
             path={redirect.from}
-            element={<Navigate to={redirect.to} replace />}
+            element={<RouteRedirect to={redirect.to} />}
           />
         ))}
         <Route
           path={v1FallbackRoute.path}
-          element={<Navigate to={v1FallbackRoute.to} replace />}
+          element={<RouteRedirect to={v1FallbackRoute.to} />}
         />
       </Route>
     </Routes>

--- a/example/src/v2/app/constants/v2-route-redirect-manifest.ts
+++ b/example/src/v2/app/constants/v2-route-redirect-manifest.ts
@@ -1,0 +1,8 @@
+import type { IRouteRedirectManifest } from '../../../shared/route-redirect';
+import { v2LegacyRouteRedirects } from './v2-legacy-route-redirects';
+import { v2RouteDefinitions } from './v2-route-definitions';
+
+export const v2RouteRedirectManifest: IRouteRedirectManifest = {
+  canonicalPaths: v2RouteDefinitions.map(({ path }) => path),
+  redirects: v2LegacyRouteRedirects,
+};

--- a/example/src/v2/app/v2-app-routes.test.tsx
+++ b/example/src/v2/app/v2-app-routes.test.tsx
@@ -2,7 +2,7 @@
 
 import * as React from 'react';
 import { cleanup, render, screen, waitFor } from '@testing-library/react';
-import { MemoryRouter } from 'react-router-dom';
+import { createMemoryRouter, RouterProvider } from 'react-router-dom';
 import { afterEach, beforeAll, describe, expect, it, vi } from 'vitest';
 import { renderApp } from '../../shared/ssr/render-app.util';
 import { V2AppRoutes } from './v2-app-routes';
@@ -16,12 +16,16 @@ afterEach(() => {
   cleanup();
 });
 
-const renderClientRoute = (path: string) =>
-  render(
-    <MemoryRouter basename="/v2" initialEntries={[`/v2${path}`]}>
-      <V2AppRoutes />
-    </MemoryRouter>
-  );
+const renderClientRoute = (path: string) => {
+  const router = createMemoryRouter([{ path: '*', element: <V2AppRoutes /> }], {
+    basename: '/v2',
+    initialEntries: [`/v2${path}`],
+  });
+
+  render(<RouterProvider router={router} />);
+
+  return router;
+};
 
 describe('v2 app routes', () => {
   it('renders the version switcher outside the Brand link on all layouts', () => {
@@ -107,15 +111,21 @@ describe('v2 app routes', () => {
   });
 
   it('redirects a legacy v2 route to its owned canonical destination', async () => {
-    renderClientRoute('/api/builder-props');
+    const router = renderClientRoute(
+      '/api/builder-props?q=a%2Fb&q=c&empty=#ref%201'
+    );
 
     expect(
       await screen.findByRole('heading', { level: 1, name: 'Builder' })
     ).toBeDefined();
+    expect(router.state.location).toMatchObject({
+      pathname: '/v2/api/builder',
+      search: '?q=a%2Fb&q=c&empty=',
+      hash: '#ref%201',
+    });
   });
-
   it('handles an unknown v2 route by returning to the v2 Home page', async () => {
-    renderClientRoute('/route-not-owned-by-v2');
+    const router = renderClientRoute('/route-not-owned-by-v2?draft=#fallback');
 
     expect(
       await screen.findByRole('heading', {
@@ -123,5 +133,10 @@ describe('v2 app routes', () => {
         name: 'React Query Builder',
       })
     ).toBeDefined();
+    expect(router.state.location).toMatchObject({
+      pathname: '/v2',
+      search: '?draft=',
+      hash: '#fallback',
+    });
   });
 });

--- a/example/src/v2/app/v2-app-routes.tsx
+++ b/example/src/v2/app/v2-app-routes.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
-import { Navigate, Route, Routes } from 'react-router-dom';
+import { Route, Routes } from 'react-router-dom';
 import { SiteShell } from '../../components/site-shell';
+import { RouteRedirect } from '../../shared/route-redirect';
 import { v2TopNavigation } from '../navigation/constants/v2-top-navigation';
 import { ApiPage } from '../pages/api-page/api-page';
 import { DemoPage } from '../pages/demo-page/demo-page';
@@ -36,12 +37,12 @@ export const V2AppRoutes: React.FC = () => {
           <Route
             key={redirect.from}
             path={redirect.from}
-            element={<Navigate to={redirect.to} replace />}
+            element={<RouteRedirect to={redirect.to} />}
           />
         ))}
         <Route
           path={v2FallbackRoute.path}
-          element={<Navigate to={v2FallbackRoute.to} replace />}
+          element={<RouteRedirect to={v2FallbackRoute.to} />}
         />
       </Route>
     </Routes>


### PR DESCRIPTION
- Redirected unversioned routes to their logical v2 destinations
- Kept legacy redirects local to v1 and v2 while preserving query strings and hashes
- Added static redirect documents, unknown-route handling, and deployment basename coverage
- Added independently owned redirect manifests and client fallback tests