### PR TITLE
feat: Updated v2 stylesheet and theming documentation

### DIFF
--- a/.codex/TASKS.md
+++ b/.codex/TASKS.md
@@ -1876,7 +1876,7 @@ for the example site and v1 library demos.
 
 ### T057 - Update v2 consumer, adapter, Monaco, and theming documentation
 
-**Status:** `[ ]` Not started
+**Status:** `[x]` Done
 
 **Depends on:** T056
 

--- a/example/src/v2/pages/api-page/api-stylesheet-imports.test.ts
+++ b/example/src/v2/pages/api-page/api-stylesheet-imports.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, it } from 'vitest';
+import { bootstrapAdapterSnippet } from './constants/bootstrap-adapter-snippet';
+import { bootstrapCreateComponentsSnippet } from './constants/bootstrap-create-components-snippet';
+import { mantineAdapterSnippet } from './constants/mantine-adapter-snippet';
+import { mantineCreateComponentsSnippet } from './constants/mantine-create-components-snippet';
+import { radixAdapterSnippet } from './constants/radix-adapter-snippet';
+import { radixCreateComponentsSnippet } from './constants/radix-create-components-snippet';
+
+const stylesheetImport =
+  "import '@vojtechportes/react-query-builder/styles.css';";
+
+const snippetModules = import.meta.glob('./constants/*snippet.ts', {
+  eager: true,
+}) as Record<string, Record<string, unknown>>;
+
+const copyReadyBuilderSnippets = Object.entries(snippetModules).flatMap(
+  ([path, module]) =>
+    Object.entries(module)
+      .filter(
+        (entry): entry is [string, string] =>
+          typeof entry[1] === 'string' && /<Builder(?:\s|\/)/.test(entry[1])
+      )
+      .map(([name, snippet]) => [`${path}:${name}`, snippet] as const)
+);
+
+const hostStylesheetCases = [
+  [
+    'Bootstrap',
+    bootstrapAdapterSnippet,
+    'bootstrap-icons/font/bootstrap-icons.css',
+  ],
+  [
+    'Bootstrap merge helper',
+    bootstrapCreateComponentsSnippet,
+    'bootstrap-icons/font/bootstrap-icons.css',
+  ],
+  ['Mantine', mantineAdapterSnippet, '@mantine/core/styles.css'],
+  [
+    'Mantine merge helper',
+    mantineCreateComponentsSnippet,
+    '@mantine/core/styles.css',
+  ],
+  ['Radix', radixAdapterSnippet, '@radix-ui/themes/styles.css'],
+  [
+    'Radix merge helper',
+    radixCreateComponentsSnippet,
+    '@radix-ui/themes/styles.css',
+  ],
+] as const;
+
+describe('v2 API stylesheet imports', () => {
+  it('discovers Builder examples across v2 API snippets', () => {
+    expect(copyReadyBuilderSnippets.length).toBeGreaterThan(10);
+  });
+
+  it.each(copyReadyBuilderSnippets)(
+    'imports the package stylesheet exactly once in %s',
+    (_name, snippet) => {
+      expect(snippet.split(stylesheetImport)).toHaveLength(2);
+    }
+  );
+
+  it.each(hostStylesheetCases)(
+    'loads the host stylesheet before the package stylesheet in the %s example',
+    (_name, snippet, hostStylesheet) => {
+      expect(snippet.indexOf(hostStylesheet)).toBeLessThan(
+        snippet.indexOf(stylesheetImport)
+      );
+    }
+  );
+});

