### PR TITLE
feat: Implemented independent v2 search

### DIFF
--- a/.codex/TASKS.md
+++ b/.codex/TASKS.md
@@ -1138,7 +1138,7 @@ unexpectedly.
 
 ### T027 - Create the independent v2 search index and tests
 
-**Status:** `[ ]` Not started
+**Status:** `[x]` Done
 
 **Depends on:** T023
 

--- a/.codex/t027-create-the-independent-v2-search-index-and-tests-tasks.md
+++ b/.codex/t027-create-the-independent-v2-search-index-and-tests-tasks.md
@@ -1,0 +1,10 @@
+# T027 - Create the independent v2 search index and tests
+
+- [x] Add v2-owned search page, document, index, and query modules.
+- [x] Derive v2 search records only from v2 page registries and the v2 route manifest.
+- [x] Wire the v2 application shell to the v2 search hook.
+- [x] Cover v2 indexing, relevance, isolation, extensibility, and navigation.
+- [x] Run v2 typecheck, focused tests, and the complete v2 test suite.
+- [x] Run Prettier on every modified code file.
+- [x] Complete the required review agent and resolve all findings.
+- [x] Mark T027 done after verification and review.

--- a/example/src/v2/app/v2-app-routes.tsx
+++ b/example/src/v2/app/v2-app-routes.tsx
@@ -1,7 +1,6 @@
 import * as React from 'react';
 import { Route, Routes } from 'react-router-dom';
 import { SiteShell } from '../../components/site-shell';
-import { useSiteSearch } from '../../hooks/use-site-search';
 import { RouteRedirect } from '../../shared/route-redirect';
 import { v2TopNavigation } from '../navigation/constants/v2-top-navigation';
 import { ApiPage } from '../pages/api-page/api-page';
@@ -9,6 +8,7 @@ import { DemoPage } from '../pages/demo-page/demo-page';
 import { DocumentationPage } from '../pages/documentation-page/documentation-page';
 import { HomePage } from '../pages/home-page/home-page';
 import { RecipesPage } from '../pages/recipes-page/recipes-page';
+import { useV2SiteSearch } from '../search/hooks/use-v2-site-search';
 import { v2FallbackRoute } from './constants/v2-fallback-route';
 import { v2LegacyRouteRedirects } from './constants/v2-legacy-route-redirects';
 import { v2RouteManifest } from './constants/v2-route-manifest';
@@ -29,7 +29,7 @@ export const V2AppRoutes: React.FC = () => {
           <SiteShell
             version="v2"
             topNavigation={v2TopNavigation}
-            useSearch={useSiteSearch}
+            useSearch={useV2SiteSearch}
           />
         }
       >

--- a/example/src/v2/search/constants/v2-search-documents.ts
+++ b/example/src/v2/search/constants/v2-search-documents.ts
@@ -1,0 +1,33 @@
+import { v2RouteManifest } from '../../app/constants/v2-route-manifest';
+import { apiPages } from '../../pages/api-page/constants/api-pages';
+import { documentationPages } from '../../pages/documentation-page/constants/documentation-pages';
+import { recipes } from '../../pages/recipes-page/pages/recipes-content';
+import type { IV2SearchPage } from '../types/v2-search-page';
+import { createV2SearchDocuments } from '../utils/create-v2-search-documents.util';
+import { v2StaticSearchPages } from './v2-static-search-pages';
+
+const v2ContentSearchPages: IV2SearchPage[] = [
+  ...documentationPages.map((page) => ({
+    path: page.path,
+    title: page.title,
+    summary: page.description,
+    searchText: page.searchText,
+  })),
+  ...apiPages.map((page) => ({
+    path: page.path,
+    title: page.title,
+    summary: page.description,
+    searchText: page.searchText,
+  })),
+  ...recipes.map((page) => ({
+    path: page.path,
+    title: page.title,
+    summary: page.description,
+    searchText: `${page.primaryKeyword} ${page.secondaryKeywords.join(' ')} ${page.searchText}`,
+  })),
+];
+
+export const v2SearchDocuments = createV2SearchDocuments(
+  [...v2StaticSearchPages, ...v2ContentSearchPages],
+  v2RouteManifest
+);

