### PR TITLE
feat: Added CSS Modules build and test infrastructure

### DIFF
--- a/.codex/TASKS.md
+++ b/.codex/TASKS.md
@@ -1259,7 +1259,7 @@ unexpectedly.
 
 ### T032 - Capture the package baseline and add CSS build/test infrastructure
 
-**Status:** `[ ]` Not started
+**Status:** `[x]` Done
 
 **Depends on:** T031
 

--- a/.codex/reports/t032/css-build-report.md
+++ b/.codex/reports/t032/css-build-report.md
@@ -1,0 +1,40 @@
+# T032 CSS build inspection
+
+The final T032 build uses `@tsdown/css@0.21.10` with the experimental options validated against tsdown 0.21.10.
+
+## Configuration contract
+
+- CSS splitting is disabled while JavaScript splitting remains enabled.
+- CSS injection is disabled.
+- The single asset name is fixed to `dist/styles.css`.
+- CSS Module local names use the private `rqb_[hash]` pattern.
+- CSS Module exports use `camelCaseOnly` and local scope.
+- T035 remains responsible for adding a public `./styles.css` export and token API.
+
+## Output inspection
+
+Two consecutive clean builds produced identical 140-file path/size manifests and the same stylesheet SHA-256:
+
+`C973BD2D306F3FE7766EC1A8D2E0BAF800252297B37EA5625E72DA9631CECB74`
+
+The stylesheet contains one private class (`.rqb_25XGoa`) and the `react-query-builder` layer declaration. It does not change any component styling. The contract class only proves CSS Module scoping and extraction before T033 migrates the first component.
+
+Automated inspection confirmed:
+
+- Exactly one CSS asset exists and it is `dist/styles.css`.
+- No emitted ESM or CJS file imports CSS or inserts a style element.
+- Direct ESM parser and CommonJS root loading pass in Node. The CSS-bearing ESM root passes the supported Vite client/SSR consumer matrix; native Node ESM root loading retains the pre-existing styled-components interop limitation recorded in the baseline.
+- Parser, formatter, and all ten locale dependency graphs in both formats contain neither CSS nor `clsx`.
+- Sixteen shared JavaScript chunks remain enabled across ESM and CJS.
+- The packed artifact contains 143 files, is 262,770 bytes compressed, and is 1,527,248 bytes unpacked.
+
+## Class composition rules
+
+T032 locks the following rules for later migrations:
+
+- Use `clsx` for state and incoming class composition.
+- Preserve incoming `className` values.
+- Keep CSS Module hashes private.
+- Prefer low-specificity local selectors.
+- Model visual state with classes or semantic data attributes.
+- Do not forward transient presentation props to DOM elements.