--- a/example/src/v2/pages/api-page/components/adapters-api-content.tsx
+++ b/example/src/v2/pages/api-page/components/adapters-api-content.tsx
@@ -56,6 +56,20 @@ export const AdaptersApiContent: React.FC = () => (
         and the Radix-specific merge helper.
       </li>
     </List>
+    <SectionTitle>Stylesheet order</SectionTitle>
+    <List>
+      <li>
+        Load the host-library stylesheet first when the host requires one, then
+        load{' '}
+        <InlineCode>@vojtechportes/react-query-builder/styles.css</InlineCode>{' '}
+        exactly once.
+      </li>
+      <li>
+        Load application overrides last. Configure adapter controls through the
+        host theme API and use public query-builder variables for the library's
+        structural surfaces.
+      </li>
+    </List>{' '}
     <SectionTitle>What adapters export</SectionTitle>
     <List>
       <li>

--- a/example/src/v2/pages/api-page/components/monaco-subpackage-api-section.tsx
+++ b/example/src/v2/pages/api-page/components/monaco-subpackage-api-section.tsx
@@ -26,6 +26,19 @@ export const MonacoSubpackageApiSection: React.FC = () => (
         <InlineCode>MonacoTextModeEditor</InlineCode>.
       </li>
       <li>
+        <ItemTitle>Stylesheet:</ItemTitle> Import{' '}
+        <InlineCode>@vojtechportes/react-query-builder/styles.css</InlineCode>{' '}
+        exactly once for both the builder and Monaco integration. The Monaco
+        subpackage does not add another CSS asset.
+      </li>
+      <li>
+        <ItemTitle>Styling hooks:</ItemTitle> Use public{' '}
+        <InlineCode>--query-builder-*</InlineCode> variables or the stable{' '}
+        <InlineCode>.rqb-monaco-text-mode-editor</InlineCode> surface class.
+        Generated <InlineCode>rqb_[local]_[hash]</InlineCode> classes are
+        private.
+      </li>
+      <li>
         <ItemTitle>Peer dependency:</ItemTitle>{' '}
         <InlineCode>monaco-editor</InlineCode> is optional and only required
         when you use that subpackage.

--- a/example/src/v2/pages/api-page/components/theming-api-content.tsx
+++ b/example/src/v2/pages/api-page/components/theming-api-content.tsx
@@ -8,18 +8,59 @@ import {
   SectionTitle,
   TextLink,
 } from '../../../../components/docs-primitives';
-import { themeProviderSignature } from '../constants/theme-provider-signature';
 import { colorsSignature } from '../constants/colors-signature';
+import { themeProviderSignature } from '../constants/theme-provider-signature';
 
 export const ThemingApiContent: React.FC = () => (
   <>
+    <SectionTitle>Stylesheet and tokens</SectionTitle>
+    <List>
+      <li>
+        <ItemTitle>
+          <InlineCode>@vojtechportes/react-query-builder/styles.css</InlineCode>
+          :
+        </ItemTitle>{' '}
+        Import this public stylesheet exactly once in the application entrypoint
+        that renders v2 builders.
+      </li>
+      <li>
+        <ItemTitle>
+          <InlineCode>--query-builder-*</InlineCode>:
+        </ItemTitle>{' '}
+        Public inherited variables for colors, spacing, padding, gaps, radii,
+        shadows, control sizing, typography, editor sizing, drop zones, motion,
+        and popover layering.
+      </li>
+      <li>
+        <ItemTitle>
+          <InlineCode>IBuilderStyle</InlineCode>:
+        </ItemTitle>{' '}
+        Typed <InlineCode>React.CSSProperties</InlineCode> extension containing
+        every public variable accepted by <InlineCode>Builder.style</InlineCode>
+        .
+      </li>
+      <li>
+        <ItemTitle>Override boundaries:</ItemTitle> Declare variables globally,
+        on an app-owned wrapper, or on one Builder through its{' '}
+        <InlineCode>style</InlineCode> prop.
+      </li>
+      <li>
+        <ItemTitle>Stable selectors:</ItemTitle> Use an app-owned{' '}
+        <InlineCode>Builder.className</InlineCode> or{' '}
+        <InlineCode>[data-query-builder=&quot;root&quot;]</InlineCode>.
+        Generated CSS Module classes such as{' '}
+        <InlineCode>rqb_[local]_[hash]</InlineCode> are private and can change
+        between releases.
+      </li>
+    </List>
+    <SectionTitle>Legacy ThemeProvider</SectionTitle>
     <CodeBlock
       code={themeProviderSignature}
       language="ts"
       label="ThemeProvider"
     />
     <CodeBlock code={colorsSignature} language="ts" label="Color types" />
-    <SectionTitle>Props</SectionTitle>
+    <SectionTitle>Props and precedence</SectionTitle>
     <List>
       <li>
         <ItemTitle>
@@ -40,22 +81,23 @@ export const ThemingApiContent: React.FC = () => (
         <InlineCode>colors</InlineCode> defaults instead of the outer provider.
       </li>
       <li>
-        <ItemTitle>Precedence:</ItemTitle> Stylesheet defaults, inherited CSS,
-        explicit provider colors, then explicit{' '}
+        <ItemTitle>Precedence:</ItemTitle> Stylesheet defaults, inherited global
+        or wrapper CSS, explicit provider colors, then explicit{' '}
         <InlineCode>Builder.style</InlineCode> values.
       </li>
       <li>
         <ItemTitle>Adapter note:</ItemTitle>{' '}
         <InlineCode>ThemeProvider</InlineCode> affects the built-in default
-        components. If a packaged adapter is used instead, these tokens do not
-        theme the adapter UI.
+        components. Packaged host-library adapters use their own theme systems.
       </li>
     </List>
     <AlertBox title="Legacy theming" variant="warning">
       <InlineCode>ThemeProvider</InlineCode> is deprecated for new integrations.
-      Use public <InlineCode>--query-builder-*</InlineCode> variables instead.
-      The provider, exported <InlineCode>colors</InlineCode>, and color types
-      stay available for the compatibility cycle.
+      Map legacy color leaves to public{' '}
+      <InlineCode>--query-builder-color-*</InlineCode> variables on a wrapper or{' '}
+      <InlineCode>Builder.style</InlineCode>. The provider, exported{' '}
+      <InlineCode>colors</InlineCode>, and color types stay available for the v2
+      compatibility cycle.
     </AlertBox>
     <AlertBox title="Documentation" variant="info">
       <TextLink to="/documentation/theming">Theming</TextLink> and{' '}

--- a/example/src/v2/pages/api-page/constants/antd-adapter-snippet.ts
+++ b/example/src/v2/pages/api-page/constants/antd-adapter-snippet.ts
@@ -1,4 +1,5 @@
-export const antdAdapterSnippet = `import { components } from '@vojtechportes/react-query-builder/antd/v6';
+export const antdAdapterSnippet = `import '@vojtechportes/react-query-builder/styles.css';
+import { components } from '@vojtechportes/react-query-builder/antd/v6';
 
 <Builder
   fields={fields}

--- a/example/src/v2/pages/api-page/constants/antd-create-components-snippet.ts
+++ b/example/src/v2/pages/api-page/constants/antd-create-components-snippet.ts
@@ -1,4 +1,5 @@
-export const antdCreateComponentsSnippet = `import {
+export const antdCreateComponentsSnippet = `import '@vojtechportes/react-query-builder/styles.css';
+import {
   Builder,
   type DenormalizedQuery,
 } from '@vojtechportes/react-query-builder';

--- a/example/src/v2/pages/api-page/constants/api-baseline.ts
+++ b/example/src/v2/pages/api-page/constants/api-baseline.ts
@@ -9,7 +9,7 @@ export const apiBaseline = [
     path: '/api/builder',
     title: 'Builder',
     contentHash:
-      '0d672433f0508771a61ec61b0feaef7bb6392980dcc0068ec24004f94f256874',
+      'ddea112faa099eed32044f490e1e52cac2997fa3805b0eb9a12cf6db77244003',
   },
   {
     path: '/api/builder-ref',
@@ -33,55 +33,55 @@ export const apiBaseline = [
     path: '/api/components',
     title: 'Components',
     contentHash:
-      'a2c2c72e9ee40eda72e57ef0968a403ca9f1f4e63e88e1402bc24e2789f1134a',
+      'f111af4d0d78fe777ecadcb45946c166fbae5ad18c146d563e70fb8e3869e7ea',
   },
   {
     path: '/api/adapters',
     title: 'Adapters',
     contentHash:
-      'c65e0be121685c17fadb4706567c0fce8c1ac6d8244b7c6e625743d0e2d2131f',
+      '6c28d824ee47310bcbd44e034218b4d56505af7469c2ac2019303d8bb9989953',
   },
   {
     path: '/api/adapters/mui',
     title: 'MUI',
     contentHash:
-      '21a901d354a34d00f53b5d5000cffe38f7778720e2de92e9567fb8b11b50d6d5',
+      '7081c05e27d303f1e4f710eb200d0433f8d81a6502dd67ce840d29964af20b8c',
   },
   {
     path: '/api/adapters/antd',
     title: 'ANTD',
     contentHash:
-      '6e4ca182f47a0aff4c273eea527ac0bc8403b1072cd00a595ca8a6ba8707d3d4',
+      'c80ce0d70d1ac9f3ea16d997368c1689bd2e9c01337ec065f6d615a1d8f6e98e',
   },
   {
     path: '/api/adapters/fluentui',
     title: 'Fluent UI',
     contentHash:
-      '9199200eef8b5300a81c1ef1b97aaa60d4bf51fff4eeb4bef305456e85cd0e39',
+      'c70e0c9ef054f3e57033885d442fd19f0ac141f2d91fda33c7a6383f5dede525',
   },
   {
     path: '/api/adapters/mantine',
     title: 'Mantine',
     contentHash:
-      '0b8af2c6e902fb802f6d3c5db155abbe5ff016a946387c57272e87b20ec2afd7',
+      'eca39cb4a6e467f4dc671e5e09cdc7bca43ae6466ab5ea3ceee6bc602cd4780a',
   },
   {
     path: '/api/adapters/bootstrap',
     title: 'Bootstrap',
     contentHash:
-      'f588ca36fd5bc3f5844e12d8249177a63923688408e80734377683c398c9de32',
+      '34e27a46c7b04fc1b12b4a1953daf59830280c55f04a500425c491dfed92db66',
   },
   {
     path: '/api/adapters/radix',
     title: 'Radix',
     contentHash:
-      '495f69109cb6361c49b6039a7efea978d4f91231f5f688d88d9bb5c7488ac08c',
+      '67b8726ab4b6f3fa6285a61fdddf173411be956d22e1f2497a0bcc5d87f824fa',
   },
   {
     path: '/api/theming',
     title: 'Theming',
     contentHash:
-      'cdabece33531446920dfa658e19d7b84c6eafbe49459773d09a5a69ecb163e95',
+      '3f1bf8c98969f3c44b07e946f12fbdb172944d46e14a937363e8dd990d8a818f',
   },
   {
     path: '/api/format-query',

--- a/example/src/v2/pages/api-page/constants/bootstrap-adapter-snippet.ts
+++ b/example/src/v2/pages/api-page/constants/bootstrap-adapter-snippet.ts
@@ -1,5 +1,6 @@
 export const bootstrapAdapterSnippet = `import 'bootstrap/dist/css/bootstrap.min.css';
 import 'bootstrap-icons/font/bootstrap-icons.css';
+import '@vojtechportes/react-query-builder/styles.css';
 import { components } from '@vojtechportes/react-query-builder/bootstrap/v5';
 
 <Builder

--- a/example/src/v2/pages/api-page/constants/bootstrap-create-components-snippet.ts
+++ b/example/src/v2/pages/api-page/constants/bootstrap-create-components-snippet.ts
@@ -4,6 +4,7 @@ export const bootstrapCreateComponentsSnippet = `import {
 } from '@vojtechportes/react-query-builder';
 import 'bootstrap/dist/css/bootstrap.min.css';
 import 'bootstrap-icons/font/bootstrap-icons.css';
+import '@vojtechportes/react-query-builder/styles.css';
 import {
   createBootstrapComponents,
   components as bootstrapComponents,

--- a/example/src/v2/pages/api-page/constants/builder-field-comparison-snippet.ts
+++ b/example/src/v2/pages/api-page/constants/builder-field-comparison-snippet.ts
@@ -1,4 +1,5 @@
-export const builderFieldComparisonSnippet = `const data: DenormalizedQuery = [
+export const builderFieldComparisonSnippet = `import '@vojtechportes/react-query-builder/styles.css';
+const data: DenormalizedQuery = [
   {
     type: 'GROUP',
     value: 'AND',

--- a/example/src/v2/pages/api-page/constants/fluent-ui-adapter-snippet.ts
+++ b/example/src/v2/pages/api-page/constants/fluent-ui-adapter-snippet.ts
@@ -1,4 +1,5 @@
-export const fluentUiAdapterSnippet = `import { components } from '@vojtechportes/react-query-builder/fluentui/v8';
+export const fluentUiAdapterSnippet = `import '@vojtechportes/react-query-builder/styles.css';
+import { components } from '@vojtechportes/react-query-builder/fluentui/v8';
 
 <Builder
   fields={fields}

--- a/example/src/v2/pages/api-page/constants/fluent-ui-create-components-snippet.ts
+++ b/example/src/v2/pages/api-page/constants/fluent-ui-create-components-snippet.ts
@@ -1,4 +1,5 @@
-export const fluentUiCreateComponentsSnippet = `import {
+export const fluentUiCreateComponentsSnippet = `import '@vojtechportes/react-query-builder/styles.css';
+import {
   Builder,
   type DenormalizedQuery,
 } from '@vojtechportes/react-query-builder';

--- a/example/src/v2/pages/api-page/constants/mantine-adapter-snippet.ts
+++ b/example/src/v2/pages/api-page/constants/mantine-adapter-snippet.ts
@@ -1,4 +1,5 @@
 export const mantineAdapterSnippet = `import '@mantine/core/styles.css';
+import '@vojtechportes/react-query-builder/styles.css';
 import { MantineProvider } from '@mantine/core';
 import { components } from '@vojtechportes/react-query-builder/mantine/v9';
 

--- a/example/src/v2/pages/api-page/constants/mantine-create-components-snippet.ts
+++ b/example/src/v2/pages/api-page/constants/mantine-create-components-snippet.ts
@@ -3,6 +3,7 @@ export const mantineCreateComponentsSnippet = `import {
   type DenormalizedQuery,
 } from '@vojtechportes/react-query-builder';
 import '@mantine/core/styles.css';
+import '@vojtechportes/react-query-builder/styles.css';
 import { MantineProvider } from '@mantine/core';
 import {
   createMantineComponents,

--- a/example/src/v2/pages/api-page/constants/monaco-components-snippet.ts
+++ b/example/src/v2/pages/api-page/constants/monaco-components-snippet.ts
@@ -1,4 +1,5 @@
-export const monacoComponentsSnippet = `import { createMonacoComponents } from '@vojtechportes/react-query-builder/monaco';
+export const monacoComponentsSnippet = `import '@vojtechportes/react-query-builder/styles.css';
+import { createMonacoComponents } from '@vojtechportes/react-query-builder/monaco';
 import { components as muiComponents } from '@vojtechportes/react-query-builder/mui/v9';
 
 const components = createMonacoComponents(muiComponents);

--- a/example/src/v2/pages/api-page/constants/mui-adapter-snippet.ts
+++ b/example/src/v2/pages/api-page/constants/mui-adapter-snippet.ts
@@ -1,4 +1,5 @@
-export const muiAdapterSnippet = `import { components } from '@vojtechportes/react-query-builder/mui/v9';
+export const muiAdapterSnippet = `import '@vojtechportes/react-query-builder/styles.css';
+import { components } from '@vojtechportes/react-query-builder/mui/v9';
 
 <Builder
   fields={fields}

--- a/example/src/v2/pages/api-page/constants/mui-create-components-snippet.ts
+++ b/example/src/v2/pages/api-page/constants/mui-create-components-snippet.ts
@@ -1,4 +1,5 @@
-export const muiCreateComponentsSnippet = `import {
+export const muiCreateComponentsSnippet = `import '@vojtechportes/react-query-builder/styles.css';
+import {
   Builder,
   type DenormalizedQuery,
 } from '@vojtechportes/react-query-builder';

--- a/example/src/v2/pages/api-page/constants/radix-adapter-snippet.ts
+++ b/example/src/v2/pages/api-page/constants/radix-adapter-snippet.ts
@@ -1,4 +1,5 @@
 export const radixAdapterSnippet = `import '@radix-ui/themes/styles.css';
+import '@vojtechportes/react-query-builder/styles.css';
 import { Theme } from '@radix-ui/themes';
 import { components } from '@vojtechportes/react-query-builder/radix/v1';
 

--- a/example/src/v2/pages/api-page/constants/radix-create-components-snippet.ts
+++ b/example/src/v2/pages/api-page/constants/radix-create-components-snippet.ts
@@ -3,6 +3,7 @@ export const radixCreateComponentsSnippet = `import {
   type DenormalizedQuery,
 } from '@vojtechportes/react-query-builder';
 import '@radix-ui/themes/styles.css';
+import '@vojtechportes/react-query-builder/styles.css';
 import { Theme } from '@radix-ui/themes';
 import {
   createRadixComponents,

--- a/example/src/v2/pages/demo-page/utils/format-builder-source.util.test.ts
+++ b/example/src/v2/pages/demo-page/utils/format-builder-source.util.test.ts
@@ -6,6 +6,7 @@ import type { CustomizationMode } from '../types/customization-mode';
 import { formatBuilderSource } from './format-builder-source.util';
 
 const canonicalPackageName = '@vojtechportes/react-query-builder';
+const packageStylesheetImport = `import '${canonicalPackageName}/styles.css';`;
 const exportedPackageSpecifiers = new Set(
   packageExports.map(({ subpath }) => `${canonicalPackageName}${subpath}`)
 );
@@ -54,6 +55,7 @@ describe('v2 formatBuilderSource', () => {
     expect(source).toContain(
       "import { demoFields, initialQueryTree } from '../constants/demo-data';"
     );
+    expect(source.split(packageStylesheetImport)).toHaveLength(2);
     expect(source).toContain('singleRootGroup');
     expect(source).toContain('showValidation');
     expect(source).not.toContain('ThemeProvider');
@@ -62,9 +64,13 @@ describe('v2 formatBuilderSource', () => {
   it.each(adapterCases)(
     'renders the %s adapter import',
     (customizationMode: CustomizationMode, packagePath) => {
-      expect(
-        formatBuilderSource({ ...defaultOptions, customizationMode })
-      ).toContain(packagePath);
+      const source = formatBuilderSource({
+        ...defaultOptions,
+        customizationMode,
+      });
+
+      expect(source).toContain(packagePath);
+      expect(source.split(packageStylesheetImport)).toHaveLength(2);
     }
   );
 
@@ -92,6 +98,7 @@ describe('v2 formatBuilderSource', () => {
     expect(source).toContain(
       "import { createMonacoComponents } from '@vojtechportes/react-query-builder/monaco';"
     );
+    expect(source.split(packageStylesheetImport)).toHaveLength(2);
     expect(source).not.toContain(
       '@vojtechportes/react-query-builder/theme-provider'
     );
@@ -105,6 +112,24 @@ describe('v2 formatBuilderSource', () => {
     expect(source).toContain('primary: {');
     expect(source).toContain('default: "#123456"');
   });
+
+  it.each([
+    ['bootstrap', 'bootstrap-icons/font/bootstrap-icons.css'],
+    ['mantine', '@mantine/core/styles.css'],
+    ['radix', '@radix-ui/themes/styles.css'],
+  ] as const)(
+    'loads the %s host stylesheet before the package stylesheet',
+    (customizationMode, hostStylesheet) => {
+      const source = formatBuilderSource({
+        ...defaultOptions,
+        customizationMode,
+      });
+
+      expect(source.indexOf(hostStylesheet)).toBeLessThan(
+        source.indexOf(packageStylesheetImport)
+      );
+    }
+  );
 
   it('emits only package specifiers exposed by the v2 binding', () => {
     const generatedSources = [

--- a/example/src/v2/pages/demo-page/utils/format-builder-source.util.ts
+++ b/example/src/v2/pages/demo-page/utils/format-builder-source.util.ts
@@ -77,6 +77,7 @@ import { components as mantineComponents } from '@vojtechportes/react-query-buil
 import { Theme } from '@radix-ui/themes';
 import { components as radixComponents } from '@vojtechportes/react-query-builder/radix/v1';`
       : null,
+    `import '@vojtechportes/react-query-builder/styles.css';`,
     `import { demoFields, initialQueryTree } from '../constants/demo-data';`,
   ]
     .filter(Boolean)

--- a/example/src/v2/pages/documentation-page/constants/documentation-baseline.ts
+++ b/example/src/v2/pages/documentation-page/constants/documentation-baseline.ts
@@ -9,55 +9,55 @@ export const documentationBaseline = [
     path: '/documentation/installation',
     title: 'Installation',
     contentHash:
-      'e0385ad2c7ce036afbf95470e5627f1573553a63d0a5bfc3ef7467e1d38975a2',
+      '26f755387de8956b275296a1e6023355e4187b4ae5b8f516910e1c7d8b773438',
   },
   {
     path: '/documentation/usage',
     title: 'Usage',
     contentHash:
-      '764fd4078f038a9d1cb5c0835a99d652f53cc3a18094b28e8606015577897d74',
+      '9f42cdb8f36b3552a82257f755e2b7411c46bfa06362a4ce8119a612fb621dce',
   },
   {
     path: '/documentation/builder-behavior',
     title: 'Builder Behavior',
     contentHash:
-      'c2bb396032346ebbcfa6ed1c6e0beb7099e1f88d087246f26f5b50c085f7561e',
+      'c8437b2414d82677efb3ab9909e59b42b14cd7990dbcbb50ec81c8d9793c1e79',
   },
   {
     path: '/documentation/builder-ref',
     title: 'Builder Ref',
     contentHash:
-      'a70765ebd3d09c74aeb8351ad5cc6c4cae0327e2386230b4ef7bfa143fbd4617',
+      '362e1499b9c686152b0c8d64789793ec26b6d61839909c4886b6810681e2b3bd',
   },
   {
     path: '/documentation/field-comparisons',
     title: 'Field Comparisons',
     contentHash:
-      '410d28b3955d51ad0ad0df72e18280d378ed97e8a340fa8e525129e76f310788',
+      'aff5a2c22a402364df01f35ee1c069467c7177123a2dbf050158c776d193653d',
   },
   {
     path: '/documentation/dynamic-field-options',
     title: 'Dynamic Field Options',
     contentHash:
-      '29528dee02cb21bcdabebbd8344706087bb0f25d7635b752ca4f75b6955bd58e',
+      '12b2e254cb3f8a1680c2d98268b240a79b87d6f5be03fc3eeef0ea8aae3181e0',
   },
   {
     path: '/documentation/validation',
     title: 'Validation',
     contentHash:
-      '630b117a9d402d25c5d128ee3ec8fa6d839d6b32043384a922f124f44a8ec7f2',
+      '1e86ba1dfbd7ad79c8e958ce165e3df001916dd381bbfb3019e27384f0b40b49',
   },
   {
     path: '/documentation/history',
     title: 'Undo and Redo',
     contentHash:
-      'ee78f399929c36c9f266f354c6e57e11c3682d0e7b01ec662cc890f80afefcf3',
+      '917d165e545f00e95c19bcd5d16667adaf917a5284b472b96836a7126e91bee3',
   },
   {
     path: '/documentation/locking-and-read-only',
     title: 'Locking and Read-only',
     contentHash:
-      '12ce1ecf0bad544558206d4c76c3de13b4c34be03541a87efb75e94310cfeadd',
+      '2c72c33f2d903d9e7ef94b7f9204333972d4d9b5cff0950d9b13756a5871a73b',
   },
   {
     path: '/documentation/parsing-and-formatting',
@@ -75,66 +75,66 @@ export const documentationBaseline = [
     path: '/documentation/text-mode',
     title: 'Text Mode',
     contentHash:
-      '961a240ccec92394dd30b92bf1f72ca352fbbcd328143d8b0eae532fe003cce1',
+      'a3e41b12ad7170847c9b0a54e4649c6b6429e93202b9b91f0071aca8730d5299',
   },
   {
     path: '/documentation/components',
     title: 'Components',
     contentHash:
-      '03899815efa95fb6ec42356df1610cbb2a74d040901d223089441338926ae550',
+      '4be720a20a3d26302b6e76f6d142f18267604194b19f8f81ee04f530b1d65f88',
   },
   {
     path: '/documentation/adapters',
     title: 'Adapters',
     contentHash:
-      '623743d4ecbfc64411b4227e477638944843b18a25b4b1a86394b5814c63252f',
+      '9babf32fce1bd29b0beb124636d98260b9e8bff717ad72443580d210dbcb4f70',
   },
   {
     path: '/documentation/adapters/mui',
     title: 'MUI',
     contentHash:
-      '551a2029e27410e98ac5d36998f2def51f9a82094a1c005126dd222e15e14cc8',
+      '4be6cf45b2ebb9f8c671401c63b1ea2340ce6292705933984216b1ac26f32c13',
   },
   {
     path: '/documentation/adapters/antd',
     title: 'ANTD',
     contentHash:
-      '55c9b1b47f48aa2e783dcb327e6498b3e6b7742f1fa05a940f7c7bf296dfd6bb',
+      'daab9c9a0c910410ad7ee63ca93c1df1d42f06803f18e36d3f7e60b63322cf66',
   },
   {
     path: '/documentation/adapters/fluentui',
     title: 'Fluent UI',
     contentHash:
-      '76664ff1e9ee04935ca58f7255881ea6db80088af37bacd2b855f7a30418c25e',
+      '2ccbb0c4441b08ac03a65d8cebed7c49e815063f0f72b650b5c096ec31eed8c4',
   },
   {
     path: '/documentation/adapters/mantine',
     title: 'Mantine',
     contentHash:
-      'a868177d59eb4efba6e7d67c3041524a464adf5fd4b4afc4ce000ce1def02b5d',
+      '4afc2211677a2d15cfce65a257bdf5852ce8eadfd47d7a8c0e41537335168f70',
   },
   {
     path: '/documentation/adapters/bootstrap',
     title: 'Bootstrap',
     contentHash:
-      '4beca84339cbe889e8b545fac29b402dc4bd2f3c803550e2b77232441c94c2cb',
+      'ec14430149ab3bf70d7c282457a0fd0d994c3f0d1dcceff75224a2ae5e93db46',
   },
   {
     path: '/documentation/adapters/radix',
     title: 'Radix',
     contentHash:
-      '8c0055ec6bddb17983d3c2eeb16b22fca9aa20aff1b88b83b3848ca3e3a103b1',
+      'a07fa7486890a753cfa272c1255dc279017191ad4f6a74f180822c9ce76e18af',
   },
   {
     path: '/documentation/theming',
     title: 'Theming',
     contentHash:
-      '0af5b3b47ec8d9727aacf26812a5b7cf272971f7ed8b8818e2ed849f54b5aee9',
+      'da3123de6a20d2f28018009c6452a5629938f8d959f35e1b6ed7f10b2758f4bd',
   },
   {
     path: '/documentation/localization',
     title: 'Localization',
     contentHash:
-      '0d75a7ba7623017766f09a994f7b59a0fae5a96d3906c025f7354f775680a46e',
+      'c3301e706ae607ca391dabe73f52f42f0dbf009d6f05fd310c9fe08e62454c33',
   },
 ] as const;

--- a/example/src/v2/pages/documentation-page/documentation-stylesheet-imports.test.ts
+++ b/example/src/v2/pages/documentation-page/documentation-stylesheet-imports.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it } from 'vitest';
+import { bootstrapCreateComponentsSnippet } from './pages/adapters-bootstrap-documentation-page/constants/bootstrap-create-components-snippet';
+import { bootstrapSnippet } from './pages/adapters-bootstrap-documentation-page/constants/bootstrap-snippet';
+import { mantineCreateComponentsSnippet } from './pages/adapters-mantine-documentation-page/constants/mantine-create-components-snippet';
+import { mantineSnippet } from './pages/adapters-mantine-documentation-page/constants/mantine-snippet';
+import { radixCreateComponentsSnippet } from './pages/adapters-radix-documentation-page/constants/radix-create-components-snippet';
+import { radixSnippet } from './pages/adapters-radix-documentation-page/constants/radix-snippet';
+
+const stylesheetImport =
+  "import '@vojtechportes/react-query-builder/styles.css';";
+
+const snippetModules = import.meta.glob('./pages/**/constants/*snippet.ts', {
+  eager: true,
+}) as Record<string, Record<string, unknown>>;
+
+const copyReadyBuilderSnippets = Object.entries(snippetModules).flatMap(
+  ([path, module]) =>
+    Object.entries(module)
+      .filter(
+        (entry): entry is [string, string] =>
+          typeof entry[1] === 'string' && /<Builder(?:\s|\/)/.test(entry[1])
+      )
+      .map(([name, snippet]) => [`${path}:${name}`, snippet] as const)
+);
+
+const hostStylesheetCases = [
+  ['Bootstrap', bootstrapSnippet, 'bootstrap-icons/font/bootstrap-icons.css'],
+  [
+    'Bootstrap merge helper',
+    bootstrapCreateComponentsSnippet,
+    'bootstrap-icons/font/bootstrap-icons.css',
+  ],
+  ['Mantine', mantineSnippet, '@mantine/core/styles.css'],
+  [
+    'Mantine merge helper',
+    mantineCreateComponentsSnippet,
+    '@mantine/core/styles.css',
+  ],
+  ['Radix', radixSnippet, '@radix-ui/themes/styles.css'],
+  [
+    'Radix merge helper',
+    radixCreateComponentsSnippet,
+    '@radix-ui/themes/styles.css',
+  ],
+] as const;
+
+describe('v2 documentation stylesheet imports', () => {
+  it('discovers Builder examples across v2 documentation snippets', () => {
+    expect(copyReadyBuilderSnippets.length).toBeGreaterThan(30);
+  });
+
+  it.each(copyReadyBuilderSnippets)(
+    'imports the package stylesheet exactly once in %s',
+    (_name, snippet) => {
+      expect(snippet.split(stylesheetImport)).toHaveLength(2);
+    }
+  );
+
+  it.each(hostStylesheetCases)(
+    'loads the host stylesheet before the package stylesheet in the %s example',
+    (_name, snippet, hostStylesheet) => {
+      expect(snippet.indexOf(hostStylesheet)).toBeLessThan(
+        snippet.indexOf(stylesheetImport)
+      );
+    }
+  );
+});

--- a/example/src/v2/pages/documentation-page/pages/adapters-antd-documentation-page/constants/antd-create-components-snippet.ts
+++ b/example/src/v2/pages/documentation-page/pages/adapters-antd-documentation-page/constants/antd-create-components-snippet.ts
@@ -1,4 +1,5 @@
-export const antdCreateComponentsSnippet = `import {
+export const antdCreateComponentsSnippet = `import '@vojtechportes/react-query-builder/styles.css';
+import {
   Builder,
   type DenormalizedQuery,
 } from '@vojtechportes/react-query-builder';

--- a/example/src/v2/pages/documentation-page/pages/adapters-antd-documentation-page/constants/antd-snippet.ts
+++ b/example/src/v2/pages/documentation-page/pages/adapters-antd-documentation-page/constants/antd-snippet.ts
@@ -1,4 +1,5 @@
-export const antdSnippet = `import {
+export const antdSnippet = `import '@vojtechportes/react-query-builder/styles.css';
+import {
   Builder,
   type DenormalizedQuery,
 } from '@vojtechportes/react-query-builder';

--- a/example/src/v2/pages/documentation-page/pages/adapters-bootstrap-documentation-page/constants/bootstrap-create-components-snippet.ts
+++ b/example/src/v2/pages/documentation-page/pages/adapters-bootstrap-documentation-page/constants/bootstrap-create-components-snippet.ts
@@ -4,6 +4,7 @@ export const bootstrapCreateComponentsSnippet = `import {
 } from '@vojtechportes/react-query-builder';
 import 'bootstrap/dist/css/bootstrap.min.css';
 import 'bootstrap-icons/font/bootstrap-icons.css';
+import '@vojtechportes/react-query-builder/styles.css';
 import {
   createBootstrapComponents,
   components as bootstrapComponents,

--- a/example/src/v2/pages/documentation-page/pages/adapters-bootstrap-documentation-page/constants/bootstrap-snippet.ts
+++ b/example/src/v2/pages/documentation-page/pages/adapters-bootstrap-documentation-page/constants/bootstrap-snippet.ts
@@ -4,6 +4,7 @@ export const bootstrapSnippet = `import {
 } from '@vojtechportes/react-query-builder';
 import 'bootstrap/dist/css/bootstrap.min.css';
 import 'bootstrap-icons/font/bootstrap-icons.css';
+import '@vojtechportes/react-query-builder/styles.css';
 import { components } from '@vojtechportes/react-query-builder/bootstrap/v5';
 
 export const MyBootstrapBuilder = () => {

--- a/example/src/v2/pages/documentation-page/pages/adapters-documentation-page/components/adapters-documentation-content.tsx
+++ b/example/src/v2/pages/documentation-page/pages/adapters-documentation-page/components/adapters-documentation-content.tsx
@@ -50,6 +50,24 @@ export const AdaptersDocumentationContent: React.FC = () => (
         merge patterns.
       </li>
     </List>
+    <SectionTitle>Stylesheet order</SectionTitle>
+    <List>
+      <li>
+        Import any host-library stylesheet first, such as Bootstrap, Mantine, or
+        Radix Themes.
+      </li>
+      <li>
+        Import{' '}
+        <InlineCode>@vojtechportes/react-query-builder/styles.css</InlineCode>{' '}
+        once after the host stylesheet. MUI, ANTD, and Fluent UI do not require
+        an additional static host stylesheet in these examples.
+      </li>
+      <li>
+        Load application-owned overrides after both stylesheets. Host component
+        theme APIs remain authoritative for adapter controls; query-builder
+        variables customize the remaining structural surfaces.
+      </li>
+    </List>{' '}
     <SectionTitle>Extending an adapter</SectionTitle>
     <List>
       <li>

--- a/example/src/v2/pages/documentation-page/pages/adapters-documentation-page/constants/mui-create-components-snippet.ts
+++ b/example/src/v2/pages/documentation-page/pages/adapters-documentation-page/constants/mui-create-components-snippet.ts
@@ -1,4 +1,5 @@
-export const muiCreateComponentsSnippet = `import {
+export const muiCreateComponentsSnippet = `import '@vojtechportes/react-query-builder/styles.css';
+import {
   Builder,
   type DenormalizedQuery,
 } from '@vojtechportes/react-query-builder';

--- a/example/src/v2/pages/documentation-page/pages/adapters-fluentui-documentation-page/constants/fluent-ui-create-components-snippet.ts
+++ b/example/src/v2/pages/documentation-page/pages/adapters-fluentui-documentation-page/constants/fluent-ui-create-components-snippet.ts
@@ -1,4 +1,5 @@
-export const fluentUiCreateComponentsSnippet = `import {
+export const fluentUiCreateComponentsSnippet = `import '@vojtechportes/react-query-builder/styles.css';
+import {
   Builder,
   type DenormalizedQuery,
 } from '@vojtechportes/react-query-builder';

--- a/example/src/v2/pages/documentation-page/pages/adapters-fluentui-documentation-page/constants/fluent-ui-snippet.ts
+++ b/example/src/v2/pages/documentation-page/pages/adapters-fluentui-documentation-page/constants/fluent-ui-snippet.ts
@@ -1,4 +1,5 @@
-export const fluentUiSnippet = `import {
+export const fluentUiSnippet = `import '@vojtechportes/react-query-builder/styles.css';
+import {
   Builder,
   type DenormalizedQuery,
 } from '@vojtechportes/react-query-builder';

--- a/example/src/v2/pages/documentation-page/pages/adapters-mantine-documentation-page/constants/mantine-create-components-snippet.ts
+++ b/example/src/v2/pages/documentation-page/pages/adapters-mantine-documentation-page/constants/mantine-create-components-snippet.ts
@@ -3,6 +3,7 @@ export const mantineCreateComponentsSnippet = `import {
   type DenormalizedQuery,
 } from '@vojtechportes/react-query-builder';
 import '@mantine/core/styles.css';
+import '@vojtechportes/react-query-builder/styles.css';
 import { MantineProvider } from '@mantine/core';
 import {
   createMantineComponents,

--- a/example/src/v2/pages/documentation-page/pages/adapters-mantine-documentation-page/constants/mantine-snippet.ts
+++ b/example/src/v2/pages/documentation-page/pages/adapters-mantine-documentation-page/constants/mantine-snippet.ts
@@ -3,6 +3,7 @@ export const mantineSnippet = `import {
   type DenormalizedQuery,
 } from '@vojtechportes/react-query-builder';
 import '@mantine/core/styles.css';
+import '@vojtechportes/react-query-builder/styles.css';
 import { MantineProvider } from '@mantine/core';
 import { components } from '@vojtechportes/react-query-builder/mantine/v9';
 

--- a/example/src/v2/pages/documentation-page/pages/adapters-mui-documentation-page/constants/mui-create-components-snippet.ts
+++ b/example/src/v2/pages/documentation-page/pages/adapters-mui-documentation-page/constants/mui-create-components-snippet.ts
@@ -1,4 +1,5 @@
-export const muiCreateComponentsSnippet = `import {
+export const muiCreateComponentsSnippet = `import '@vojtechportes/react-query-builder/styles.css';
+import {
   Builder,
   type DenormalizedQuery,
 } from '@vojtechportes/react-query-builder';

--- a/example/src/v2/pages/documentation-page/pages/adapters-mui-documentation-page/constants/mui-snippet.ts
+++ b/example/src/v2/pages/documentation-page/pages/adapters-mui-documentation-page/constants/mui-snippet.ts
@@ -1,4 +1,5 @@
-export const muiSnippet = `import {
+export const muiSnippet = `import '@vojtechportes/react-query-builder/styles.css';
+import {
   Builder,
   type DenormalizedQuery,
 } from '@vojtechportes/react-query-builder';

--- a/example/src/v2/pages/documentation-page/pages/adapters-radix-documentation-page/constants/radix-create-components-snippet.ts
+++ b/example/src/v2/pages/documentation-page/pages/adapters-radix-documentation-page/constants/radix-create-components-snippet.ts
@@ -3,6 +3,7 @@ export const radixCreateComponentsSnippet = `import {
   type DenormalizedQuery,
 } from '@vojtechportes/react-query-builder';
 import '@radix-ui/themes/styles.css';
+import '@vojtechportes/react-query-builder/styles.css';
 import { Theme } from '@radix-ui/themes';
 import {
   createRadixComponents,

--- a/example/src/v2/pages/documentation-page/pages/adapters-radix-documentation-page/constants/radix-snippet.ts
+++ b/example/src/v2/pages/documentation-page/pages/adapters-radix-documentation-page/constants/radix-snippet.ts
@@ -3,6 +3,7 @@ export const radixSnippet = `import {
   type DenormalizedQuery,
 } from '@vojtechportes/react-query-builder';
 import '@radix-ui/themes/styles.css';
+import '@vojtechportes/react-query-builder/styles.css';
 import { Theme } from '@radix-ui/themes';
 import { components } from '@vojtechportes/react-query-builder/radix/v1';
 

--- a/example/src/v2/pages/documentation-page/pages/builder-behavior-documentation-page/constants/builder-behavior-snippet.ts
+++ b/example/src/v2/pages/documentation-page/pages/builder-behavior-documentation-page/constants/builder-behavior-snippet.ts
@@ -1,4 +1,5 @@
-export const builderBehaviorSnippet = `<Builder
+export const builderBehaviorSnippet = `import '@vojtechportes/react-query-builder/styles.css';
+<Builder
   fields={fields}
   data={data}
   lockable

--- a/example/src/v2/pages/documentation-page/pages/builder-ref-documentation-page/constants/builder-ref-basic-snippet.ts
+++ b/example/src/v2/pages/documentation-page/pages/builder-ref-documentation-page/constants/builder-ref-basic-snippet.ts
@@ -1,4 +1,5 @@
-export const builderRefBasicSnippet = `import React, { useState } from 'react';
+export const builderRefBasicSnippet = `import '@vojtechportes/react-query-builder/styles.css';
+import React, { useState } from 'react';
 import {
   Builder,
   useBuilderRef,

--- a/example/src/v2/pages/documentation-page/pages/components-documentation-page/constants/components-snippet.ts
+++ b/example/src/v2/pages/documentation-page/pages/components-documentation-page/constants/components-snippet.ts
@@ -1,4 +1,5 @@
-export const componentsSnippet = `const components = {
+export const componentsSnippet = `import '@vojtechportes/react-query-builder/styles.css';
+const components = {
   Add: MyAddButton,
   Remove: MyRemoveButton,
   form: {

--- a/example/src/v2/pages/documentation-page/pages/dynamic-field-options-documentation-page/constants/dynamic-field-options-react-query-snippet.ts
+++ b/example/src/v2/pages/documentation-page/pages/dynamic-field-options-documentation-page/constants/dynamic-field-options-react-query-snippet.ts
@@ -1,4 +1,5 @@
-export const dynamicFieldOptionsReactQuerySnippet = `import React, { useEffect, useState } from 'react';
+export const dynamicFieldOptionsReactQuerySnippet = `import '@vojtechportes/react-query-builder/styles.css';
+import React, { useEffect, useState } from 'react';
 import { useQueries } from '@tanstack/react-query';
 import {
   Builder,

--- a/example/src/v2/pages/documentation-page/pages/dynamic-field-options-documentation-page/constants/dynamic-field-options-reload-snippet.ts
+++ b/example/src/v2/pages/documentation-page/pages/dynamic-field-options-documentation-page/constants/dynamic-field-options-reload-snippet.ts
@@ -1,4 +1,5 @@
-export const dynamicFieldOptionsReloadSnippet = `const builderRef = useBuilderRef();
+export const dynamicFieldOptionsReloadSnippet = `import '@vojtechportes/react-query-builder/styles.css';
+const builderRef = useBuilderRef();
 
 <Builder
   ref={builderRef}

--- a/example/src/v2/pages/documentation-page/pages/dynamic-field-options-documentation-page/constants/dynamic-field-options-snippet.ts
+++ b/example/src/v2/pages/documentation-page/pages/dynamic-field-options-documentation-page/constants/dynamic-field-options-snippet.ts
@@ -1,4 +1,5 @@
-export const dynamicFieldOptionsSnippet = `import React, { useCallback, useEffect, useState } from 'react';
+export const dynamicFieldOptionsSnippet = `import '@vojtechportes/react-query-builder/styles.css';
+import React, { useCallback, useEffect, useState } from 'react';
 import {
   Builder,
   useBuilderRef,

--- a/example/src/v2/pages/documentation-page/pages/dynamic-field-options-documentation-page/constants/dynamic-rule-options-snippet.ts
+++ b/example/src/v2/pages/documentation-page/pages/dynamic-field-options-documentation-page/constants/dynamic-rule-options-snippet.ts
@@ -1,4 +1,5 @@
-export const dynamicRuleOptionsSnippet = `import React, { useEffect, useState } from 'react';
+export const dynamicRuleOptionsSnippet = `import '@vojtechportes/react-query-builder/styles.css';
+import React, { useEffect, useState } from 'react';
 import {
   Builder,
   useBuilderRef,

--- a/example/src/v2/pages/documentation-page/pages/field-comparisons-documentation-page/constants/field-comparison-snippet.ts
+++ b/example/src/v2/pages/documentation-page/pages/field-comparisons-documentation-page/constants/field-comparison-snippet.ts
@@ -1,4 +1,5 @@
-export const fieldComparisonSnippet = `import React, { useState } from 'react';
+export const fieldComparisonSnippet = `import '@vojtechportes/react-query-builder/styles.css';
+import React, { useState } from 'react';
 import {
   Builder,
   type DenormalizedQuery,

--- a/example/src/v2/pages/documentation-page/pages/history-documentation-page/constants/history-controls-snippet.ts
+++ b/example/src/v2/pages/documentation-page/pages/history-documentation-page/constants/history-controls-snippet.ts
@@ -1,4 +1,5 @@
-export const historyControlsSnippet = `const components = {
+export const historyControlsSnippet = `import '@vojtechportes/react-query-builder/styles.css';
+const components = {
   HistoryControls: ({
     undoButton,
     redoButton,

--- a/example/src/v2/pages/documentation-page/pages/history-documentation-page/constants/history-snippet.ts
+++ b/example/src/v2/pages/documentation-page/pages/history-documentation-page/constants/history-snippet.ts
@@ -1,4 +1,5 @@
-export const historySnippet = `import React, { useState } from 'react';
+export const historySnippet = `import '@vojtechportes/react-query-builder/styles.css';
+import React, { useState } from 'react';
 import {
   Builder,
   type DenormalizedQuery,

--- a/example/src/v2/pages/documentation-page/pages/installation-documentation-page/components/installation-documentation-content.tsx
+++ b/example/src/v2/pages/documentation-page/pages/installation-documentation-page/components/installation-documentation-content.tsx
@@ -10,6 +10,12 @@ export const InstallationDocumentationContent: React.FC = () => (
       Install the package and use it with React <InlineCode>18+</InlineCode>.
     </p>
     <CodeBlock code={installationSnippet} language="bash" label="npm" />
+    <p>
+      Import{' '}
+      <InlineCode>@vojtechportes/react-query-builder/styles.css</InlineCode>{' '}
+      once in the client or framework entrypoint that renders v2 builders. The
+      package does not inject component styles at runtime.
+    </p>{' '}
     <AlertBox title="Peer dependencies" variant="info">
       The package expects compatible <InlineCode>react</InlineCode> and{' '}
       <InlineCode>react-dom</InlineCode> versions in the consuming app. In

--- a/example/src/v2/pages/documentation-page/pages/localization-documentation-page/constants/first-party-locale-snippet.ts
+++ b/example/src/v2/pages/documentation-page/pages/localization-documentation-page/constants/first-party-locale-snippet.ts
@@ -1,4 +1,5 @@
-export const firstPartyLocaleSnippet = `import { Builder } from '@vojtechportes/react-query-builder';
+export const firstPartyLocaleSnippet = `import '@vojtechportes/react-query-builder/styles.css';
+import { Builder } from '@vojtechportes/react-query-builder';
 import { strings } from '@vojtechportes/react-query-builder/locale/fr-FR';
 
 <Builder

--- a/example/src/v2/pages/documentation-page/pages/localization-documentation-page/constants/strings-snippet.ts
+++ b/example/src/v2/pages/documentation-page/pages/localization-documentation-page/constants/strings-snippet.ts
@@ -1,4 +1,5 @@
-export const stringsSnippet = `import { strings } from '@vojtechportes/react-query-builder';
+export const stringsSnippet = `import '@vojtechportes/react-query-builder/styles.css';
+import { strings } from '@vojtechportes/react-query-builder';
 
 <Builder
   fields={fields}

--- a/example/src/v2/pages/documentation-page/pages/locking-and-read-only-documentation-page/constants/clone-button-snippet.ts
+++ b/example/src/v2/pages/documentation-page/pages/locking-and-read-only-documentation-page/constants/clone-button-snippet.ts
@@ -1,4 +1,5 @@
-export const cloneButtonSnippet = `const components = {
+export const cloneButtonSnippet = `import '@vojtechportes/react-query-builder/styles.css';
+const components = {
   CloneButton: MyCloneButton,
 };
 

--- a/example/src/v2/pages/documentation-page/pages/locking-and-read-only-documentation-page/constants/lock-toggle-snippet.ts
+++ b/example/src/v2/pages/documentation-page/pages/locking-and-read-only-documentation-page/constants/lock-toggle-snippet.ts
@@ -1,4 +1,5 @@
-export const lockToggleSnippet = `const components = {
+export const lockToggleSnippet = `import '@vojtechportes/react-query-builder/styles.css';
+const components = {
   LockToggle: MyLockToggle,
 };
 

--- a/example/src/v2/pages/documentation-page/pages/locking-and-read-only-documentation-page/constants/locking-gui-snippet.ts
+++ b/example/src/v2/pages/documentation-page/pages/locking-and-read-only-documentation-page/constants/locking-gui-snippet.ts
@@ -1,4 +1,5 @@
-export const lockingGuiSnippet = `<Builder
+export const lockingGuiSnippet = `import '@vojtechportes/react-query-builder/styles.css';
+<Builder
   fields={fields}
   data={data}
   lockable

--- a/example/src/v2/pages/documentation-page/pages/locking-and-read-only-documentation-page/constants/locking-snippet.ts
+++ b/example/src/v2/pages/documentation-page/pages/locking-and-read-only-documentation-page/constants/locking-snippet.ts
@@ -1,4 +1,5 @@
-export const lockingSnippet = `const data: DenormalizedQuery = [
+export const lockingSnippet = `import '@vojtechportes/react-query-builder/styles.css';
+const data: DenormalizedQuery = [
   {
     type: 'GROUP',
     value: 'AND',

--- a/example/src/v2/pages/documentation-page/pages/text-mode-documentation-page/components/text-mode-documentation-content.tsx
+++ b/example/src/v2/pages/documentation-page/pages/text-mode-documentation-page/components/text-mode-documentation-content.tsx
@@ -167,6 +167,12 @@ export const TextModeDocumentationContent: React.FC = () => (
       </li>
     </List>
     <SectionTitle>Using Monaco text mode</SectionTitle>
+    <p>
+      Monaco uses the same public{' '}
+      <InlineCode>@vojtechportes/react-query-builder/styles.css</InlineCode>{' '}
+      import as the default builder. Import it once; the Monaco subpackage does
+      not ship a second stylesheet.
+    </p>
     <CodeBlock
       code={monacoTextModeSnippet}
       language="tsx"
@@ -182,6 +188,22 @@ export const TextModeDocumentationContent: React.FC = () => (
       language="tsx"
       label="Compose Monaco with ANTD"
     />
+    <SectionTitle>Monaco styling hooks</SectionTitle>
+    <List>
+      <li>
+        Use public editor, color, spacing, radius, and shadow CSS variables for
+        supported presentation changes.
+      </li>
+      <li>
+        <InlineCode>.rqb-monaco-text-mode-editor</InlineCode> is the stable
+        class on the Monaco surface when an application needs a wrapper-scoped
+        selector.
+      </li>
+      <li>
+        Generated <InlineCode>rqb_[local]_[hash]</InlineCode> CSS Module classes
+        are private and must not be used as selectors.
+      </li>
+    </List>{' '}
     <SectionTitle>Text-mode strings</SectionTitle>
     <p>
       Text-mode labels and messages are part of the regular{' '}

--- a/example/src/v2/pages/documentation-page/pages/text-mode-documentation-page/constants/monaco-text-mode-snippet.ts
+++ b/example/src/v2/pages/documentation-page/pages/text-mode-documentation-page/constants/monaco-text-mode-snippet.ts
@@ -1,4 +1,5 @@
-export const monacoTextModeSnippet = `import React, { useState } from 'react';
+export const monacoTextModeSnippet = `import '@vojtechportes/react-query-builder/styles.css';
+import React, { useState } from 'react';
 import {
   Builder,
   type DenormalizedQuery,

--- a/example/src/v2/pages/documentation-page/pages/text-mode-documentation-page/constants/monaco-with-antd-snippet.ts
+++ b/example/src/v2/pages/documentation-page/pages/text-mode-documentation-page/constants/monaco-with-antd-snippet.ts
@@ -1,4 +1,5 @@
-export const monacoWithAntdSnippet = `import { Builder } from '@vojtechportes/react-query-builder';
+export const monacoWithAntdSnippet = `import '@vojtechportes/react-query-builder/styles.css';
+import { Builder } from '@vojtechportes/react-query-builder';
 import { components as antdComponents } from '@vojtechportes/react-query-builder/antd/v6';
 import { createMonacoComponents } from '@vojtechportes/react-query-builder/monaco';
 

--- a/example/src/v2/pages/documentation-page/pages/text-mode-documentation-page/constants/monaco-with-mui-snippet.ts
+++ b/example/src/v2/pages/documentation-page/pages/text-mode-documentation-page/constants/monaco-with-mui-snippet.ts
@@ -1,4 +1,5 @@
-export const monacoWithMuiSnippet = `import { Builder } from '@vojtechportes/react-query-builder';
+export const monacoWithMuiSnippet = `import '@vojtechportes/react-query-builder/styles.css';
+import { Builder } from '@vojtechportes/react-query-builder';
 import { components as muiComponents } from '@vojtechportes/react-query-builder/mui/v9';
 import { createMonacoComponents } from '@vojtechportes/react-query-builder/monaco';
 

--- a/example/src/v2/pages/documentation-page/pages/text-mode-documentation-page/constants/text-mode-config-snippet.ts
+++ b/example/src/v2/pages/documentation-page/pages/text-mode-documentation-page/constants/text-mode-config-snippet.ts
@@ -1,4 +1,5 @@
-export const textModeConfigSnippet = `<Builder
+export const textModeConfigSnippet = `import '@vojtechportes/react-query-builder/styles.css';
+<Builder
   fields={fields}
   data={data}
   textMode={{

--- a/example/src/v2/pages/documentation-page/pages/text-mode-documentation-page/constants/text-mode-default-mode-snippet.ts
+++ b/example/src/v2/pages/documentation-page/pages/text-mode-documentation-page/constants/text-mode-default-mode-snippet.ts
@@ -1,4 +1,5 @@
-export const textModeDefaultModeSnippet = `<Builder
+export const textModeDefaultModeSnippet = `import '@vojtechportes/react-query-builder/styles.css';
+<Builder
   fields={fields}
   data={data}
   textMode

--- a/example/src/v2/pages/documentation-page/pages/text-mode-documentation-page/constants/text-mode-snippet.ts
+++ b/example/src/v2/pages/documentation-page/pages/text-mode-documentation-page/constants/text-mode-snippet.ts
@@ -1,4 +1,5 @@
-export const textModeSnippet = `import React, { useState } from 'react';
+export const textModeSnippet = `import '@vojtechportes/react-query-builder/styles.css';
+import React, { useState } from 'react';
 import {
   Builder,
   type DenormalizedQuery,

--- a/example/src/v2/pages/documentation-page/pages/text-mode-documentation-page/constants/text-mode-strings-snippet.ts
+++ b/example/src/v2/pages/documentation-page/pages/text-mode-documentation-page/constants/text-mode-strings-snippet.ts
@@ -1,4 +1,5 @@
-export const textModeStringsSnippet = `import { strings } from '@vojtechportes/react-query-builder';
+export const textModeStringsSnippet = `import '@vojtechportes/react-query-builder/styles.css';
+import { strings } from '@vojtechportes/react-query-builder';
 
 <Builder
   fields={fields}

--- a/example/src/v2/pages/documentation-page/pages/theming-documentation-page/components/theming-documentation-content.tsx
+++ b/example/src/v2/pages/documentation-page/pages/theming-documentation-page/components/theming-documentation-content.tsx
@@ -8,63 +8,147 @@ import {
   SectionTitle,
   TextLink,
 } from '../../../../../../components/docs-primitives';
+import { builderStyleThemeSnippet } from '../constants/builder-style-theme-snippet';
+import { globalThemeSnippet } from '../constants/global-theme-snippet';
 import { themeSnippet } from '../constants/theme-snippet';
+import { wrapperThemeSnippet } from '../constants/wrapper-theme-snippet';
 
 export const ThemingDocumentationContent: React.FC = () => (
   <>
     <p>
-      Customize new integrations with inherited{' '}
-      <InlineCode>--query-builder-*</InlineCode> CSS variables. The theme
-      provider remains available as a legacy color compatibility API for the
-      built-in components.
+      Import{' '}
+      <InlineCode>@vojtechportes/react-query-builder/styles.css</InlineCode>{' '}
+      once, then customize the built-in components with inherited{' '}
+      <InlineCode>--query-builder-*</InlineCode> CSS variables. The stylesheet
+      supplies the default token values; components do not inject runtime
+      styles.
     </p>
+    <SectionTitle>Global overrides</SectionTitle>
+    <p>
+      Set variables on <InlineCode>:root</InlineCode> when every builder and
+      standalone built-in control should share the same values.
+    </p>
+    <CodeBlock code={globalThemeSnippet} language="css" label="Global tokens" />
+    <SectionTitle>Wrapper overrides</SectionTitle>
+    <p>
+      Set variables on an application-owned wrapper to scope a theme to one
+      subtree. The values are inherited by the builder and its built-in
+      controls.
+    </p>
+    <CodeBlock
+      code={wrapperThemeSnippet}
+      language="css"
+      label="Wrapper-scoped tokens"
+    />
+    <SectionTitle>Builder overrides</SectionTitle>
+    <p>
+      Use the typed <InlineCode>Builder.style</InlineCode> prop for values that
+      belong to one builder instance. This is the most specific supported token
+      override boundary.
+    </p>
+    <CodeBlock
+      code={builderStyleThemeSnippet}
+      language="tsx"
+      label="Per-Builder tokens"
+    />
+    <SectionTitle>Public token groups</SectionTitle>
+    <List>
+      <li>
+        <ItemTitle>Colors:</ItemTitle>{' '}
+        <InlineCode>--query-builder-color-primary-*</InlineCode>,{' '}
+        <InlineCode>--query-builder-color-secondary-*</InlineCode>, grey scale,
+        status colors, and white.
+      </li>
+      <li>
+        <ItemTitle>Spacing and layout:</ItemTitle>{' '}
+        <InlineCode>--query-builder-spacing-*</InlineCode>, root/group/rule
+        padding, control/group gaps, control dimensions, and drop-zone height.
+      </li>
+      <li>
+        <ItemTitle>Shape and depth:</ItemTitle>{' '}
+        <InlineCode>--query-builder-radius-*</InlineCode> and{' '}
+        <InlineCode>--query-builder-shadow-*</InlineCode> tokens for roots,
+        groups, popovers, and focus rings.
+      </li>
+      <li>
+        <ItemTitle>Typography and editors:</ItemTitle> Font, font size, line
+        height, editor typography, editor minimum height, motion, and popover
+        layering tokens.
+      </li>
+    </List>
+    <p>
+      <InlineCode>IBuilderStyle</InlineCode> is the typed list of every public
+      token accepted by <InlineCode>Builder.style</InlineCode>. The same
+      variable names can be declared in global or wrapper CSS.
+    </p>
+    <SectionTitle>Precedence</SectionTitle>
+    <p>Values are resolved in this order, from lowest to highest:</p>
+    <List>
+      <li>
+        <ItemTitle>Stylesheet defaults:</ItemTitle> Generated color defaults and
+        the public layout, sizing, typography, motion, and layering defaults in{' '}
+        <InlineCode>styles.css</InlineCode>.
+      </li>
+      <li>
+        <ItemTitle>Inherited CSS:</ItemTitle> Variables declared by your app on{' '}
+        <InlineCode>:root</InlineCode> or a wrapper around the builder.
+      </li>
+      <li>
+        <ItemTitle>ThemeProvider:</ItemTitle> Only color values explicitly
+        supplied to the nearest legacy provider become compatibility variables.
+      </li>
+      <li>
+        <ItemTitle>Builder style:</ItemTitle> Variables passed through the{' '}
+        <InlineCode>Builder.style</InlineCode> prop are the final override on
+        the builder root.
+      </li>
+    </List>
+    <SectionTitle>Stable styling hooks</SectionTitle>
+    <List>
+      <li>
+        Pass an application-owned <InlineCode>className</InlineCode> to{' '}
+        <InlineCode>Builder</InlineCode> or select its stable{' '}
+        <InlineCode>[data-query-builder=&quot;root&quot;]</InlineCode>{' '}
+        attribute.
+      </li>
+      <li>
+        Prefer public CSS variables for built-in presentation and the component
+        override API when you need different markup.
+      </li>
+      <li>
+        CSS Module classes shaped like{' '}
+        <InlineCode>rqb_[local]_[hash]</InlineCode> are private build output.
+        Their names can change between releases and must not be used as
+        selectors.
+      </li>
+    </List>
+    <SectionTitle>Migrating from ThemeProvider</SectionTitle>
     <CodeBlock
       code={themeSnippet}
       language="tsx"
       label="Legacy theme provider"
     />
-    <SectionTitle>Precedence</SectionTitle>
-    <p>Color values are resolved in this order, from lowest to highest:</p>
-    <List>
-      <li>
-        <ItemTitle>Stylesheet defaults:</ItemTitle> Tokens from the public{' '}
-        <InlineCode>styles.css</InlineCode> stylesheet or component fallbacks.
-      </li>
-      <li>
-        <ItemTitle>Inherited CSS:</ItemTitle> Variables declared by your app on
-        a wrapper around the builder or a standalone control.
-      </li>
-      <li>
-        <ItemTitle>ThemeProvider:</ItemTitle> Only color values explicitly
-        supplied to the nearest provider are written as compatibility variables.
-      </li>
-      <li>
-        <ItemTitle>Builder style:</ItemTitle> Variables passed through the{' '}
-        <InlineCode>Builder</InlineCode> <InlineCode>style</InlineCode> prop are
-        the final override on the builder root.
-      </li>
-    </List>
     <p>
-      A provider does not add a DOM wrapper. Partial colors leave other CSS
-      variables untouched, so inherited app styles keep working. Nested
-      providers replace the outer provider value instead of merging with it;
-      omitted legacy colors resolve to the exported defaults.
+      Replace each legacy color leaf with its matching CSS variable. For
+      example, <InlineCode>colors.primary.default</InlineCode> becomes{' '}
+      <InlineCode>--query-builder-color-primary-default</InlineCode>. Put shared
+      values on a wrapper or pass one-off values through{' '}
+      <InlineCode>Builder.style</InlineCode>, then remove the provider when it
+      no longer serves other builders.
     </p>
     <AlertBox title="Legacy API" variant="warning">
       Prefer CSS variables for new code. <InlineCode>ThemeProvider</InlineCode>,{' '}
       <InlineCode>colors</InlineCode>, and the public color types remain
-      available for the v2 compatibility cycle.
+      available for the v2 compatibility cycle. The provider has no DOM wrapper,
+      only handles colors, and nested providers replace rather than merge the
+      outer color value.
     </AlertBox>
     <AlertBox title="Adapters and theming" variant="info">
-      <InlineCode>ThemeProvider</InlineCode> customizes the built-in default
-      component set. If you use an adapter from{' '}
-      <TextLink to="/documentation/adapters">Adapters</TextLink>, such as{' '}
-      <InlineCode>mui/v7</InlineCode>, <InlineCode>mui/v9</InlineCode>,{' '}
-      <InlineCode>antd/v5</InlineCode>, <InlineCode>antd/v6</InlineCode>,{' '}
-      <InlineCode>bootstrap/v5</InlineCode>,{' '}
-      <InlineCode>fluentui/v8</InlineCode>, <InlineCode>mantine/v8</InlineCode>,{' '}
-      <InlineCode>mantine/v9</InlineCode>, or <InlineCode>radix/v1</InlineCode>,
-      these theme tokens do not affect the adapter UI.
+      <InlineCode>ThemeProvider</InlineCode> and the built-in color tokens do
+      not theme host-library controls supplied by an adapter. Configure the host
+      UI library through its own theme API and use query-builder variables for
+      the remaining structural surfaces. See{' '}
+      <TextLink to="/documentation/adapters">Adapters</TextLink>.
     </AlertBox>
     <AlertBox title="API reference" variant="info">
       <TextLink to="/api/theming">Theming</TextLink> and{' '}

--- a/example/src/v2/pages/documentation-page/pages/theming-documentation-page/constants/builder-style-theme-snippet.ts
+++ b/example/src/v2/pages/documentation-page/pages/theming-documentation-page/constants/builder-style-theme-snippet.ts
@@ -1,0 +1,18 @@
+export const builderStyleThemeSnippet = `import '@vojtechportes/react-query-builder/styles.css';
+import {
+  Builder,
+  type IBuilderStyle,
+} from '@vojtechportes/react-query-builder';
+
+const builderStyle: IBuilderStyle = {
+  '--query-builder-color-primary-default': '#3157c8',
+  '--query-builder-root-padding': '1.25rem',
+  '--query-builder-root-radius': '8px',
+};
+
+<Builder
+  data={data}
+  fields={fields}
+  style={builderStyle}
+  onChange={setData}
+/>;`;

--- a/example/src/v2/pages/documentation-page/pages/theming-documentation-page/constants/global-theme-snippet.ts
+++ b/example/src/v2/pages/documentation-page/pages/theming-documentation-page/constants/global-theme-snippet.ts
@@ -1,0 +1,5 @@
+export const globalThemeSnippet = `:root {
+  --query-builder-color-primary-default: #3157c8;
+  --query-builder-root-padding: 1.25rem;
+  --query-builder-root-radius: 8px;
+}`;

--- a/example/src/v2/pages/documentation-page/pages/theming-documentation-page/constants/theme-snippet.ts
+++ b/example/src/v2/pages/documentation-page/pages/theming-documentation-page/constants/theme-snippet.ts
@@ -1,4 +1,5 @@
-export const themeSnippet = `import {
+export const themeSnippet = `import '@vojtechportes/react-query-builder/styles.css';
+import {
   Builder,
   ThemeProvider,
 } from '@vojtechportes/react-query-builder';

--- a/example/src/v2/pages/documentation-page/pages/theming-documentation-page/constants/wrapper-theme-snippet.ts
+++ b/example/src/v2/pages/documentation-page/pages/theming-documentation-page/constants/wrapper-theme-snippet.ts
@@ -1,0 +1,5 @@
+export const wrapperThemeSnippet = `.orders-query-builder {
+  --query-builder-color-primary-default: #3157c8;
+  --query-builder-group-padding: 1rem;
+  --query-builder-shadow-group: 0 8px 24px rgb(15 23 42 / 12%);
+}`;

--- a/example/src/v2/pages/documentation-page/pages/usage-documentation-page/components/usage-documentation-content.tsx
+++ b/example/src/v2/pages/documentation-page/pages/usage-documentation-page/components/usage-documentation-content.tsx
@@ -9,7 +9,11 @@ import { basicUsageSnippet } from '../constants/basic-usage-snippet';
 
 export const UsageDocumentationContent: React.FC = () => (
   <>
-    <p>Basic controlled usage.</p>
+    <p>
+      Basic controlled usage. The stylesheet side-effect import belongs once in
+      your application entrypoint; it is included in this standalone example so
+      the copied setup is complete.
+    </p>
     <CodeBlock code={basicUsageSnippet} language="tsx" label="Basic setup" />
     <p>
       The example includes a single rule with{' '}

--- a/example/src/v2/pages/documentation-page/pages/usage-documentation-page/constants/basic-usage-snippet.ts
+++ b/example/src/v2/pages/documentation-page/pages/usage-documentation-page/constants/basic-usage-snippet.ts
@@ -1,4 +1,5 @@
-export const basicUsageSnippet = `import React, { useState } from 'react';
+export const basicUsageSnippet = `import '@vojtechportes/react-query-builder/styles.css';
+import React, { useState } from 'react';
 import {
   Builder,
   type DenormalizedQuery,

--- a/example/src/v2/pages/documentation-page/pages/validation-documentation-page/constants/usage-limit-snippet.ts
+++ b/example/src/v2/pages/documentation-page/pages/validation-documentation-page/constants/usage-limit-snippet.ts
@@ -1,4 +1,5 @@
-export const usageLimitSnippet = `const fields: IBuilderFieldProps[] = [
+export const usageLimitSnippet = `import '@vojtechportes/react-query-builder/styles.css';
+const fields: IBuilderFieldProps[] = [
   {
     field: 'PRIMARY_EMAIL',
     label: 'Primary email',

--- a/example/src/v2/pages/documentation-page/pages/validation-documentation-page/constants/validation-snippet.ts
+++ b/example/src/v2/pages/documentation-page/pages/validation-documentation-page/constants/validation-snippet.ts
@@ -1,4 +1,5 @@
-export const validationSnippet = `const fields: IBuilderFieldProps[] = [
+export const validationSnippet = `import '@vojtechportes/react-query-builder/styles.css';
+const fields: IBuilderFieldProps[] = [
   {
     field: 'COMPANY_NAME',
     label: 'Company name',


### PR DESCRIPTION
- Added explicit stylesheet imports to v2 Builder, adapter, Monaco, and generated-source examples
- Documented token overrides, precedence, stylesheet order, stable hooks, and ThemeProvider migration
- Added discovery-based documentation coverage while preserving v1 and recipe content