--- a/example/src/v2/search/constants/v2-static-search-pages.ts
+++ b/example/src/v2/search/constants/v2-static-search-pages.ts
@@ -1,0 +1,28 @@
+import type { IV2SearchPage } from '../types/v2-search-page';
+
+export const v2StaticSearchPages: IV2SearchPage[] = [
+  {
+    path: '/',
+    title: 'Home',
+    summary:
+      'Highly configurable TypeScript library for visual and text-based query editing, validation, theming, and query conversion.',
+    searchText:
+      'Home TypeScript library visual text query editing validation theming customization parsing formatting React Query Builder',
+  },
+  {
+    path: '/demo',
+    title: 'Demo',
+    summary:
+      'Interactive playground for fields, adapters, validation, text editing, localization, and query output.',
+    searchText:
+      'Demo interactive playground fields adapters validation text editing localization query output theme controls',
+  },
+  {
+    path: '/recipes',
+    title: 'Recipes',
+    summary:
+      'Practical React Query Builder integrations, backend workflows, parsing, exports, and advanced patterns.',
+    searchText:
+      'Recipes integrations backend workflows parsing export advanced patterns React Query Builder',
+  },
+];

--- a/example/src/v2/search/hooks/use-v2-site-search.ts
+++ b/example/src/v2/search/hooks/use-v2-site-search.ts
@@ -1,0 +1,17 @@
+import * as React from 'react';
+import type { ISiteSearchResult } from '../../../components/search/types/site-search-result';
+import { v2SearchDocuments } from '../constants/v2-search-documents';
+import { createV2SearchIndex } from '../utils/create-v2-search-index.util';
+import { searchV2Index } from '../utils/search-v2-index.util';
+
+export const useV2SiteSearch = (query: string): ISiteSearchResult[] => {
+  const searchIndex = React.useMemo(
+    () => createV2SearchIndex(v2SearchDocuments),
+    []
+  );
+
+  return React.useMemo(
+    () => searchV2Index(searchIndex, query),
+    [query, searchIndex]
+  );
+};

--- a/example/src/v2/search/types/v2-search-document.ts
+++ b/example/src/v2/search/types/v2-search-document.ts
@@ -1,0 +1,8 @@
+export interface IV2SearchDocument {
+  id: string;
+  title: string;
+  path: string;
+  publicPath: string;
+  summary: string;
+  content: string;
+}

--- a/example/src/v2/search/types/v2-search-page.ts
+++ b/example/src/v2/search/types/v2-search-page.ts
@@ -1,0 +1,6 @@
+export interface IV2SearchPage {
+  path: string;
+  title: string;
+  summary: string;
+  searchText: string;
+}

--- a/example/src/v2/search/utils/create-v2-search-documents.util.ts
+++ b/example/src/v2/search/utils/create-v2-search-documents.util.ts
@@ -1,0 +1,31 @@
+import type { IV2RouteRecord } from '../../app/types/v2-route-record';
+import type { IV2SearchDocument } from '../types/v2-search-document';
+import type { IV2SearchPage } from '../types/v2-search-page';
+
+export const createV2SearchDocuments = (
+  pages: readonly IV2SearchPage[],
+  routeManifest: readonly IV2RouteRecord[]
+): IV2SearchDocument[] => {
+  const routesByPath = new Map(
+    routeManifest.map((route) => [route.path, route])
+  );
+
+  return pages.map((page) => {
+    const route = routesByPath.get(page.path);
+
+    if (!route) {
+      throw new Error(
+        `Cannot index v2 search page without a v2 route: ${page.path}`
+      );
+    }
+
+    return {
+      id: page.path,
+      title: page.title,
+      path: route.path,
+      publicPath: route.publicPath,
+      summary: page.summary,
+      content: `${page.title} ${page.summary} ${page.searchText}`,
+    };
+  });
+};