--- a/.codex/reports/t032/package-baseline.md
+++ b/.codex/reports/t032/package-baseline.md
@@ -1,0 +1,56 @@
+# T032 pre-infrastructure package baseline
+
+This report records the package state before T032 changed dependencies, source imports, or build configuration. Values are deterministic byte counts from a clean `npm run build`; JavaScript minification used esbuild 0.25.12 with target `es2020`, and gzip used level 9.
+
+## Public package entries
+
+| Entry                         | Raw bytes | Minified bytes | Minified gzip bytes |
+| ----------------------------- | --------: | -------------: | ------------------: |
+| `dist/index.mjs`              |   194,087 |         80,206 |              23,319 |
+| `dist/index.cjs`              |   199,248 |         83,826 |              23,550 |
+| `dist/parseQuery.mjs`         |       188 |             92 |                 107 |
+| `dist/parseQuery.cjs`         |       293 |            157 |                 156 |
+| `dist/formatQuery.mjs`        |       215 |             97 |                 112 |
+| `dist/formatQuery.cjs`        |       318 |            165 |                 160 |
+| `dist/locale/en-US/index.mjs` |     5,399 |          4,786 |               1,679 |
+| `dist/locale/en-US/index.cjs` |     5,479 |          4,850 |               1,722 |
+
+The clean build emitted 16 shared JavaScript chunks across ESM and CJS. JavaScript splitting was enabled and no CSS asset was emitted.
+
+## Consumer bundles
+
+The version-owned package-binding fixtures were rebuilt before the T032 source/configuration changes. Vite output is already minified.
+
+| Consumer        | Minified bytes | Gzip bytes |
+| --------------- | -------------: | ---------: |
+| V1 client       |      1,389,983 |    314,653 |
+| Local V2 client |      1,417,499 |    318,759 |
+| V1 SSR          |      2,237,680 |    404,283 |
+| Local V2 SSR    |      2,270,557 |    408,104 |
+
+Both V1 and local V2 client builds passed. Both SSR builds passed. The package-binding matrix exercised the root ESM surface through Vite; direct CommonJS root loading and direct ESM parser loading also passed. Direct native-Node loading of the pre-T032 ESM root failed in the existing styled-components output because `styled.div` was not callable. T032 does not change that existing runtime interop behavior.
+
+## Installed production dependencies
+
+The pre-T032 package declared five runtime dependencies:
+
+- `@dnd-kit/core@6.3.1`
+- `@dnd-kit/sortable@10.0.0`
+- `prismjs@1.30.0`
+- `styled-components@6.4.2`
+- `tslib@2.8.1`
+
+The resolved non-extraneous production tree contained 21 unique name/version pairs. `clsx` was not a direct or reachable package dependency before T032.
+
+## Packed artifact
+
+`npm pack --dry-run --json --cache .npm-cache` reported:
+
+| Metric          |        Baseline |
+| --------------- | --------------: |
+| Tarball size    |   262,530 bytes |
+| Unpacked size   | 1,526,692 bytes |
+| File count      |             142 |
+| Package version |          1.33.1 |
+
+The baseline tarball contained ESM, CJS, and public declaration outputs. It contained no stylesheet and exposed no stylesheet subpath.

--- a/.codex/reports/t032/verification-report.md
+++ b/.codex/reports/t032/verification-report.md
@@ -1,0 +1,24 @@
+# T032 verification report
+
+## Passed checks
+
+- Focused CSS Module Jest contract: 1 test passed.
+- Root library build: passed repeatedly with deterministic output.
+- Automated CSS output and non-UI boundary inspection: passed.
+- Task-specific ESLint: passed.
+- V1/V2 package-binding TypeScript checks: passed.
+- V1/V2 recipe snippet TypeScript checks: passed.
+- V1/V2 client and SSR package-binding builds: passed.
+- V1/V2 package-binding runtime tests: 13 tests per version passed.
+- V1/V2 final package-binding verification: passed.
+- Package dry-run inspection: passed.
+
+## Repository-wide checks
+
+A root Jest run completed 96 of 97 suites with all 492 executed tests passing before the npm repair attempt. The remaining suite initially failed because the canonical local package workspace link was missing. The complete package-binding matrix then passed against the intended V1 and local V2 bindings.
+
+The current in-place root Jest rerun is blocked by npm 10's legacy peer resolver omitting the pre-existing optional `@testing-library/dom` peer. Repairing node_modules in place is prevented by an active user-owned Vite preview process locking Rollup. The committed package lock retains the original testing-library peer entries, so a clean normal install restores it. This is an environment limitation, not a source or lockfile regression.
+
+Repository-wide `npm run lint` traverses pre-existing generated `.tmp` and `example/.versioned-dist` files and reports generated-code diagnostics. The task-owned files pass ESLint. T032 does not broaden its scope by changing repository ignore policy.
+
+The root unscoped `tsc --noEmit` also retains pre-existing workspace/optional-peer declaration failures. The dedicated V1/V2 package-binding TypeScript checks pass and explicitly validate the CSS Module declaration through the local V2 source binding.

