### PR TITLE
feat: Added ThemeProvider CSS variable compatibility

### DIFF
--- a/.codex/TASKS.md
+++ b/.codex/TASKS.md
@@ -1366,7 +1366,7 @@ unexpectedly.
 
 ### T036 - Add the ThemeProvider-to-CSS-variable compatibility bridge
 
-**Status:** `[ ]` Not started
+**Status:** `[x]` Done
 
 **Depends on:** T035
 

--- a/.codex/reports/t036/verification-report.md
+++ b/.codex/reports/t036/verification-report.md
@@ -1,0 +1,36 @@
+# T036 verification report
+
+## Result
+
+T036 adds the legacy ThemeProvider-to-CSS-variable compatibility bridge for one
+deprecation cycle. ThemeProvider remains DOMless, accepts deep partial color
+overrides, preserves nearest-provider replacement semantics, and serializes only
+explicit color leaves. Builder style remains the final inline override, while
+standalone DropZone roots receive the nearest provider compatibility variables.
+Existing standalone styled controls continue to resolve partial provider values
+through the legacy theme path.
+
+The public `colors` and `IColors` contracts remain intact. `IThemeProps`,
+`IThemeProviderProps`, and `ThemeColorOverrides` are exported, and ThemeProvider
+color theming is marked deprecated in declarations and v2 documentation.
+
+## Verification
+
+- Focused theme, Builder precedence, standalone Button, and DropZone suites: 34 passed.
+- V2 theming documentation and API content suites: 28 passed.
+- Task-scoped ESLint: passed.
+- Modified code Prettier check: passed.
+- Root package build and generated declarations: passed.
+- V2 site TypeScript check: passed.
+- CSS infrastructure, public stylesheet, packed client, and packed SSR checks: passed.
+- Full root Jest run: 102 suites and all 524 executed tests passed; the sole failing
+  suite is the previously recorded example alias fixture that cannot resolve the
+  local `@vojtechportes/react-query-builder` workspace package.
+- Required code-review agent: initial standalone CSS-module bridge gap fixed;
+  re-review approved with no findings.
+
+## Residual risk
+
+CSS cascade behavior is covered through inline variable assertions and packed
+consumer builds rather than a real-browser computed-style visual test. Browser
+visual parity remains part of the later migration verification tasks.

--- a/.codex/t036-theme-provider-to-css-variable-compatibility-bridge-tasks.md
+++ b/.codex/t036-theme-provider-to-css-variable-compatibility-bridge-tasks.md
@@ -1,0 +1,10 @@
+# T036 - ThemeProvider-to-CSS-variable compatibility bridge
+
+- [x] Confirm T035 token and Builder style contracts.
+- [x] Accept and resolve deep partial legacy color overrides.
+- [x] Keep ThemeProvider DOMless and preserve nested context replacement.
+- [x] Apply explicit compatibility variables to Builder and standalone DropZone roots.
+- [x] Document token precedence and ThemeProvider deprecation.
+- [x] Add focused provider, precedence, standalone, API, and declaration tests.
+- [x] Run Prettier, tests, lint, build, and review-agent verification.
+- [x] Mark T036 done.

--- a/README.md
+++ b/README.md
@@ -222,6 +222,30 @@ and React Query integration example:
 
 - <a href="https://www.react-query-builder.com/documentation/dynamic-field-options" target="_blank" rel="noopener noreferrer">Dynamic Field Options Documentation</a>
 