--- a/example/src/v2/search/utils/create-v2-search-index.util.ts
+++ b/example/src/v2/search/utils/create-v2-search-index.util.ts
@@ -1,0 +1,20 @@
+import MiniSearch from 'minisearch';
+import type { IV2SearchDocument } from '../types/v2-search-document';
+
+export const createV2SearchIndex = (
+  documents: readonly IV2SearchDocument[]
+): MiniSearch<IV2SearchDocument> => {
+  const searchIndex = new MiniSearch<IV2SearchDocument>({
+    fields: ['title', 'content'],
+    storeFields: ['title', 'path', 'publicPath', 'summary'],
+    searchOptions: {
+      boost: { title: 3 },
+      fuzzy: 0.15,
+      prefix: true,
+    },
+  });
+
+  searchIndex.addAll([...documents]);
+
+  return searchIndex;
+};

--- a/example/src/v2/search/utils/search-v2-index.util.ts
+++ b/example/src/v2/search/utils/search-v2-index.util.ts
@@ -1,0 +1,18 @@
+import type MiniSearch from 'minisearch';
+import type { ISiteSearchResult } from '../../../components/search/types/site-search-result';
+import type { IV2SearchDocument } from '../types/v2-search-document';
+
+export const searchV2Index = (
+  searchIndex: MiniSearch<IV2SearchDocument>,
+  query: string
+): ISiteSearchResult[] => {
+  const trimmedQuery = query.trim();
+
+  if (!trimmedQuery) {
+    return [];
+  }
+
+  return searchIndex.search(trimmedQuery, {
+    combineWith: 'AND',
+  }) as unknown as ISiteSearchResult[];
+};

--- a/example/src/v2/search/v2-search-index.test.ts
+++ b/example/src/v2/search/v2-search-index.test.ts
@@ -1,0 +1,103 @@
+import { describe, expect, it } from 'vitest';
+import { v2RouteManifest } from '../app/constants/v2-route-manifest';
+import { v2SearchDocuments } from './constants/v2-search-documents';
+import { createV2SearchDocuments } from './utils/create-v2-search-documents.util';
+import { createV2SearchIndex } from './utils/create-v2-search-index.util';
+import { searchV2Index } from './utils/search-v2-index.util';
+
+const searchIndex = createV2SearchIndex(v2SearchDocuments);
+
+describe('v2 search index', () => {
+  it('indexes every canonical v2 route exactly once', () => {
+    const documentPaths = v2SearchDocuments.map((document) => document.path);
+    const manifestPaths = v2RouteManifest.map((route) => route.path);
+
+    expect(documentPaths).toHaveLength(55);
+    expect(new Set(documentPaths).size).toBe(documentPaths.length);
+    expect(new Set(documentPaths)).toEqual(new Set(manifestPaths));
+  });
+
+  it('uses v2 manifest paths for every result URL', () => {
+    const routesByPath = new Map(
+      v2RouteManifest.map((route) => [route.path, route])
+    );
+
+    for (const document of v2SearchDocuments) {
+      const route = routesByPath.get(document.path);
+
+      expect(route).toBeDefined();
+      expect(document.publicPath).toBe(route?.publicPath);
+      expect(document.publicPath).toMatch(/^\/v2(?:\/|$)/);
+      expect(document.publicPath).not.toContain('/v1');
+    }
+  });
+
+  it.each([
+    ['interactive playground localization', '/demo'],
+    ['dynamic field options', '/documentation/dynamic-field-options'],
+    ['createMuiComponents API', '/api/adapters/mui'],
+    ['AG Grid filter panel', '/recipes/ag-grid-query-builder'],
+  ])('returns the relevant v2 result for %s', (query, expectedPath) => {
+    expect(searchV2Index(searchIndex, query)[0]?.path).toBe(expectedPath);
+  });
+
+  it('supports prefix and fuzzy matching while requiring every term', () => {
+    expect(searchV2Index(searchIndex, 'localiz')[0]?.path).toBe(
+      '/documentation/localization'
+    );
+    expect(searchV2Index(searchIndex, 'instalation')[0]?.path).toBe(
+      '/documentation/installation'
+    );
+    expect(searchV2Index(searchIndex, 'parseQuery missing-term')).toEqual([]);
+    expect(searchV2Index(searchIndex, '   ')).toEqual([]);
+  });
+
+  it('rejects an indexable page that has no v2 route', () => {
+    expect(() =>
+      createV2SearchDocuments(
+        [
+          {
+            path: '/missing',
+            title: 'Missing',
+            summary: 'This page has no v2 route.',
+            searchText: 'missing-v2-route-sentinel',
+          },
+        ],
+        v2RouteManifest
+      )
+    ).toThrow('Cannot index v2 search page without a v2 route: /missing');
+  });
+
+  it('indexes a v2-only page without a v1 equivalent', () => {
+    const v2OnlyRoute = {
+      ...v2RouteManifest[0],
+      path: '/v2-only',
+      publicPath: '/v2/v2-only',
+    };
+    const documents = createV2SearchDocuments(
+      [
+        {
+          path: '/v2-only',
+          title: 'V2 only',
+          summary: 'Available only in the v2 route manifest.',
+          searchText: 'v2-only-search-sentinel',
+        },
+      ],
+      [v2OnlyRoute]
+    );
+    const v2OnlyIndex = createV2SearchIndex(documents);
+
+    expect(searchV2Index(v2OnlyIndex, 'v2-only-search-sentinel')).toMatchObject(
+      [
+        {
+          path: '/v2-only',
+          publicPath: '/v2/v2-only',
+        },
+      ]
+    );
+  });
+
+  it('does not include v1-only static page copy', () => {
+    expect(searchV2Index(searchIndex, 'nested filter editors')).toEqual([]);
+  });
+});