--- a/.codex/t032-capture-package-baseline-and-add-css-build-test-infrastructure-tasks.md
+++ b/.codex/t032-capture-package-baseline-and-add-css-build-test-infrastructure-tasks.md
@@ -1,0 +1,26 @@
+# T032 - Capture the package baseline and add CSS build/test infrastructure
+
+- [x] Validate T032 scope and constraints with the required planning agent.
+- [x] Capture pre-change package, consumer, dependency, ESM/CJS, and tarball baselines.
+- [x] Pin `@tsdown/css` and `clsx` and synchronize the lockfile.
+- [x] Add deterministic single-file CSS extraction with injection disabled.
+- [x] Add CSS Module TypeScript declarations and Jest handling.
+- [x] Add a focused CSS Module class-composition contract test.
+- [x] Add automated CSS output, non-UI boundary, shared-chunk, ESM, and CJS checks.
+- [x] Run the T032 smoke/build/test matrix.
+- [x] Run Prettier on all modified code.
+- [x] Complete the required review-agent pass and resolve findings.
+- [x] Mark T032 done only after verification and review.
+
+## Scope boundary
+
+T033 owns the first production component migration, including `src/drop-zone.tsx`. T032 adds infrastructure only and does not migrate or move a production component. T035 owns the public stylesheet export and token contract, so `dist/styles.css` is intentionally not exported from `package.json` yet.
+
+## Review
+
+The independent review agent reported two P2 verification gaps. Both were resolved by accurately labeling native non-UI ESM coverage, documenting the existing native root ESM limitation, and deriving the boundary check across all locale ESM/CJS entries. The re-review found no issues.
+
+## Residual limitations
+
+- Native Node loading of the ESM root retains the pre-existing styled-components interop failure. The supported Vite client and SSR ESM consumer matrix passes.
+- The in-place node_modules tree cannot rerun the full root Jest suite because npm's legacy peer resolver omitted the lockfile-recorded `@testing-library/dom` peer while an active preview process locks Rollup. The committed lockfile retains the peer, and the focused test passed before the local install was disturbed.

--- a/jest.config.cjs
+++ b/jest.config.cjs
@@ -9,6 +9,10 @@ module.exports = {
     '!src/types/**',
   ],
   moduleFileExtensions: ['ts', 'tsx', 'js', 'jsx', 'json'],
+  moduleNameMapper: {
+    '\\.module\\.css$': '<rootDir>/src/__mocks__/css-module.mock.cjs',
+    '\\.css$': '<rootDir>/src/__mocks__/style.mock.cjs',
+  },
   setupFilesAfterEnv: ['<rootDir>/setup-tests.ts'],
   testEnvironment: 'jsdom',
   testMatch: ['<rootDir>/src/**/*.test.ts', '<rootDir>/src/**/*.test.tsx'],

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",
         "@dnd-kit/sortable": "^10.0.0",
+        "clsx": "2.1.1",
         "prismjs": "^1.30.0",
         "styled-components": "^6.4.2",
         "tslib": "^2.8.1"
@@ -33,6 +34,7 @@
         "@testing-library/jest-dom": "^6.9.1",
         "@testing-library/react": "^16.3.2",
         "@testing-library/user-event": "^14.6.1",
+        "@tsdown/css": "0.21.10",
         "@types/jest": "^29.5.14",
         "@types/react": "^18.3.12",
         "@types/react-dom": "^18.3.1",
@@ -7438,6 +7440,49 @@
         "node": ">= 10"
       }
     },
