### PR TITLE
feat: Added independent v1 search indexing

### DIFF
--- a/.codex/TASKS.md
+++ b/.codex/TASKS.md
@@ -1115,7 +1115,7 @@ unexpectedly.
 
 ### T026 - Create the independent v1 search index and tests
 
-**Status:** `[ ]` Not started
+**Status:** `[x]` Done
 
 **Depends on:** T022
 

--- a/example/src/app/app-routes.tsx
+++ b/example/src/app/app-routes.tsx
@@ -4,6 +4,7 @@ import { SiteShell } from '../components/site-shell';
 import { canonicalSeoPages } from '../constants/seo-pages';
 import { TOP_LEVEL_NAV } from '../constants/site-constants';
 import type { IAppContentPages } from './types/app-content-pages';
+import { useSiteSearch } from '../hooks/use-site-search';
 
 const redirects = [
   { from: '/api/builder-props', to: '/api/builder' },
@@ -56,6 +57,7 @@ export const AppRoutes: React.FC<IAppContentPages> = ({
               label: item.label,
               path: item.to,
             }))}
+            useSearch={useSiteSearch}
           />
         }
       >

--- a/example/src/components/header-search.tsx
+++ b/example/src/components/header-search.tsx
@@ -1,8 +1,8 @@
 import * as React from 'react';
 import styled from 'styled-components';
 import { useNavigate } from 'react-router-dom';
-import { useSiteSearch } from '../hooks/use-site-search';
 import { CloseIcon, SearchIcon } from './icons';