--- a/example/src/v2/search/v2-search-navigation.test.tsx
+++ b/example/src/v2/search/v2-search-navigation.test.tsx
@@ -1,0 +1,50 @@
+/* @vitest-environment jsdom */
+
+import * as React from 'react';
+import { cleanup, fireEvent, render, screen } from '@testing-library/react';
+import { createMemoryRouter, RouterProvider } from 'react-router-dom';
+import { afterEach, beforeAll, describe, expect, it, vi } from 'vitest';
+import { V2AppRoutes } from '../app/v2-app-routes';
+
+beforeAll(() => {
+  window.scrollTo = vi.fn();
+});
+
+afterEach(() => {
+  cleanup();
+});
+
+const renderSearchRoute = (basename: string) => {
+  const router = createMemoryRouter([{ path: '*', element: <V2AppRoutes /> }], {
+    basename,
+    initialEntries: [basename],
+  });
+
+  render(<RouterProvider router={router} />);
+
+  return router;
+};
+
+describe('v2 search navigation', () => {
+  it.each([
+    ['/v2', '/v2/api/parse-query'],
+    ['/react-query-builder/v2', '/react-query-builder/v2/api/parse-query'],
+  ])(
+    'navigates inside the v2 basename %s without duplicating its prefix',
+    async (basename, expectedPathname) => {
+      const router = renderSearchRoute(basename);
+      const searchInput = screen.getAllByPlaceholderText(
+        'Search docs and pages'
+      )[0];
+
+      fireEvent.focus(searchInput);
+      fireEvent.change(searchInput, { target: { value: 'parseQuery' } });
+      fireEvent.click(
+        await screen.findByRole('button', { name: /parseQuery API reference/i })
+      );
+
+      expect(router.state.location.pathname).toBe(expectedPathname);
+      expect((searchInput as HTMLInputElement).value).toBe('');
+    }
+  );
+});


### PR DESCRIPTION
- Added v2-owned search records, indexing utilities, and manifest-derived URLs
- Wired the v2 application shell to the independent search hook
- Added indexing, isolation, relevance, extensibility, and navigation tests
- Marked T027 as completed