+    "node_modules/@tsdown/css": {
+      "version": "0.21.10",
+      "resolved": "https://registry.npmjs.org/@tsdown/css/-/css-0.21.10.tgz",
+      "integrity": "sha512-JCq5KKx2WymgJiKYB7QIJLh8JjVyD3ncIr1xdX4sxh3XsSN+jVAKpp3X53bhaGNsPnaZmu3j/TLIl9F9sBJPiQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "lightningcss": "^1.32.0",
+        "postcss-load-config": "^6.0.1",
+        "rolldown": "1.0.0-rc.17"
+      },
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sxzz"
+      },
+      "peerDependencies": {
+        "postcss": "^8.4.0",
+        "postcss-import": "^16.0.0",
+        "postcss-modules": "^6.0.0",
+        "sass": "*",
+        "sass-embedded": "*",
+        "tsdown": "0.21.10"
+      },
+      "peerDependenciesMeta": {
+        "postcss": {
+          "optional": true
+        },
+        "postcss-import": {
+          "optional": true
+        },
+        "postcss-modules": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@tybys/wasm-util": {
       "version": "0.10.3",
       "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.3.tgz",
@@ -13461,6 +13506,19 @@
         "url": "https://opencollective.com/parcel"
       }
     },
+    "node_modules/lilconfig": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/lilconfig/-/lilconfig-3.1.3.tgz",
+      "integrity": "sha512-/vlFKAoH5Cgt3Ie+JLhRbwOsCQePABiU3tJ1egGvyQ+33R/vcwM2Zl2QR/LzjsBeItPt3oSVXapn+m4nQDvpzw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antonk52"
+      }
+    },
     "node_modules/lines-and-columns": {
       "version": "1.1.6",
       "license": "MIT"
@@ -14040,6 +14098,49 @@
       },
       "engines": {
         "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/postcss-load-config": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/postcss-load-config/-/postcss-load-config-6.0.1.tgz",
+      "integrity": "sha512-oPtTM4oerL+UXmx+93ytZVN82RrlY/wPUV8IeDxFrzIjXOLF1pN+EmKPLbubvKHT2HC20xXsCAH2Z+CKV6Oz/g==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "lilconfig": "^3.1.1"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "peerDependencies": {
+        "jiti": ">=1.21.0",
+        "postcss": ">=8.0.9",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "jiti": {
+          "optional": true
+        },
+        "postcss": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
+        }
       }
     },
     "node_modules/prelude-ls": {

--- a/package.json
+++ b/package.json
@@ -198,6 +198,7 @@
     "test": "jest --runInBand",
     "test:update": "jest --updateSnapshot --runInBand",
     "test:watch": "jest --watch",
+    "test:css-infrastructure": "jest --runInBand --collectCoverage=false src/styles/css-module-contract.test.ts && npm run build && node scripts/css-build/verify-css-build.util.mjs",
     "lint": "eslint .",
     "prettier:check": "prettier --check .",
     "example:dev": "npm run dev --workspace example",
@@ -272,6 +273,7 @@
   "dependencies": {
     "@dnd-kit/core": "^6.3.1",
     "@dnd-kit/sortable": "^10.0.0",
+    "clsx": "2.1.1",
     "prismjs": "^1.30.0",
     "styled-components": "^6.4.2",
     "tslib": "^2.8.1"
@@ -291,6 +293,7 @@
     "@testing-library/jest-dom": "^6.9.1",
     "@testing-library/react": "^16.3.2",
     "@testing-library/user-event": "^14.6.1",
+    "@tsdown/css": "0.21.10",
     "@types/jest": "^29.5.14",
     "@types/react": "^18.3.12",
     "@types/react-dom": "^18.3.1",

--- a/scripts/css-build/verify-css-build.util.mjs
+++ b/scripts/css-build/verify-css-build.util.mjs
@@ -1,0 +1,169 @@
+import { createRequire } from 'node:module';
+import { readdir, readFile } from 'node:fs/promises';
+import path from 'node:path';
+import { pathToFileURL } from 'node:url';
+
+const verifyCssBuild = async () => {
+  const rootDirectory = path.resolve(import.meta.dirname, '..', '..');
+  const distributionDirectory = path.join(rootDirectory, 'dist');
+  const pendingDirectories = [distributionDirectory];
+  const distributionFiles = [];
+
+  while (pendingDirectories.length > 0) {
+    const directory = pendingDirectories.pop();
+
+    if (!directory) {
+      continue;
+    }
+
+    for (const entry of await readdir(directory, { withFileTypes: true })) {
+      const entryPath = path.join(directory, entry.name);
+
+      if (entry.isDirectory()) {
+        pendingDirectories.push(entryPath);
+      } else {
+        distributionFiles.push(entryPath);
+      }
+    }
+  }
+
+  distributionFiles.sort();
+
+  const cssFiles = distributionFiles.filter((fileName) =>
+    fileName.endsWith('.css')
+  );
+  const expectedStylesheet = path.join(distributionDirectory, 'styles.css');
+
+  if (cssFiles.length !== 1 || cssFiles[0] !== expectedStylesheet) {
+    throw new Error(
+      `Expected exactly dist/styles.css, received: ${cssFiles
+        .map((fileName) => path.relative(rootDirectory, fileName))
+        .join(', ')}`
+    );
+  }
+
+  const stylesheet = await readFile(expectedStylesheet, 'utf8');
+
+  if (!stylesheet.includes('@layer react-query-builder')) {
+    throw new Error('dist/styles.css is missing the stable layer declaration');
+  }
+
+  const javascriptFiles = distributionFiles.filter((fileName) =>
+    /\.(?:cjs|mjs)$/.test(fileName)
+  );
+
+  for (const fileName of javascriptFiles) {
+    const source = await readFile(fileName, 'utf8');
+
+    if (
+      /(?:document\.createElement\(['"]style|appendChild\([^)]*style|styles\.css)/.test(
+        source
+      )
+    ) {
+      throw new Error(
+        `${path.relative(rootDirectory, fileName)} contains CSS injection or an asset import`
+      );
+    }
+  }
+
+  const localeEntries = (
+    await readdir(path.join(distributionDirectory, 'locale'), {
+      withFileTypes: true,
+    })
+  )
+    .filter((entry) => entry.isDirectory())
+    .flatMap((entry) => [
+      `locale/${entry.name}/index.mjs`,
+      `locale/${entry.name}/index.cjs`,
+    ]);
+  const nonUiEntryFiles = [
+    'parseQuery.mjs',
+    'parseQuery.cjs',
+    'formatQuery.mjs',
+    'formatQuery.cjs',
+    ...localeEntries,
+  ];
+
+  for (const relativeEntry of nonUiEntryFiles) {
+    const queue = [path.join(distributionDirectory, relativeEntry)];
+    const visited = new Set();
+
+    while (queue.length > 0) {
+      const fileName = queue.pop();
+
+      if (!fileName || visited.has(fileName)) {
+        continue;
+      }
+
+      visited.add(fileName);
+
+      const source = await readFile(fileName, 'utf8');
+
+      if (/\bclsx\b|\.css\b/.test(source)) {
+        throw new Error(
+          `${relativeEntry} reaches CSS or clsx through ${path.relative(
+            distributionDirectory,
+            fileName
+          )}`
+        );
+      }
+
+      for (const match of source.matchAll(
+        /(?:from\s+|import\s*\(|require\s*\()\s*['"](\.[^'"]+)['"]/g
+      )) {
+        const dependencyPath = path.resolve(path.dirname(fileName), match[1]);
+
+        if (dependencyPath.startsWith(distributionDirectory)) {
+          queue.push(dependencyPath);
+        }
+      }
+    }
+  }
+
+  const sharedJavaScriptChunks = javascriptFiles.filter((fileName) => {
+    const relativeFileName = path.relative(distributionDirectory, fileName);
+
+    return (
+      !relativeFileName.includes(path.sep) &&
+      ![
+        'index.cjs',
+        'index.mjs',
+        'parseQuery.cjs',
+        'parseQuery.mjs',
+        'formatQuery.cjs',
+        'formatQuery.mjs',
+      ].includes(relativeFileName)
+    );
+  });
+
+  if (sharedJavaScriptChunks.length === 0) {
+    throw new Error('Expected shared JavaScript chunks to remain enabled');
+  }
+
+  const esmModule = await import(
+    pathToFileURL(path.join(distributionDirectory, 'parseQuery.mjs')).href
+  );
+  const require = createRequire(import.meta.url);
+  const cjsModule = require(path.join(distributionDirectory, 'index.cjs'));
+
+  if (typeof esmModule.parseQuery !== 'function' || !cjsModule.Builder) {
+    throw new Error('ESM non-UI or CJS root entry did not load in Node');
+  }
+
+  console.log(
+    JSON.stringify(
+      {
+        cssFiles: ['dist/styles.css'],
+        cssInjection: false,
+        cjsSsrLoad: 'passed',
+        esmNonUiLoad: 'passed',
+        nonUiEntriesCssAndClsxFree: true,
+        sharedJavaScriptChunks: sharedJavaScriptChunks.length,
+      },
+      null,
+      2
+    )
+  );
+};
+
+await verifyCssBuild();

--- a/src/__mocks__/css-module.mock.cjs
+++ b/src/__mocks__/css-module.mock.cjs
@@ -1,0 +1,12 @@
+const classNames = new Proxy(
+  {},
+  {
+    get: (_target, property) =>
+      typeof property === 'string' ? property : undefined,
+  }
+);
+
+module.exports = {
+  __esModule: true,
+  default: classNames,
+};

--- a/src/__mocks__/style.mock.cjs
+++ b/src/__mocks__/style.mock.cjs
@@ -1,0 +1,1 @@
+module.exports = {};

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,4 +1,6 @@
-﻿export { Builder, defaultComponents } from './builder';
+import './styles/css-module-contract';
+
+export { Builder, defaultComponents } from './builder';
 export { useBuilderRef } from './hooks/use-builder-ref';
 export { useBuilderRuleDependencies } from './hooks/use-builder-rule-dependencies';
 export type {

--- a/src/styles/css-module-contract.module.css
+++ b/src/styles/css-module-contract.module.css
@@ -1,0 +1,5 @@
+@layer react-query-builder;
+
+.infrastructure {
+  --rqb-css-modules: ready;
+}

--- a/src/styles/css-module-contract.test.ts
+++ b/src/styles/css-module-contract.test.ts
@@ -1,0 +1,10 @@
+import clsx from 'clsx';
+import styles from './css-module-contract.module.css';
+
+describe('CSS Module contract', () => {
+  it('resolves private class keys in Jest and composes incoming classes', () => {
+    expect(clsx(styles.infrastructure, 'incoming-class')).toBe(
+      'infrastructure incoming-class'
+    );
+  });
+});

--- a/src/styles/css-module-contract.ts
+++ b/src/styles/css-module-contract.ts
@@ -1,0 +1,6 @@
+// eslint-disable-next-line @typescript-eslint/triple-slash-reference
+/// <reference path="../../types/css-modules.d.ts" />
+
+import styles from './css-module-contract.module.css';
+
+void styles.infrastructure;

--- a/tsdown.config.ts
+++ b/tsdown.config.ts
@@ -1,7 +1,17 @@
-﻿import { defineConfig } from 'tsdown';
+import { defineConfig } from 'tsdown';
 
 export default defineConfig({
   clean: true,
+  css: {
+    fileName: 'styles.css',
+    inject: false,
+    modules: {
+      generateScopedName: 'rqb_[hash]',
+      localsConvention: 'camelCaseOnly',
+      scopeBehaviour: 'local',
+    },
+    splitting: false,
+  },
   dts: {
     cjsReexport: true,
   },

--- a/types/css-modules.d.ts
+++ b/types/css-modules.d.ts
@@ -1,0 +1,5 @@
+declare module '*.module.css' {
+  const classes: Readonly<Record<string, string>>;
+
+  export default classes;
+}


### PR DESCRIPTION
- Captured package and consumer size, dependency, tarball, ESM, and CJS baselines
- Added pinned CSS tooling, deterministic stylesheet extraction, TypeScript declarations, and Jest handling
- Preserved CSS-free non-UI exports and shared JavaScript chunks
- Added automated CSS output and package consumer verification