+## Styling and legacy color theming
+
+Import `@vojtechportes/react-query-builder/styles.css` once and customize the
+inherited `--query-builder-*` CSS variables for new integrations.
+
+`ThemeProvider` remains available as a deprecated compatibility API for the
+built-in components. Its `colors` prop accepts deep partial color overrides and
+does not add a DOM wrapper. Only supplied color values become inline CSS
+variables, so omitted values do not suppress CSS inherited from your app.
+
+Nested providers keep replacement semantics: the nearest provider replaces the
+outer provider value, and omitted legacy colors resolve to the exported
+`colors` defaults. On a Builder, precedence runs from stylesheet defaults, to
+inherited CSS, to explicit ThemeProvider colors, and finally to variables in the
+Builder `style` prop.
+
+```tsx
+import { Builder, ThemeProvider } from '@vojtechportes/react-query-builder';
+
+<ThemeProvider colors={{ primary: { default: '#3f51b5' } }}>
+  <Builder data={data} fields={fields} onChange={setData} />
+</ThemeProvider>;
+```
+
 ## UI Adapters
 
 The package also exposes ready-made component mappings through versioned

--- a/example/src/v2/pages/api-page/components/theming-api-content.tsx
+++ b/example/src/v2/pages/api-page/components/theming-api-content.tsx
@@ -25,33 +25,24 @@ export const ThemingApiContent: React.FC = () => (
         <ItemTitle>
           <InlineCode>colors</InlineCode>:
         </ItemTitle>{' '}
-        Optional partial replacement source for theme color values provided
-        through context.
+        Optional deep partial color overrides. Only provided leaves become CSS
+        variables; omitted leaves continue to inherit from consumer CSS.
       </li>
       <li>
         <ItemTitle>
           <InlineCode>children</InlineCode>:
         </ItemTitle>{' '}
-        Optional React subtree that receives the theme context.
+        Optional React subtree that receives context without an added DOM node.
       </li>
       <li>
-        <ItemTitle>
-          <InlineCode>colors.primary</InlineCode> and{' '}
-          <InlineCode>colors.secondary</InlineCode>:
-        </ItemTitle>{' '}
-        Color variants used by primary and secondary action surfaces.
+        <ItemTitle>Nested providers:</ItemTitle> The nearest provider replaces
+        the outer context value. Missing legacy values resolve from the exported{' '}
+        <InlineCode>colors</InlineCode> defaults instead of the outer provider.
       </li>
       <li>
-        <ItemTitle>
-          <InlineCode>colors.grey</InlineCode>:
-        </ItemTitle>{' '}
-        Neutral palette used for borders, text, backgrounds, and control states.
-      </li>
-      <li>
-        <ItemTitle>
-          <InlineCode>colors.white</InlineCode>:
-        </ItemTitle>{' '}
-        Surface color used by builder containers and controls.
+        <ItemTitle>Precedence:</ItemTitle> Stylesheet defaults, inherited CSS,
+        explicit provider colors, then explicit{' '}
+        <InlineCode>Builder.style</InlineCode> values.
       </li>
       <li>
         <ItemTitle>Adapter note:</ItemTitle>{' '}
@@ -60,6 +51,12 @@ export const ThemingApiContent: React.FC = () => (
         theme the adapter UI.
       </li>
     </List>
+    <AlertBox title="Legacy theming" variant="warning">
+      <InlineCode>ThemeProvider</InlineCode> is deprecated for new integrations.
+      Use public <InlineCode>--query-builder-*</InlineCode> variables instead.
+      The provider, exported <InlineCode>colors</InlineCode>, and color types
+      stay available for the compatibility cycle.
+    </AlertBox>
     <AlertBox title="Documentation" variant="info">
       <TextLink to="/documentation/theming">Theming</TextLink> and{' '}
       <TextLink to="/documentation/adapters">Adapters</TextLink>.

--- a/example/src/v2/pages/api-page/constants/api-baseline.ts
+++ b/example/src/v2/pages/api-page/constants/api-baseline.ts
@@ -81,7 +81,7 @@ export const apiBaseline = [
     path: '/api/theming',
     title: 'Theming',
     contentHash:
-      '9d5cb90f8da7ffdab0a8e80ec778e198a85bbe62a2c14ccbd912b189f1a48dbf',
+      'cdabece33531446920dfa658e19d7b84c6eafbe49459773d09a5a69ecb163e95',
   },
   {
     path: '/api/format-query',

--- a/example/src/v2/pages/api-page/constants/theme-provider-signature.ts
+++ b/example/src/v2/pages/api-page/constants/theme-provider-signature.ts
@@ -1,9 +1,20 @@
-export const themeProviderSignature = `export interface IThemeProps {
-  colors?: IColors;
+export const themeProviderSignature = `export type ThemeColorOverrides = {
+  [Key in keyof IColors]?: IColors[Key] extends string
+    ? IColors[Key]
+    : Partial<IColors[Key]>;
+};
+
+export interface IThemeProps<
+  TColors extends ThemeColorOverrides = IColors,
+> {
+  colors?: TColors;
 }
 
-export interface IThemeProviderProps extends IThemeProps {
+/** @deprecated Prefer public --query-builder-* CSS variables. */
+export interface IThemeProviderProps
+  extends IThemeProps<ThemeColorOverrides> {
   children?: React.ReactNode;
 }
 
+/** @deprecated Prefer public --query-builder-* CSS variables. */
 export const ThemeProvider: React.FC<IThemeProviderProps>;`;

--- a/example/src/v2/pages/documentation-page/constants/documentation-baseline.ts
+++ b/example/src/v2/pages/documentation-page/constants/documentation-baseline.ts
@@ -129,7 +129,7 @@ export const documentationBaseline = [
     path: '/documentation/theming',
     title: 'Theming',
     contentHash:
-      '9e2fa30cbec8402749d1989bfb149ac3f51e81c92fc3df1d9ca3341ec373d277',
+      '0af5b3b47ec8d9727aacf26812a5b7cf272971f7ed8b8818e2ed849f54b5aee9',
   },
   {
     path: '/documentation/localization',

--- a/example/src/v2/pages/documentation-page/pages/theming-documentation-page/components/theming-documentation-content.tsx
+++ b/example/src/v2/pages/documentation-page/pages/theming-documentation-page/components/theming-documentation-content.tsx
@@ -3,6 +3,9 @@ import { AlertBox } from '../../../../../../components/alert-box';
 import { CodeBlock } from '../../../../../../components/code-block';
 import {
   InlineCode,
+  ItemTitle,
+  List,
+  SectionTitle,
   TextLink,
 } from '../../../../../../components/docs-primitives';
 import { themeSnippet } from '../constants/theme-snippet';
@@ -10,11 +13,48 @@ import { themeSnippet } from '../constants/theme-snippet';
 export const ThemingDocumentationContent: React.FC = () => (
   <>
     <p>
-      Use the theme provider to override builder color tokens. For control and
-      container replacement, see{' '}
-      <TextLink to="/documentation/components">Components</TextLink>.
+      Customize new integrations with inherited{' '}
+      <InlineCode>--query-builder-*</InlineCode> CSS variables. The theme
+      provider remains available as a legacy color compatibility API for the
+      built-in components.
     </p>
-    <CodeBlock code={themeSnippet} language="tsx" label="Theme provider" />
+    <CodeBlock
+      code={themeSnippet}
+      language="tsx"
+      label="Legacy theme provider"
+    />
+    <SectionTitle>Precedence</SectionTitle>
+    <p>Color values are resolved in this order, from lowest to highest:</p>
+    <List>
+      <li>
+        <ItemTitle>Stylesheet defaults:</ItemTitle> Tokens from the public{' '}
+        <InlineCode>styles.css</InlineCode> stylesheet or component fallbacks.
+      </li>
+      <li>
+        <ItemTitle>Inherited CSS:</ItemTitle> Variables declared by your app on
+        a wrapper around the builder or a standalone control.
+      </li>
+      <li>
+        <ItemTitle>ThemeProvider:</ItemTitle> Only color values explicitly
+        supplied to the nearest provider are written as compatibility variables.
+      </li>
+      <li>
+        <ItemTitle>Builder style:</ItemTitle> Variables passed through the{' '}
+        <InlineCode>Builder</InlineCode> <InlineCode>style</InlineCode> prop are
+        the final override on the builder root.
+      </li>
+    </List>
+    <p>
+      A provider does not add a DOM wrapper. Partial colors leave other CSS
+      variables untouched, so inherited app styles keep working. Nested
+      providers replace the outer provider value instead of merging with it;
+      omitted legacy colors resolve to the exported defaults.
+    </p>
+    <AlertBox title="Legacy API" variant="warning">
+      Prefer CSS variables for new code. <InlineCode>ThemeProvider</InlineCode>,{' '}
+      <InlineCode>colors</InlineCode>, and the public color types remain
+      available for the v2 compatibility cycle.
+    </AlertBox>
     <AlertBox title="Adapters and theming" variant="info">
       <InlineCode>ThemeProvider</InlineCode> customizes the built-in default
       component set. If you use an adapter from{' '}

--- a/example/src/v2/pages/documentation-page/pages/theming-documentation-page/constants/theme-snippet.ts
+++ b/example/src/v2/pages/documentation-page/pages/theming-documentation-page/constants/theme-snippet.ts
@@ -1,14 +1,8 @@
-export const themeSnippet = `import { ThemeProvider } from '@vojtechportes/react-query-builder/theme-provider';
-import { colors } from '@vojtechportes/react-query-builder';
+export const themeSnippet = `import {
+  Builder,
+  ThemeProvider,
+} from '@vojtechportes/react-query-builder';
 
-<ThemeProvider
-  colors={{
-    ...colors,
-    primary: {
-      ...colors.primary,
-      default: '#3f51b5',
-    },
-  }}
->
+<ThemeProvider colors={{ primary: { default: '#3f51b5' } }}>
   <Builder data={data} fields={fields} onChange={setData} />
 </ThemeProvider>;`;

--- a/src/builder/builder-theme-css-variables.test.tsx
+++ b/src/builder/builder-theme-css-variables.test.tsx
@@ -54,6 +54,61 @@ describe('#components/Builder theme CSS variables', () => {
     ).toBe('2rem');
   });
 
+  it('serializes only partial provider values and preserves inherited CSS', () => {
+    const { container } = render(
+      <div
+        style={
+          {
+            '--query-builder-color-primary-default': '#fedcba',
+          } as React.CSSProperties
+        }
+      >
+        <ThemeProvider colors={{ grey: { 300: '#abcdef' } }}>
+          <Builder {...requiredProps} />
+        </ThemeProvider>
+      </div>
+    );
+    const builderRoot = container.querySelector(
+      '[data-query-builder="root"]'
+    ) as HTMLElement;
+
+    expect(
+      builderRoot.style.getPropertyValue('--query-builder-color-grey-300')
+    ).toBe('#abcdef');
+    expect(
+      builderRoot.style.getPropertyValue(
+        '--query-builder-color-primary-default'
+      )
+    ).toBe('');
+    expect(
+      builderRoot.parentElement?.style.getPropertyValue(
+        '--query-builder-color-primary-default'
+      )
+    ).toBe('#fedcba');
+  });
+
+  it('uses only the nearest provider compatibility variables', () => {
+    const { container } = render(
+      <ThemeProvider colors={{ primary: { default: '#123456' } }}>
+        <ThemeProvider colors={{ grey: { 300: '#abcdef' } }}>
+          <Builder {...requiredProps} />
+        </ThemeProvider>
+      </ThemeProvider>
+    );
+    const builderRoot = container.querySelector(
+      '[data-query-builder="root"]'
+    ) as HTMLElement;
+
+    expect(
+      builderRoot.style.getPropertyValue('--query-builder-color-grey-300')
+    ).toBe('#abcdef');
+    expect(
+      builderRoot.style.getPropertyValue(
+        '--query-builder-color-primary-default'
+      )
+    ).toBe('');
+  });
+
   it('preserves root class and style props with explicit styles taking precedence', () => {
     const themeColors = {
       ...colors,

--- a/src/drop-zone/drop-zone.test.tsx
+++ b/src/drop-zone/drop-zone.test.tsx
@@ -2,6 +2,7 @@ import { useDroppable } from '@dnd-kit/core';
 import { render } from '@testing-library/react';
 import React from 'react';
 import { DropZone, IDropZoneProps } from './drop-zone';
+import { ThemeProvider } from '../theme-provider/theme-provider';
 import styles from './drop-zone.module.css';
 
 jest.mock('@dnd-kit/core', () => ({
@@ -124,6 +125,40 @@ describe('#components/DropZone', () => {
 
     expect(anchor.style.length).toBe(0);
     expect(inner.style.length).toBe(0);
+  });
+
+  it('serializes only explicit provider colors on a standalone root', () => {
+    const { container } = render(
+      <ThemeProvider colors={{ grey: { 300: '#abcdef' } }}>
+        <DropZone {...defaultProps} isActive />
+      </ThemeProvider>
+    );
+    const anchor = container.firstElementChild as HTMLElement;
+
+    expect(
+      anchor.style.getPropertyValue('--query-builder-color-grey-300')
+    ).toBe('#abcdef');
+    expect(
+      anchor.style.getPropertyValue('--query-builder-color-primary-default')
+    ).toBe('');
+  });
+
+  it('uses only the nearest provider variables on a standalone root', () => {
+    const { container } = render(
+      <ThemeProvider colors={{ primary: { default: '#123456' } }}>
+        <ThemeProvider colors={{ grey: { 300: '#abcdef' } }}>
+          <DropZone {...defaultProps} isActive />
+        </ThemeProvider>
+      </ThemeProvider>
+    );
+    const anchor = container.firstElementChild as HTMLElement;
+
+    expect(
+      anchor.style.getPropertyValue('--query-builder-color-grey-300')
+    ).toBe('#abcdef');
+    expect(
+      anchor.style.getPropertyValue('--query-builder-color-primary-default')
+    ).toBe('');
   });
 
   it('exposes every CSS Module class used by the component', () => {

--- a/src/drop-zone/drop-zone.tsx
+++ b/src/drop-zone/drop-zone.tsx
@@ -1,6 +1,7 @@
 import { useDroppable } from '@dnd-kit/core';
 import clsx from 'clsx';
 import React, { FC } from 'react';
+import { useThemeCssVariables } from '../theme-provider/hooks/use-theme-css-variables';
 import styles from './drop-zone.module.css';
 
 export interface IDropZoneProps {
@@ -24,6 +25,7 @@ export const DropZone: FC<IDropZoneProps> = ({
   disableTransition = false,
   className,
 }) => {
+  const themeCssVariables = useThemeCssVariables();
   const { setNodeRef } = useDroppable({
     id,
     data: {
@@ -37,6 +39,7 @@ export const DropZone: FC<IDropZoneProps> = ({
   return (
     <div
       ref={setNodeRef}
+      style={themeCssVariables}
       className={clsx(styles.anchor, className, {
         [styles.active]: isActive,
         [styles.dragging]: isDragging,

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -88,7 +88,11 @@ export type {
   IBooleanValueValidationRule,
 } from './builder';
 export { ThemeProvider } from './theme-provider/theme-provider';
-export type { IThemeProviderProps } from './theme-provider/theme-provider';
+export type {
+  IThemeProps,
+  IThemeProviderProps,
+} from './theme-provider/theme-provider';
+export type { ThemeColorOverrides } from './theme-provider/types/theme-color-overrides';
 
 export { BuilderContext } from './builder-context';
 export type {

--- a/src/theme-provider/hooks/use-theme.ts
+++ b/src/theme-provider/hooks/use-theme.ts
@@ -1,17 +1,16 @@
 import { useContext, useMemo } from 'react';
-import { IThemeProps, ThemeContext } from '../theme-provider'
 import { IColors } from '../../constants/colors';
-import { mergeThemeColors } from '../utils/merge-theme-colors';
+import { IThemeProps, ThemeContext } from '../theme-provider';
+import { mergeThemeColors } from '../utils/merge-theme-colors.util';
 
 export const useTheme = (): Required<IThemeProps> => {
   const themeContext = useContext(ThemeContext);
-  
   const resolvedColors = useMemo<IColors>(
-    () => mergeThemeColors(themeContext?.colors),
-    [themeContext?.colors]
+    () => mergeThemeColors(themeContext.colors),
+    [themeContext.colors]
   );
 
   return {
-    colors: resolvedColors
-  }
-}
+    colors: resolvedColors,
+  };
+};

--- a/src/theme-provider/theme-provider.test.tsx
+++ b/src/theme-provider/theme-provider.test.tsx
@@ -1,0 +1,79 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { Button } from '../button';
+import { colors } from '../constants/colors';
+import { useTheme } from './hooks/use-theme';
+import { ThemeProvider } from './theme-provider';
+
+const ThemeProbe = () => {
+  const theme = useTheme();
+
+  return (
+    <span
+      data-testid="theme-probe"
+      data-primary={theme.colors.primary.default}
+      data-grey={theme.colors.grey['300']}
+    />
+  );
+};
+
+describe('#components/ThemeProvider', () => {
+  it('is DOMless', () => {
+    const { container } = render(
+      <ThemeProvider>
+        <span>First</span>
+        <span>Second</span>
+      </ThemeProvider>
+    );
+
+    expect(container.children).toHaveLength(2);
+    expect(container.firstElementChild?.textContent).toBe('First');
+    expect(container.lastElementChild?.textContent).toBe('Second');
+  });
+
+  it('accepts partial overrides and resolves omitted legacy colors to defaults', () => {
+    render(
+      <ThemeProvider colors={{ primary: { default: '#123456' } }}>
+        <ThemeProbe />
+      </ThemeProvider>
+    );
+
+    expect(screen.getByTestId('theme-probe').getAttribute('data-primary')).toBe(
+      '#123456'
+    );
+    expect(screen.getByTestId('theme-probe').getAttribute('data-grey')).toBe(
+      colors.grey['300']
+    );
+  });
+
+  it('keeps the nearest provider replacement semantics', () => {
+    render(
+      <ThemeProvider colors={{ primary: { default: '#123456' } }}>
+        <ThemeProvider colors={{ grey: { 300: '#abcdef' } }}>
+          <ThemeProbe />
+        </ThemeProvider>
+      </ThemeProvider>
+    );
+
+    expect(screen.getByTestId('theme-probe').getAttribute('data-primary')).toBe(
+      colors.primary.default
+    );
+    expect(screen.getByTestId('theme-probe').getAttribute('data-grey')).toBe(
+      '#abcdef'
+    );
+  });
+
+  it('supports a standalone exported control with partial colors', () => {
+    render(
+      <ThemeProvider colors={{ primary: { default: 'rgb(1, 2, 3)' } }}>
+        <Button label="Standalone" onClick={jest.fn()} />
+      </ThemeProvider>
+    );
+    const buttonStyle = getComputedStyle(
+      screen.getByRole('button', { name: 'Standalone' })
+    );
+
+    expect(buttonStyle.backgroundColor).toBe('rgb(1, 2, 3)');
+    expect(buttonStyle.color).toBe('rgb(255, 255, 255)');
+  });
+});

--- a/src/theme-provider/theme-provider.tsx
+++ b/src/theme-provider/theme-provider.tsx
@@ -1,26 +1,31 @@
-import { IColors } from '../constants/colors';
 import React, { FC, createContext, useMemo } from 'react';
+import type { IColors } from '../constants/colors';
+import type { ThemeColorOverrides } from './types/theme-color-overrides';
 
-export interface IThemeProps {
-  colors?: IColors;
+export interface IThemeProps<TColors extends ThemeColorOverrides = IColors> {
+  colors?: TColors;
 }
 
-export interface IThemeProviderProps extends IThemeProps {
+/**
+ * @deprecated ThemeProvider color theming is a legacy compatibility API. Prefer
+ * the public `--query-builder-*` CSS variables for new integrations.
+ */
+export interface IThemeProviderProps extends IThemeProps<ThemeColorOverrides> {
   children?: React.ReactNode;
 }
 
-export const ThemeContext = createContext<IThemeProps>(
-  {} as IThemeProps
-);
+export const ThemeContext = createContext<IThemeProps<ThemeColorOverrides>>({});
 
+/**
+ * @deprecated ThemeProvider color theming is a legacy compatibility API. Prefer
+ * the public `--query-builder-*` CSS variables for new integrations.
+ */
 export const ThemeProvider: FC<IThemeProviderProps> = ({
   colors,
   children,
 }) => {
-  const value = useMemo<IThemeProps>(
-    () => ({
-      colors,
-    }),
+  const value = useMemo<IThemeProps<ThemeColorOverrides>>(
+    () => ({ colors }),
     [colors]
   );
 

--- a/src/theme-provider/types/theme-color-overrides.ts
+++ b/src/theme-provider/types/theme-color-overrides.ts
@@ -1,0 +1,7 @@
+import type { IColors } from '../../constants/colors';
+
+export type ThemeColorOverrides = {
+  [Key in keyof IColors]?: IColors[Key] extends string
+    ? IColors[Key]
+    : Partial<IColors[Key]>;
+};

--- a/src/theme-provider/utils/create-theme-css-variables.util.test.ts
+++ b/src/theme-provider/utils/create-theme-css-variables.util.test.ts
@@ -1,5 +1,6 @@
 import { colors } from '../../constants/colors';
 import { IThemeProps } from '../theme-provider';
+import type { ThemeColorOverrides } from '../types/theme-color-overrides';
 import { createThemeCssVariables } from './create-theme-css-variables.util';
 
 describe('#utils/createThemeCssVariables', () => {
@@ -39,7 +40,7 @@ describe('#utils/createThemeCssVariables', () => {
   });
 
   it('serializes only provided runtime overrides', () => {
-    const partialTheme = {
+    const partialTheme: IThemeProps<ThemeColorOverrides> = {
       colors: {
         primary: {
           default: '#123456',
@@ -48,7 +49,7 @@ describe('#utils/createThemeCssVariables', () => {
           300: '#abcdef',
         },
       },
-    } as IThemeProps;
+    };
 
     expect(createThemeCssVariables(partialTheme)).toEqual({
       '--query-builder-color-primary-default': '#123456',

--- a/src/theme-provider/utils/create-theme-css-variables.util.ts
+++ b/src/theme-provider/utils/create-theme-css-variables.util.ts
@@ -1,9 +1,10 @@
 import { CSSProperties } from 'react';
 import { IThemeProps } from '../theme-provider';
+import type { ThemeColorOverrides } from '../types/theme-color-overrides';
 
 export const createThemeCssVariables = ({
   colors,
-}: IThemeProps): CSSProperties => {
+}: IThemeProps<ThemeColorOverrides>): CSSProperties => {
   const variables = {
     '--query-builder-color-primary-default': colors?.primary?.default,
     '--query-builder-color-primary-light': colors?.primary?.light,

--- a/src/theme-provider/utils/merge-theme-colors.util.ts
+++ b/src/theme-provider/utils/merge-theme-colors.util.ts
@@ -1,6 +1,9 @@
 import { colors, IColors } from '../../constants/colors';
+import type { ThemeColorOverrides } from '../types/theme-color-overrides';
 
-export const mergeThemeColors = (nextColors?: IColors): IColors => ({
+export const mergeThemeColors = (
+  nextColors?: ThemeColorOverrides
+): IColors => ({
   ...colors,
   ...nextColors,
   primary: {


### PR DESCRIPTION
- Added deep partial legacy color overrides and public theme types
- Preserved DOMless and nested ThemeProvider behavior
- Applied compatibility variables to Builder and standalone controls
- Documented CSS variable precedence and deprecated legacy theming
- Added focused provider, precedence, declaration, and standalone tests
- Marked T036 as completed