+import type { SiteSearchHook } from './search/types/site-search-hook';
 
 const Root = styled.div`
   position: relative;
@@ -110,11 +110,15 @@ const ResultSummary = styled.div`
   line-height: 1.5;
 `;
 
-export const HeaderSearch: React.FC = () => {
+export interface IHeaderSearchProps {
+  useSearch: SiteSearchHook;
+}
+
+export const HeaderSearch: React.FC<IHeaderSearchProps> = ({ useSearch }) => {
   const [query, setQuery] = React.useState('');
   const [isOpen, setIsOpen] = React.useState(false);
   const navigate = useNavigate();
-  const results = useSiteSearch(query);
+  const results = useSearch(query);
   const rootRef = React.useRef<HTMLDivElement>(null);
 
   React.useEffect(() => {
@@ -152,7 +156,7 @@ export const HeaderSearch: React.FC = () => {
             setIsOpen(true);
           }
         }}
-        onChange={event => {
+        onChange={(event) => {
           const nextValue = event.target.value;
           setQuery(nextValue);
           setIsOpen(Boolean(nextValue.trim()));
@@ -173,7 +177,7 @@ export const HeaderSearch: React.FC = () => {
 
       {shouldShowResults ? (
         <Results>
-          {results.slice(0, 6).map(result => (
+          {results.slice(0, 6).map((result) => (
             <ResultButton
               key={result.id}
               onClick={() => {

--- a/example/src/components/search/types/site-search-hook.ts
+++ b/example/src/components/search/types/site-search-hook.ts
@@ -1,0 +1,3 @@
+﻿import type { ISiteSearchResult } from './site-search-result';
+
+export type SiteSearchHook = (query: string) => ISiteSearchResult[];

--- a/example/src/components/search/types/site-search-result.ts
+++ b/example/src/components/search/types/site-search-result.ts
@@ -1,0 +1,7 @@
+﻿export interface ISiteSearchResult {
+  id: string;
+  title: string;
+  path: string;
+  publicPath: string;
+  summary: string;
+}

--- a/example/src/components/site-shell.tsx
+++ b/example/src/components/site-shell.tsx
@@ -11,6 +11,7 @@ import { loadCookieConsentBanner } from './load-cookie-consent-banner';
 import type { SiteVersion } from '../shared/versioned-url';
 import { routerBasename } from '../app/router-basename';
 import { VersionSwitcher } from './version-switcher/version-switcher';
+import type { SiteSearchHook } from './search/types/site-search-hook';
 
 const GlobalStyle = createGlobalStyle`
   :root {
@@ -350,11 +351,13 @@ const Footer = styled.footer`
 export interface ISiteShellProps {
   version: SiteVersion;
   topNavigation: readonly { label: string; path: string }[];
+  useSearch: SiteSearchHook;
 }
 
 export const SiteShell: React.FC<ISiteShellProps> = ({
   version,
   topNavigation,
+  useSearch,
 }) => {
   const [mobileMenuOpen, setMobileMenuOpen] = React.useState(false);
   const location = useLocation();
@@ -401,7 +404,7 @@ export const SiteShell: React.FC<ISiteShellProps> = ({
               </Nav>
 
               <UtilityRow>
-                <HeaderSearch />
+                <HeaderSearch useSearch={useSearch} />
               </UtilityRow>
             </DesktopOnly>
 
@@ -478,7 +481,7 @@ export const SiteShell: React.FC<ISiteShellProps> = ({
             </MenuButton>
           </MobilePanelHeader>
           <MobileSearchWrap>
-            <HeaderSearch />
+            <HeaderSearch useSearch={useSearch} />
           </MobileSearchWrap>
           <MobileNav>
             {topNavigation.map((item) => (

--- a/example/src/hooks/use-site-search.ts
+++ b/example/src/hooks/use-site-search.ts
@@ -3,11 +3,13 @@ import MiniSearch from 'minisearch';
 import { apiPages } from '../pages/api-page/pages/api-content';
 import { documentationPages } from '../pages/documentation-page/pages/documentation-content';
 import { recipes } from '../pages/recipes-page/pages/recipes-content';
+import type { ISiteSearchResult } from '../components/search/types/site-search-result';
 
 interface ISearchDocument {
   id: string;
   title: string;
   path: string;
+  publicPath: string;
   summary: string;
   content: string;
 }
@@ -17,6 +19,7 @@ const searchDocuments: ISearchDocument[] = [
     id: 'home',
     title: 'Home',
     path: '/',
+    publicPath: '/',
     summary:
       'Highly configurable TypeScript library for nested filter editors, query formatting, and query parsing.',
     content:
@@ -26,6 +29,7 @@ const searchDocuments: ISearchDocument[] = [
     id: 'demo',
     title: 'Demo',
     path: '/demo',
+    publicPath: '/demo',
     summary:
       'Interactive builder demo with control toggles, theme editing, and output previews.',
     content:
@@ -35,6 +39,7 @@ const searchDocuments: ISearchDocument[] = [
     id: page.path,
     title: page.title,
     path: page.path,
+    publicPath: page.path,
     summary: page.description,
     content: `${page.title} ${page.description} ${page.searchText}`,
   })),
@@ -42,6 +47,7 @@ const searchDocuments: ISearchDocument[] = [
     id: page.path,
     title: page.title,
     path: page.path,
+    publicPath: page.path,
     summary: page.description,
     content: `${page.title} ${page.description} ${page.searchText}`,
   })),
@@ -49,16 +55,17 @@ const searchDocuments: ISearchDocument[] = [
     id: page.path,
     title: page.title,
     path: page.path,
+    publicPath: page.path,
     summary: page.description,
     content: `${page.title} ${page.description} ${page.primaryKeyword} ${page.secondaryKeywords.join(' ')} ${page.searchText}`,
   })),
 ];
 
-export const useSiteSearch = (query: string) => {
+export const useSiteSearch = (query: string): ISiteSearchResult[] => {
   const miniSearch = React.useMemo(() => {
     const search = new MiniSearch<ISearchDocument>({
       fields: ['title', 'content'],
-      storeFields: ['title', 'path', 'summary'],
+      storeFields: ['title', 'path', 'publicPath', 'summary'],
       searchOptions: {
         boost: { title: 3 },
         fuzzy: 0.15,
@@ -80,6 +87,6 @@ export const useSiteSearch = (query: string) => {
 
     return miniSearch.search(trimmed, {
       combineWith: 'AND',
-    });
+    }) as unknown as ISiteSearchResult[];
   }, [miniSearch, query]);
 };

--- a/example/src/v1/app/v1-app-routes.tsx
+++ b/example/src/v1/app/v1-app-routes.tsx
@@ -8,6 +8,7 @@ import { DemoPage } from '../pages/demo-page/demo-page';
 import { DocumentationPage } from '../pages/documentation-page/documentation-page';
 import { HomePage } from '../pages/home-page/home-page';
 import { RecipesPage } from '../pages/recipes-page/recipes-page';
+import { useV1SiteSearch } from '../search/hooks/use-v1-site-search';
 import { v1FallbackRoute } from './constants/v1-fallback-route';
 import { v1LegacyRouteRedirects } from './constants/v1-legacy-route-redirects';
 import { v1RouteManifest } from './constants/v1-route-manifest';
@@ -24,7 +25,13 @@ export const V1AppRoutes: React.FC = () => {
   return (
     <Routes>
       <Route
-        element={<SiteShell version="v1" topNavigation={v1TopNavigation} />}
+        element={
+          <SiteShell
+            version="v1"
+            topNavigation={v1TopNavigation}
+            useSearch={useV1SiteSearch}
+          />
+        }
       >
         {v1RouteManifest.map((route) => (
           <Route

--- a/example/src/v1/search/constants/v1-search-documents.ts
+++ b/example/src/v1/search/constants/v1-search-documents.ts
@@ -1,0 +1,33 @@
+﻿import { v1RouteManifest } from '../../app/constants/v1-route-manifest';
+import { apiPages } from '../../pages/api-page/constants/api-pages';
+import { documentationPages } from '../../pages/documentation-page/constants/documentation-pages';
+import { recipes } from '../../pages/recipes-page/pages/recipes-content';
+import type { IV1SearchPage } from '../types/v1-search-page';
+import { createV1SearchDocuments } from '../utils/create-v1-search-documents.util';
+import { v1StaticSearchPages } from './v1-static-search-pages';
+
+const v1ContentSearchPages: IV1SearchPage[] = [
+  ...documentationPages.map((page) => ({
+    path: page.path,
+    title: page.title,
+    summary: page.description,
+    searchText: page.searchText,
+  })),
+  ...apiPages.map((page) => ({
+    path: page.path,
+    title: page.title,
+    summary: page.description,
+    searchText: page.searchText,
+  })),
+  ...recipes.map((page) => ({
+    path: page.path,
+    title: page.title,
+    summary: page.description,
+    searchText: `${page.primaryKeyword} ${page.secondaryKeywords.join(' ')} ${page.searchText}`,
+  })),
+];
+
+export const v1SearchDocuments = createV1SearchDocuments(
+  [...v1StaticSearchPages, ...v1ContentSearchPages],
+  v1RouteManifest
+);

--- a/example/src/v1/search/constants/v1-static-search-pages.ts
+++ b/example/src/v1/search/constants/v1-static-search-pages.ts
@@ -1,0 +1,28 @@
+﻿import type { IV1SearchPage } from '../types/v1-search-page';
+
+export const v1StaticSearchPages: IV1SearchPage[] = [
+  {
+    path: '/',
+    title: 'Home',
+    summary:
+      'Highly configurable TypeScript library for nested filter editors, query formatting, and query parsing.',
+    searchText:
+      'Home highly configurable typescript library nested filter editors query formatting query parsing demo documentation react query builder',
+  },
+  {
+    path: '/demo',
+    title: 'Demo',
+    summary:
+      'Interactive builder demo with control toggles, theme editing, and output previews.',
+    searchText:
+      'Demo interactive builder controls readOnly draggable singleRootGroup output formats theme editor',
+  },
+  {
+    path: '/recipes',
+    title: 'Recipes',
+    summary:
+      'Practical React Query Builder integrations, backend workflows, parsing, exports, and advanced patterns.',
+    searchText:
+      'Recipes integrations backend workflows parsing export advanced patterns React Query Builder',
+  },
+];

--- a/example/src/v1/search/hooks/use-v1-site-search.ts
+++ b/example/src/v1/search/hooks/use-v1-site-search.ts
@@ -1,0 +1,17 @@
+import * as React from 'react';
+import type { ISiteSearchResult } from '../../../components/search/types/site-search-result';
+import { v1SearchDocuments } from '../constants/v1-search-documents';
+import { createV1SearchIndex } from '../utils/create-v1-search-index.util';
+import { searchV1Index } from '../utils/search-v1-index.util';
+
+export const useV1SiteSearch = (query: string): ISiteSearchResult[] => {
+  const searchIndex = React.useMemo(
+    () => createV1SearchIndex(v1SearchDocuments),
+    []
+  );
+
+  return React.useMemo(
+    () => searchV1Index(searchIndex, query),
+    [query, searchIndex]
+  );
+};

--- a/example/src/v1/search/types/v1-search-document.ts
+++ b/example/src/v1/search/types/v1-search-document.ts
@@ -1,0 +1,8 @@
+﻿export interface IV1SearchDocument {
+  id: string;
+  title: string;
+  path: string;
+  publicPath: string;
+  summary: string;
+  content: string;
+}

--- a/example/src/v1/search/types/v1-search-page.ts
+++ b/example/src/v1/search/types/v1-search-page.ts
@@ -1,0 +1,6 @@
+﻿export interface IV1SearchPage {
+  path: string;
+  title: string;
+  summary: string;
+  searchText: string;
+}

--- a/example/src/v1/search/utils/create-v1-search-documents.util.ts
+++ b/example/src/v1/search/utils/create-v1-search-documents.util.ts
@@ -1,0 +1,31 @@
+﻿import type { IV1RouteRecord } from '../../app/types/v1-route-record';
+import type { IV1SearchDocument } from '../types/v1-search-document';
+import type { IV1SearchPage } from '../types/v1-search-page';
+
+export const createV1SearchDocuments = (
+  pages: readonly IV1SearchPage[],
+  routeManifest: readonly IV1RouteRecord[]
+): IV1SearchDocument[] => {
+  const routesByPath = new Map(
+    routeManifest.map((route) => [route.path, route])
+  );
+
+  return pages.map((page) => {
+    const route = routesByPath.get(page.path);
+
+    if (!route) {
+      throw new Error(
+        `Cannot index v1 search page without a v1 route: ${page.path}`
+      );
+    }
+
+    return {
+      id: page.path,
+      title: page.title,
+      path: route.path,
+      publicPath: route.publicPath,
+      summary: page.summary,
+      content: `${page.title} ${page.summary} ${page.searchText}`,
+    };
+  });
+};

--- a/example/src/v1/search/utils/create-v1-search-index.util.ts
+++ b/example/src/v1/search/utils/create-v1-search-index.util.ts
@@ -1,0 +1,20 @@
+﻿import MiniSearch from 'minisearch';
+import type { IV1SearchDocument } from '../types/v1-search-document';
+
+export const createV1SearchIndex = (
+  documents: readonly IV1SearchDocument[]
+): MiniSearch<IV1SearchDocument> => {
+  const searchIndex = new MiniSearch<IV1SearchDocument>({
+    fields: ['title', 'content'],
+    storeFields: ['title', 'path', 'publicPath', 'summary'],
+    searchOptions: {
+      boost: { title: 3 },
+      fuzzy: 0.15,
+      prefix: true,
+    },
+  });
+
+  searchIndex.addAll([...documents]);
+
+  return searchIndex;
+};

--- a/example/src/v1/search/utils/search-v1-index.util.ts
+++ b/example/src/v1/search/utils/search-v1-index.util.ts
@@ -1,0 +1,18 @@
+﻿import type MiniSearch from 'minisearch';
+import type { ISiteSearchResult } from '../../../components/search/types/site-search-result';
+import type { IV1SearchDocument } from '../types/v1-search-document';
+
+export const searchV1Index = (
+  searchIndex: MiniSearch<IV1SearchDocument>,
+  query: string
+): ISiteSearchResult[] => {
+  const trimmedQuery = query.trim();
+
+  if (!trimmedQuery) {
+    return [];
+  }
+
+  return searchIndex.search(trimmedQuery, {
+    combineWith: 'AND',
+  }) as unknown as ISiteSearchResult[];
+};

--- a/example/src/v1/search/v1-search-index.test.ts
+++ b/example/src/v1/search/v1-search-index.test.ts
@@ -1,0 +1,72 @@
+﻿import { describe, expect, it } from 'vitest';
+import { v1RouteManifest } from '../app/constants/v1-route-manifest';
+import { v1SearchDocuments } from './constants/v1-search-documents';
+import { createV1SearchDocuments } from './utils/create-v1-search-documents.util';
+import { createV1SearchIndex } from './utils/create-v1-search-index.util';
+import { searchV1Index } from './utils/search-v1-index.util';
+
+const searchIndex = createV1SearchIndex(v1SearchDocuments);
+
+describe('v1 search index', () => {
+  it('indexes every canonical v1 route exactly once', () => {
+    const documentPaths = v1SearchDocuments.map((document) => document.path);
+    const manifestPaths = v1RouteManifest.map((route) => route.path);
+
+    expect(documentPaths).toHaveLength(55);
+    expect(new Set(documentPaths).size).toBe(documentPaths.length);
+    expect(new Set(documentPaths)).toEqual(new Set(manifestPaths));
+  });
+
+  it('uses v1 manifest paths for every result URL', () => {
+    const routesByPath = new Map(
+      v1RouteManifest.map((route) => [route.path, route])
+    );
+
+    for (const document of v1SearchDocuments) {
+      const route = routesByPath.get(document.path);
+
+      expect(route).toBeDefined();
+      expect(document.publicPath).toBe(route?.publicPath);
+      expect(document.publicPath).toMatch(/^\/v1(?:\/|$)/);
+      expect(document.publicPath).not.toContain('/v2');
+    }
+  });
+
+  it.each([
+    ['interactive theme editor', '/demo'],
+    ['dynamic field options', '/documentation/dynamic-field-options'],
+    ['parseQuery parameters', '/api/parse-query'],
+    ['AG Grid filter panel', '/recipes/ag-grid-query-builder'],
+  ])('returns the relevant v1 result for %s', (query, expectedPath) => {
+    expect(searchV1Index(searchIndex, query)[0]?.path).toBe(expectedPath);
+  });
+
+  it('supports prefix and fuzzy matching while requiring every term', () => {
+    expect(searchV1Index(searchIndex, 'localiz')[0]?.path).toBe(
+      '/documentation/localization'
+    );
+    expect(searchV1Index(searchIndex, 'instalation')[0]?.path).toBe(
+      '/documentation/installation'
+    );
+    expect(searchV1Index(searchIndex, 'parseQuery missing-term')).toEqual([]);
+    expect(searchV1Index(searchIndex, '   ')).toEqual([]);
+  });
+
+  it('rejects an indexable page that has no v1 route', () => {
+    expect(() =>
+      createV1SearchDocuments(
+        [
+          {
+            path: '/v2-only',
+            title: 'V2 only',
+            summary: 'Must not enter v1 search.',
+            searchText: 'v2-only-search-sentinel',
+          },
+        ],
+        v1RouteManifest
+      )
+    ).toThrow('Cannot index v1 search page without a v1 route: /v2-only');
+
+    expect(searchV1Index(searchIndex, 'v2-only-search-sentinel')).toEqual([]);
+  });
+});

--- a/example/src/v1/search/v1-search-navigation.test.tsx
+++ b/example/src/v1/search/v1-search-navigation.test.tsx
@@ -1,0 +1,50 @@
+/* @vitest-environment jsdom */
+
+import * as React from 'react';
+import { cleanup, fireEvent, render, screen } from '@testing-library/react';
+import { createMemoryRouter, RouterProvider } from 'react-router-dom';
+import { afterEach, beforeAll, describe, expect, it, vi } from 'vitest';
+import { V1AppRoutes } from '../app/v1-app-routes';
+
+beforeAll(() => {
+  window.scrollTo = vi.fn();
+});
+
+afterEach(() => {
+  cleanup();
+});
+
+const renderSearchRoute = (basename: string) => {
+  const router = createMemoryRouter([{ path: '*', element: <V1AppRoutes /> }], {
+    basename,
+    initialEntries: [basename],
+  });
+
+  render(<RouterProvider router={router} />);
+
+  return router;
+};
+
+describe('v1 search navigation', () => {
+  it.each([
+    ['/v1', '/v1/api/parse-query'],
+    ['/react-query-builder/v1', '/react-query-builder/v1/api/parse-query'],
+  ])(
+    'navigates inside the v1 basename %s without duplicating its prefix',
+    async (basename, expectedPathname) => {
+      const router = renderSearchRoute(basename);
+      const searchInput = screen.getAllByPlaceholderText(
+        'Search docs and pages'
+      )[0];
+
+      fireEvent.focus(searchInput);
+      fireEvent.change(searchInput, { target: { value: 'parseQuery' } });
+      fireEvent.click(
+        await screen.findByRole('button', { name: /parseQuery API reference/i })
+      );
+
+      expect(router.state.location.pathname).toBe(expectedPathname);
+      expect((searchInput as HTMLInputElement).value).toBe('');
+    }
+  );
+});

--- a/example/src/v2/app/v2-app-routes.tsx
+++ b/example/src/v2/app/v2-app-routes.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
 import { Route, Routes } from 'react-router-dom';
 import { SiteShell } from '../../components/site-shell';
+import { useSiteSearch } from '../../hooks/use-site-search';
 import { RouteRedirect } from '../../shared/route-redirect';
 import { v2TopNavigation } from '../navigation/constants/v2-top-navigation';
 import { ApiPage } from '../pages/api-page/api-page';
@@ -24,7 +25,13 @@ export const V2AppRoutes: React.FC = () => {
   return (
     <Routes>
       <Route
-        element={<SiteShell version="v2" topNavigation={v2TopNavigation} />}
+        element={
+          <SiteShell
+            version="v2"
+            topNavigation={v2TopNavigation}
+            useSearch={useSiteSearch}
+          />
+        }
       >
         {v2RouteManifest.map((route) => (
           <Route


### PR DESCRIPTION
- Added v1-owned search records and MiniSearch configuration
- Added manifest-derived v1 result URLs and basename-safe navigation
- Separated shared search UI from version-owned search data
- Added indexing, relevance, isolation, route validation, and navigation tests
- Marked T026 as completed