### PR TITLE
feat: Added reactive dark mode for default components

### DIFF
--- a/.codex/TASKS.md
+++ b/.codex/TASKS.md
@@ -2605,3 +2605,62 @@ site/v1 usage.
 - Run `npm run build:v2 --workspace website`.
 - Run browser checks for the default and container-free Builder layouts.
 - Run `git diff --check` and the repository-required code-review agent, then resolve all findings.
+
+### T080 - Add reactive dark mode for default components
+
+**Status:** `[x]` Done
+
+**Goal:** Provide a typed, opt-in dark color-variable theme for built-in components that switches at runtime without remounting the Builder, while retaining a stable customizable Builder root and readable built-in SQL highlighting.
+
+**Scope:**
+
+- Rename `showOuterContainer` to `useDefaultContainerStyles`, defaulting to `true`.
+- Always render the Builder root `div` with `data-query-builder="root"`, forwarded `className`, merged `style`, and the optional color-scheme attribute. When `useDefaultContainerStyles` is `false`, retain the built-in typography/color baseline and omit only the visual container styles.
+- Add `colorScheme?: 'light' | 'dark'` to `IBuilderProps`. Leave it undefined by default to preserve existing inherited-variable behavior.
+- Add a separately importable `@vojtechportes/react-query-builder/dark-mode.variables.css` package export containing dark color-variable overrides for built-in components.
+- Generate explicit light and dark low-specificity selectors so sibling and nested Builders can use independent color schemes, including a light Builder inside a dark ancestor.
+- Keep `styles.css` as the required base stylesheet and keep dark mode opt-in.
+- Rename the canonical `--query-builder-color-white` surface token to `--query-builder-color-background` across built-in components, typed style overrides, generated variables, tests, and v2 documentation/API references.
+- Preserve the legacy TypeScript color theme API and map its `colors.white` value to the new background variable.
+- Replace hard-coded built-in SQL syntax-highlighting colors with existing query-builder palette variables and ensure light and dark palettes remain readable.
+- Remove visible seams between adjacent built-in group operator controls in dark mode.
+- Normalize the default action-button label to an 11px-equivalent rem size so root and nested group buttons rasterize consistently without changing their 32px control height.
+- Keep host-library adapter theme switching outside the package dark-mode stylesheet; adapters continue to use their own theme providers or theme APIs.
+- Forward the typed Builder color scheme to custom text editors and map it reactively to package-owned Monaco themes based on `vs` / `vs-dark`. Map Monaco SQL tokens to the same canonical palette roles as the built-in text editor and add scheme-aware protected-range colors. Keep consumer-defined Monaco themes, CSS-variable synchronization, and per-instance orchestration outside this task.
+- Update package build, export, package binding, packed-artifact, stylesheet-consumer, and release verification for the additional public CSS file.
+- Document importing, typed switching, precedence, root-container behavior, token migration, text mode, Monaco, and adapter boundaries in the v2 Documentation and API sections only.
+- Replace the v2 Demo `showOuterContainer` control with `useDefaultContainerStyles` and add a Dark mode checkbox directly below the Default components option in Customization. Enable and apply dark mode only for default components, update generated source, and preserve the selected preference when switching temporarily to an adapter.
+- Preserve v1 website content and behavior, existing query behavior, and unrelated worktree changes.
+
+**Acceptance criteria:**
+
+- The Builder always renders one root `div`; `className`, `style`, `data-query-builder="root"`, and `colorScheme` continue to work when default container styles are disabled.
+- `useDefaultContainerStyles` defaults to `true`; setting it to `false` retains the built-in typography/color baseline and removes only root padding, background, border, radius, and shadow.
+- Consumers can import `styles.css` and `dark-mode.variables.css`, then switch `colorScheme` between light and dark without remounting the Builder or resetting its state.
+- Explicit light and dark Builders can coexist as siblings or nested descendants without leaking their palettes into one another.
+- Omitting `colorScheme` preserves inherited application variables and existing theming behavior.
+- Consumer root classes, legacy ThemeProvider variables, and explicit `Builder.style` variables retain their documented precedence over scheme defaults.
+- Built-in controls, surfaces, overlays, focus states, validation states, drag-and-drop affordances, and built-in text mode have readable light and dark colors.
+- Root and nested default action buttons share the same 11px label metrics and 32px control height.
+- Built-in SQL highlighting uses query-builder palette variables instead of standalone color literals.
+- The packaged Monaco editor follows the Builder color scheme without remounting and maps SQL keywords, operators, delimiters, strings, numbers, functions, identifiers, foreground, and background to the same canonical light/dark palette roles as the built-in editor. An undefined scheme uses the package light theme. Monaco's global standalone theme means the latest mounted packaged editor, or the editor whose scheme changes most recently, wins across simultaneously mounted Monaco editors; consumer-defined and independent per-editor themes remain application-managed.
+- `--query-builder-color-background` is the canonical built-in surface token and is available through `IBuilderStyle`.
+- The package publishes and exports both public stylesheets with CSS side effects preserved.
+- The v2 Documentation and API sections describe the typed color scheme, required import, precedence, renamed container prop, token migration, text-mode colors, Monaco boundary, and adapter boundary.
+- The v2 Demo controls update the preview immediately and produce matching copy-ready source; the dark-mode checkbox is enabled only for default components.
+- V1 content and host-library adapter theming remain unchanged.
+
+**Verification:**
+
+- Run Prettier on every modified non-Markdown code and configuration file.
+- Run focused Builder root, generated-token, CSS contract, ThemeProvider mapping, built-in component, text-mode, package-export, packed-consumer, v2 Documentation/API, and v2 Demo tests.
+- Run `npm run test:css-infrastructure`.
+- Run `npm run test:packed-entries`.
+- Run `npm run verify:publish-artifact`.
+- Run `npm run package-bindings:verify --workspace website`.
+- Run `npm run typecheck:v2 --workspace website` and `npm run test:v2 --workspace website`.
+- Run `npm test`, `npm run lint`, `npm run build`, `npm run verify:architecture`, and `npm run build:v2 --workspace website`.
+- Run desktop and mobile browser checks for light/dark switching, scoped sibling and nested Builders, disabled default container styles, built-in text mode, validation/read-only states, and adapter checkbox behavior.
+- Check representative foreground/background combinations for accessible contrast in both modes.
+- Run `git diff --check`.
+- Run the repository-required code-review agent and resolve all findings.

--- a/package.json
+++ b/package.json
@@ -55,6 +55,7 @@
       "require": "./dist/index.cjs"
     },
     "./styles.css": "./dist/styles.css",
+    "./dark-mode.variables.css": "./dist/dark-mode.variables.css",
     "./parseQuery": {
       "types": "./dist/parseQuery.d.ts",
       "import": "./dist/parseQuery.mjs",
@@ -173,6 +174,7 @@
     "MIGRATION-2.0.md",
     "dist",
     "dist/styles.css",
+    "dist/dark-mode.variables.css",
     "!dist/**/*.map",
     "!dist/**/*.d.ts",
     "dist/index.d.ts",
@@ -201,7 +203,7 @@
   ],
   "scripts": {
     "styles:tokens": "node scripts/generate-style-tokens.mjs",
-    "build": "npm run styles:tokens && tsdown && node scripts/css-build/restore-css-module-class-names.util.mjs && node scripts/copy-dts.mjs",
+    "build": "npm run styles:tokens && tsdown && node scripts/css-build/restore-css-module-class-names.util.mjs && node scripts/generate-style-tokens.mjs --distribution-only && node scripts/copy-dts.mjs",
     "dev": "tsdown --watch",
     "test": "jest --runInBand",
     "test:update": "jest --updateSnapshot --runInBand",

--- a/scripts/css-build/verify-css-build.util.mjs
+++ b/scripts/css-build/verify-css-build.util.mjs
@@ -32,20 +32,38 @@ const verifyCssBuild = async () => {
   const cssFiles = distributionFiles.filter((fileName) =>
     fileName.endsWith('.css')
   );
-  const expectedStylesheet = path.join(distributionDirectory, 'styles.css');
+  const expectedStylesheets = [
+    path.join(distributionDirectory, 'dark-mode.variables.css'),
+    path.join(distributionDirectory, 'styles.css'),
+  ];
 
-  if (cssFiles.length !== 1 || cssFiles[0] !== expectedStylesheet) {
+  if (
+    cssFiles.length !== expectedStylesheets.length ||
+    cssFiles.some((fileName, index) => fileName !== expectedStylesheets[index])
+  ) {
     throw new Error(
-      `Expected exactly dist/styles.css, received: ${cssFiles
+      `Expected public stylesheets, received: ${cssFiles
         .map((fileName) => path.relative(rootDirectory, fileName))
         .join(', ')}`
     );
   }
 
+  const expectedStylesheet = path.join(distributionDirectory, 'styles.css');
+  const darkModeStylesheet = await readFile(
+    path.join(distributionDirectory, 'dark-mode.variables.css'),
+    'utf8'
+  );
   const stylesheet = await readFile(expectedStylesheet, 'utf8');
-
   if (!stylesheet.includes('@layer react-query-builder')) {
     throw new Error('dist/styles.css is missing the stable layer declaration');
+  }
+  if (
+    !darkModeStylesheet.includes(
+      ":where([data-query-builder-color-scheme='dark'])"
+    ) ||
+    !darkModeStylesheet.includes('--query-builder-color-background:')
+  ) {
+    throw new Error('dist/dark-mode.variables.css is missing dark tokens');
   }
 
   const javascriptFiles = distributionFiles.filter((fileName) =>
@@ -133,14 +151,18 @@ const verifyCssBuild = async () => {
         {
           key: 'option',
           fragments: [
-            'color: var(--query-builder-color-primary-contrast-text);',
-            'background: var(--query-builder-color-grey-500);',
-            'border: 1px solid var(--query-builder-color-grey-800);',
+            'color: light-dark(',
+            '--query-builder-color-grey-900',
+            'background: light-dark(',
+            '--query-builder-color-grey-400',
+            'border: 1px solid light-dark(',
+            '--query-builder-color-grey-500',
           ],
         },
         {
           key: 'selected',
           fragments: [
+            'color: var(--query-builder-color-primary-contrast-text);',
             'background: var(--query-builder-color-primary-default);',
           ],
         },
@@ -166,7 +188,7 @@ const verifyCssBuild = async () => {
         {
           key: 'group',
           fragments: [
-            'background: #f4f4f4;',
+            'background: var(--query-builder-color-grey-100);',
             'border: 1px solid var(--query-builder-color-grey-200);',
             'border-radius: var(--query-builder-radius-sm, 4px);',
           ],
@@ -237,14 +259,14 @@ const verifyCssBuild = async () => {
           key: 'outlined',
           fragments: [
             'color: var(--alert-primary);',
-            'background: color-mix(in srgb, var(--alert-primary) 5%, var(--query-builder-color-white) 95%);',
+            'background: color-mix(in srgb, var(--alert-primary) 5%, var(--query-builder-color-background) 95%);',
             'border-color: var(--alert-light);',
           ],
         },
         {
           key: 'filled',
           fragments: [
-            'color: var(--query-builder-color-white);',
+            'color: var(--query-builder-color-background);',
             'background: var(--alert-primary);',
             'border-color: var(--alert-primary);',
           ],
@@ -570,7 +592,7 @@ const verifyCssBuild = async () => {
           fragments: [
             'min-height: var(--query-builder-editor-min-height);',
             'border: 1px solid var(--query-builder-color-grey-300);',
-            'background: var(--query-builder-color-white);',
+            'background: var(--query-builder-color-background);',
           ],
         },
         {
@@ -740,8 +762,10 @@ const verifyCssBuild = async () => {
   const groupContainerMappings = cssModuleMappings.get('GroupContainer');
   const requiredGroupSelectors = [
     `.${groupOptionMappings.disabled}.${groupOptionMappings.selected}`,
+    `.${groupContainerMappings.left} > div:not(:last-child)`,
     `.${groupContainerMappings.left} > div:first-child`,
     `.${groupContainerMappings.left} > div + div`,
+    `.${groupContainerMappings.left} > div[data-selected="true"]`,
     `.${groupContainerMappings.left} > div:last-child`,
     `.${groupContainerMappings.header}.${groupContainerMappings.withLeftControls}:not(.${groupContainerMappings.withRightControls})`,
   ];
@@ -753,6 +777,19 @@ const verifyCssBuild = async () => {
   }
 
   const normalizedStylesheet = stylesheet.replace(/\s+/g, ' ');
+  const requiredGroupSeamBlocks = [
+    `.${groupContainerMappings.left} > div + div { border-left: 0; margin-left: -1px; }`,
+    `.${groupContainerMappings.left} > div[data-selected="true"] { z-index: 1; position: relative; }`,
+  ];
+
+  for (const block of requiredGroupSeamBlocks) {
+    if (!normalizedStylesheet.includes(block)) {
+      throw new Error(
+        `Group extracted stylesheet is missing seam declaration block: ${block}`
+      );
+    }
+  }
+
   const compactGroupBlock =
     `@media (width <= 900px) { ` +
     `.${groupContainerMappings.header} { ` +
@@ -872,7 +909,7 @@ const verifyCssBuild = async () => {
     '--query-builder-color-primary-light: #757de8;',
     '--query-builder-color-secondary-light: #ff7961;',
     '--query-builder-color-secondary-default: #f44336;',
-    '--query-builder-color-white: #fff;',
+    '--query-builder-color-background: #fff;',
     '--query-builder-color-grey-100: #f5f5f5;',
     '--query-builder-color-grey-200: #eee;',
     '--query-builder-color-grey-300: #e0e0e0;',
@@ -1009,7 +1046,7 @@ const verifyCssBuild = async () => {
   console.log(
     JSON.stringify(
       {
-        cssFiles: ['dist/styles.css'],
+        cssFiles: ['dist/dark-mode.variables.css', 'dist/styles.css'],
         alertColorMatrixContract: true,
         alertCssModuleClassesUnique: true,
         alertRulesExactlyOnce: true,

--- a/scripts/css-build/verify-public-stylesheet.util.mjs
+++ b/scripts/css-build/verify-public-stylesheet.util.mjs
@@ -6,16 +6,22 @@ const verifyPublicStylesheet = async () => {
   const rootDirectory = path.resolve(import.meta.dirname, '..', '..');
   const packageJsonPath = path.join(rootDirectory, 'package.json');
   const stylesheetPath = path.join(rootDirectory, 'dist', 'styles.css');
+  const darkModeStylesheetPath = path.join(
+    rootDirectory,
+    'dist',
+    'dark-mode.variables.css'
+  );
   const packageJson = JSON.parse(await readFile(packageJsonPath, 'utf8'));
   const stylesheet = await readFile(stylesheetPath, 'utf8');
+  const darkModeStylesheet = await readFile(darkModeStylesheetPath, 'utf8');
 
   if (
     packageJson.style !== './dist/styles.css' ||
-    packageJson.exports?.['./styles.css'] !== './dist/styles.css'
+    packageJson.exports?.['./styles.css'] !== './dist/styles.css' ||
+    packageJson.exports?.['./dark-mode.variables.css'] !==
+      './dist/dark-mode.variables.css'
   ) {
-    throw new Error(
-      'The public stylesheet metadata does not resolve dist/styles.css'
-    );
+    throw new Error('The public stylesheet metadata is invalid');
   }
 
   if (
@@ -27,7 +33,7 @@ const verifyPublicStylesheet = async () => {
   const requiredTokens = [
     '--query-builder-color-primary-default',
     '--query-builder-color-grey-300',
-    '--query-builder-color-white',
+    '--query-builder-color-background',
     '--query-builder-spacing-sm',
     '--query-builder-root-padding',
     '--query-builder-group-padding',
@@ -57,10 +63,32 @@ const verifyPublicStylesheet = async () => {
     throw new Error(`Missing public tokens: ${missingTokens.join(', ')}`);
   }
 
-  if (!stylesheet.includes(':where(:root)')) {
-    throw new Error(
-      'Public token defaults must remain inherited and low-specificity'
-    );
+  if (
+    !stylesheet.includes(':where(:root)') ||
+    !/:where\(\[data-query-builder-color-scheme=["']light["']\]\)/.test(
+      stylesheet
+    )
+  ) {
+    throw new Error('Light defaults and explicit light tokens are invalid');
+  }
+
+  if (
+    darkModeStylesheet.includes(':where(:root)') ||
+    !/:where\(\[data-query-builder-color-scheme=["']dark["']\]\)/.test(
+      darkModeStylesheet
+    ) ||
+    !requiredTokens
+      .filter((token) => token.startsWith('--query-builder-color-'))
+      .every((token) => darkModeStylesheet.includes(`${token}:`))
+  ) {
+    throw new Error('Dark mode tokens are invalid or not scoped');
+  }
+
+  if (
+    stylesheet.includes('--query-builder-color-white') ||
+    darkModeStylesheet.includes('--query-builder-color-white')
+  ) {
+    throw new Error('The removed white token is still published');
   }
 
   const npmExecutable =
@@ -83,28 +111,32 @@ const verifyPublicStylesheet = async () => {
     }
   );
   const packResult = JSON.parse(packOutput)[0];
-  const packedStylesheets = packResult.files.filter(({ path: filePath }) =>
-    filePath.endsWith('.css')
-  );
+  const packedStylesheets = packResult.files
+    .filter(({ path: filePath }) => filePath.endsWith('.css'))
+    .map(({ path: filePath }) => filePath)
+    .sort();
+  const expectedPackedStylesheets = [
+    'dist/dark-mode.variables.css',
+    'dist/styles.css',
+  ];
 
   if (
-    packedStylesheets.length !== 1 ||
-    packedStylesheets[0].path !== 'dist/styles.css'
+    JSON.stringify(packedStylesheets) !==
+    JSON.stringify(expectedPackedStylesheets)
   ) {
     throw new Error(
-      `Expected one packed stylesheet, received: ${packedStylesheets
-        .map(({ path: filePath }) => filePath)
-        .join(', ')}`
+      `Expected public stylesheets, received: ${packedStylesheets.join(', ')}`
     );
   }
 
   console.log(
     JSON.stringify(
       {
-        publicStylesheetExport: packageJson.exports['./styles.css'],
-        packedStylesheets: packedStylesheets.map(
-          ({ path: filePath }) => filePath
-        ),
+        publicStylesheetExports: {
+          darkMode: packageJson.exports['./dark-mode.variables.css'],
+          styles: packageJson.exports['./styles.css'],
+        },
+        packedStylesheets,
         publicTokenCount: requiredTokens.length,
         cssSideEffects: packageJson.sideEffects,
       },

--- a/scripts/css-build/verify-stylesheet-consumers.util.mjs
+++ b/scripts/css-build/verify-stylesheet-consumers.util.mjs
@@ -80,8 +80,25 @@ const verifyStylesheetConsumers = async () => {
       { stdio: 'pipe' }
     );
 
-    for (const includeStyles of [true, false]) {
-      const consumerName = includeStyles ? 'with-css' : 'without-css';
+    const consumerScenarios = [
+      {
+        consumerName: 'with-css',
+        stylesheetImport:
+          "import '@vojtechportes/react-query-builder/styles.css';\n",
+      },
+      {
+        consumerName: 'with-dark-css',
+        stylesheetImport:
+          "import '@vojtechportes/react-query-builder/styles.css';\nimport '@vojtechportes/react-query-builder/dark-mode.variables.css';\n",
+      },
+      {
+        consumerName: 'without-css',
+        stylesheetImport: '',
+      },
+    ];
+
+    for (const { consumerName, stylesheetImport } of consumerScenarios) {
+      const includeStyles = stylesheetImport.length > 0;
       const clientOutputDirectory = path.join(
         consumerDirectory,
         `dist-client-${consumerName}`
@@ -90,9 +107,6 @@ const verifyStylesheetConsumers = async () => {
         consumerDirectory,
         `dist-ssr-${consumerName}`
       );
-      const stylesheetImport = includeStyles
-        ? "import '@vojtechportes/react-query-builder/styles.css';\n"
-        : '';
 
       await mkdir(consumerDirectory, { recursive: true });
       await writeFile(

--- a/scripts/generate-style-tokens.mjs
+++ b/scripts/generate-style-tokens.mjs
@@ -1,35 +1,18 @@
-import { readFileSync, writeFileSync } from 'node:fs';
+import { mkdirSync, readFileSync, writeFileSync } from 'node:fs';
 import { join } from 'node:path';
 import { cwd } from 'node:process';
 import ts from 'typescript';
 
 const rootDir = cwd();
-const colorsPath = join(
-  rootDir,
-  'src',
-  'builder',
-  'theme',
-  'styles',
-  'colors.ts'
-);
-const tokensPath = join(
-  rootDir,
-  'src',
-  'builder',
-  'theme',
-  'styles',
-  'tokens.css'
-);
-const sourceText = readFileSync(colorsPath, 'utf8');
-const sourceFile = ts.createSourceFile(
-  colorsPath,
-  sourceText,
-  ts.ScriptTarget.Latest,
-  true,
-  ts.ScriptKind.TS
-);
+const stylesDirectory = join(rootDir, 'src', 'builder', 'theme', 'styles');
+const colorsPath = join(stylesDirectory, 'colors.ts');
+const darkColorsPath = join(stylesDirectory, 'dark-colors.ts');
+const tokensPath = join(stylesDirectory, 'tokens.css');
+const darkTokensPath = join(stylesDirectory, 'dark-mode.variables.css');
+const distributionPath = join(rootDir, 'dist', 'dark-mode.variables.css');
+const distributionOnly = process.argv.includes('--distribution-only');
 
-const readObjectLiteral = (objectLiteral) => {
+const readObjectLiteral = (objectLiteral, sourceFile) => {
   const result = {};
 
   for (const property of objectLiteral.properties) {
@@ -41,7 +24,7 @@ const readObjectLiteral = (objectLiteral) => {
     const initializer = property.initializer;
 
     if (ts.isObjectLiteralExpression(initializer)) {
-      result[key] = readObjectLiteral(initializer);
+      result[key] = readObjectLiteral(initializer, sourceFile);
       continue;
     }
 
@@ -53,7 +36,16 @@ const readObjectLiteral = (objectLiteral) => {
   return result;
 };
 
-const findColorsObject = () => {
+const readExportedColors = (filePath, exportName) => {
+  const sourceText = readFileSync(filePath, 'utf8');
+  const sourceFile = ts.createSourceFile(
+    filePath,
+    sourceText,
+    ts.ScriptTarget.Latest,
+    true,
+    ts.ScriptKind.TS
+  );
+
   for (const statement of sourceFile.statements) {
     if (!ts.isVariableStatement(statement)) {
       continue;
@@ -62,20 +54,19 @@ const findColorsObject = () => {
     for (const declaration of statement.declarationList.declarations) {
       if (
         ts.isIdentifier(declaration.name) &&
-        declaration.name.text === 'colors' &&
+        declaration.name.text === exportName &&
         declaration.initializer &&
         ts.isObjectLiteralExpression(declaration.initializer)
       ) {
-        return readObjectLiteral(declaration.initializer);
+        return readObjectLiteral(declaration.initializer, sourceFile);
       }
     }
   }
 
-  throw new Error('Unable to find exported colors object.');
+  throw new Error(`Unable to find exported ${exportName} object.`);
 };
 
-const colors = findColorsObject();
-const colorVariables = [
+const createColorVariables = (colors) => [
   ['--query-builder-color-primary-default', colors.primary.default],
   ['--query-builder-color-primary-light', colors.primary.light],
   ['--query-builder-color-primary-dark', colors.primary.dark],
@@ -104,7 +95,7 @@ const colorVariables = [
   ['--query-builder-color-warning-light', colors.warning.light],
   ['--query-builder-color-error-primary', colors.error.primary],
   ['--query-builder-color-error-light', colors.error.light],
-  ['--query-builder-color-white', colors.white],
+  ['--query-builder-color-background', colors.white],
 ];
 
 const staticVariables = [
@@ -144,12 +135,38 @@ const staticVariables = [
   ['--query-builder-popover-z-index', '5'],
 ];
 
-const formatVariable = ([name, value]) => `    ${name}: ${value};`;
-const content = `@layer react-query-builder {
+const formatVariables = (variables) =>
+  variables.map(([name, value]) => `    ${name}: ${value};`).join('\n');
+
+const lightColorVariables = createColorVariables(
+  readExportedColors(colorsPath, 'colors')
+);
+const darkColorVariables = createColorVariables(
+  readExportedColors(darkColorsPath, 'darkColors')
+);
+const lightContent = `@layer react-query-builder {
   :where(:root) {
-${[...colorVariables, ...staticVariables].map(formatVariable).join('\n')}
+${formatVariables([...lightColorVariables, ...staticVariables])}
+  }
+
+  :where([data-query-builder-color-scheme='light']) {
+    color-scheme: light;
+${formatVariables(lightColorVariables)}
+  }
+}
+`;
+const darkContent = `@layer react-query-builder {
+  :where([data-query-builder-color-scheme='dark']) {
+    color-scheme: dark;
+${formatVariables(darkColorVariables)}
   }
 }
 `;
 
-writeFileSync(tokensPath, content);
+if (!distributionOnly) {
+  writeFileSync(tokensPath, lightContent);
+  writeFileSync(darkTokensPath, darkContent);
+} else {
+  mkdirSync(join(rootDir, 'dist'), { recursive: true });
+  writeFileSync(distributionPath, darkContent);
+}

--- a/scripts/release-verification/verify-publish-artifact.util.mjs
+++ b/scripts/release-verification/verify-publish-artifact.util.mjs
@@ -72,6 +72,8 @@ const verifyPublishArtifact = async () => {
     }
     if (
       manifest.exports?.['./styles.css'] !== './dist/styles.css' ||
+      manifest.exports?.['./dark-mode.variables.css'] !==
+        './dist/dark-mode.variables.css' ||
       manifest.style !== './dist/styles.css'
     ) {
       throw new Error('Packed stylesheet exports are missing or invalid');

--- a/scripts/verify-packed-entry-consumers.util.mjs
+++ b/scripts/verify-packed-entry-consumers.util.mjs
@@ -287,6 +287,7 @@ const verifyPackedEntryConsumers = async () => {
     for (const exportSubpath of [
       '.',
       './styles.css',
+      './dark-mode.variables.css',
       ...entries
         .map(({ subpath }) => `.${subpath}`)
         .filter((value) => value !== '.'),
@@ -696,7 +697,7 @@ console.log(markup);
 
     await writeFile(
       styledEntry,
-      `import '${packageName}/styles.css';\n${uiImports}\n`
+      `import '${packageName}/styles.css';\nimport '${packageName}/dark-mode.variables.css';\n${uiImports}\n`
     );
     await build({
       root: currentConsumerDirectory,
@@ -725,13 +726,16 @@ console.log(markup);
       const source = await readFile(path.join(styledOutput, cssAsset), 'utf8');
 
       if (source.includes('@layer react-query-builder')) {
-        const tokenOccurrences =
+        const lightTokenOccurrences =
           source.match(/--query-builder-color-primary-default:\s*#3f51b5/g)
             ?.length || 0;
+        const darkTokenOccurrences =
+          source.match(/--query-builder-color-primary-default:\s*#8c9eff/g)
+            ?.length || 0;
 
-        if (tokenOccurrences !== 1) {
+        if (lightTokenOccurrences !== 2 || darkTokenOccurrences !== 1) {
           throw new Error(
-            `Expected package stylesheet content once, received ${tokenOccurrences}`
+            `Expected default, explicit light, and dark tokens once each; received ${lightTokenOccurrences} light and ${darkTokenOccurrences} dark occurrences`
           );
         }
 

--- a/src/builder/builder-theme-css-variables.test.tsx
+++ b/src/builder/builder-theme-css-variables.test.tsx
@@ -138,7 +138,9 @@ describe('#components/Builder theme CSS variables', () => {
       '[data-query-builder="root"]'
     ) as HTMLElement;
 
-    expect(builderRoot).toHaveClass(builderStyles.builder, 'consumer-builder');
+    expect(builderRoot.className.split(' ')).toEqual(
+      expect.arrayContaining([builderStyles.builder, 'consumer-builder'])
+    );
     expect(builderRoot.style.color).toBe('rgb(1, 2, 3)');
     expect(
       builderRoot.style.getPropertyValue('--query-builder-color-grey-300')

--- a/src/builder/builder.test.tsx
+++ b/src/builder/builder.test.tsx
@@ -133,15 +133,17 @@ const getAllByDataTest = (
 const CustomTextModeEditor = ({
   value,
   errorMessage,
+  colorScheme,
   protectedRanges = [],
   onChange,
 }: {
   value: string;
   errorMessage: string | null;
+  colorScheme?: 'light' | 'dark';
   protectedRanges?: Array<{ start: number; end: number }>;
   onChange: (value: string) => void;
 }) => (
-  <div data-test="CustomTextModeEditor">
+  <div data-test="CustomTextModeEditor" data-color-scheme={colorScheme}>
     <textarea
       data-test="CustomTextModeEditorInput"
       value={value}
@@ -165,7 +167,7 @@ describe('#components/Builder', () => {
     expect(onChange).not.toHaveBeenCalled();
   });
 
-  it('Renders the outer container by default and can omit it', () => {
+  it('always renders the root and can omit only its default container styles', () => {
     const onChange = jest.fn();
     const props: IBuilderProps = {
       fields,
@@ -174,14 +176,35 @@ describe('#components/Builder', () => {
       onChange,
     };
     const { container, rerender } = render(<Builder {...props} />);
+    const defaultRoot = container.querySelector('[data-query-builder="root"]');
 
-    expect(
-      container.querySelector('[data-query-builder="root"]')
-    ).toBeInTheDocument();
+    expect(defaultRoot).toBeInTheDocument();
+    expect(defaultRoot).toHaveClass('builder', 'container');
 
-    rerender(<Builder {...props} showOuterContainer={false} />);
+    rerender(
+      <Builder
+        {...props}
+        className="consumer-root"
+        colorScheme="dark"
+        style={{ '--query-builder-color-background': '#123456' }}
+        useDefaultContainerStyles={false}
+      />
+    );
 
-    expect(container.querySelector('[data-query-builder="root"]')).toBeNull();
+    const containerFreeRoot = container.querySelector(
+      '[data-query-builder="root"]'
+    );
+
+    expect(containerFreeRoot).toBeInTheDocument();
+    expect(containerFreeRoot).toHaveClass('builder', 'consumer-root');
+    expect(containerFreeRoot).not.toHaveClass('container');
+    expect(containerFreeRoot).toHaveAttribute(
+      'data-query-builder-color-scheme',
+      'dark'
+    );
+    expect(containerFreeRoot).toHaveStyle({
+      '--query-builder-color-background': '#123456',
+    });
     expect(getByDataTest(container, 'AddRootRule')).toBeInTheDocument();
 
     fireEvent.click(getByDataTest(container, 'AddRootRule'));
@@ -547,6 +570,39 @@ describe('#components/Builder', () => {
     ).toBeGreaterThan(0);
   });
 
+  it('forwards colorScheme to a custom TextModeEditor without remounting it', () => {
+    const props: IBuilderProps = {
+      fields,
+      data: [
+        {
+          type: 'GROUP',
+          value: 'AND',
+          isNegated: false,
+          children: [
+            { field: 'MOCK_FIELD', value: 'alpha', operator: 'EQUAL' },
+          ],
+        },
+      ],
+      textMode: true,
+      defaultMode: 'text',
+      components: {
+        ...defaultComponents,
+        TextModeEditor: CustomTextModeEditor,
+      },
+      onChange: jest.fn(),
+    };
+    const { container, rerender } = render(
+      <Builder {...props} colorScheme="dark" />
+    );
+    const editor = getByDataTest(container, 'CustomTextModeEditor');
+
+    expect(editor).toHaveAttribute('data-color-scheme', 'dark');
+
+    rerender(<Builder {...props} colorScheme="light" />);
+
+    expect(getByDataTest(container, 'CustomTextModeEditor')).toBe(editor);
+    expect(editor).toHaveAttribute('data-color-scheme', 'light');
+  });
   it('Protects the full text editor range when the Builder is read-only', () => {
     const { container } = render(
       <Builder

--- a/src/builder/builder.tsx
+++ b/src/builder/builder.tsx
@@ -100,7 +100,8 @@ export const Builder = forwardRef<IBuilderRef, IBuilderProps>(
       fields,
       className,
       style,
-      showOuterContainer = true,
+      useDefaultContainerStyles = true,
+      colorScheme,
       components = defaultComponents,
       strings = defaultStrings,
       readOnly = false,
@@ -930,6 +931,7 @@ export const Builder = forwardRef<IBuilderRef, IBuilderProps>(
                   strings.textMode?.lockedRangesHover || null
                 }
                 errorMessage={textErrorMessage}
+                colorScheme={colorScheme}
                 readOnly={readOnly}
                 allowProtectedRangeDeletion={!readOnlyProtectsDelete}
                 onChange={handleTextChange}
@@ -938,16 +940,13 @@ export const Builder = forwardRef<IBuilderRef, IBuilderProps>(
           })()
         : builderContent;
 
-    const BuilderOuterComponent = showOuterContainer
-      ? StyledBuilder
-      : React.Fragment;
-    const builderOuterProps = showOuterContainer
-      ? {
-          className,
-          'data-query-builder': 'root',
-          style: rootStyle,
-        }
-      : {};
+    const builderOuterProps = {
+      className,
+      'data-query-builder': 'root',
+      'data-query-builder-color-scheme': colorScheme,
+      style: rootStyle,
+      useDefaultStyles: useDefaultContainerStyles,
+    };
     return (
       <BuilderContextProvider
         fields={fields}
@@ -979,7 +978,7 @@ export const Builder = forwardRef<IBuilderRef, IBuilderProps>(
           redo,
         }}
       >
-        <BuilderOuterComponent {...builderOuterProps}>
+        <StyledBuilder {...builderOuterProps}>
           {textModeBlockedByLocks && strings.textMode?.locksUnsupported ? (
             <TextModeBlockedAlertContainer>
               <AlertComponent
@@ -1029,7 +1028,7 @@ export const Builder = forwardRef<IBuilderRef, IBuilderProps>(
           ) : (
             content
           )}
-        </BuilderOuterComponent>
+        </StyledBuilder>
       </BuilderContextProvider>
     );
   }

--- a/src/builder/components/alert/alert.module.css
+++ b/src/builder/components/alert/alert.module.css
@@ -36,13 +36,13 @@
     background: color-mix(
       in srgb,
       var(--alert-primary) 5%,
-      var(--query-builder-color-white) 95%
+      var(--query-builder-color-background) 95%
     );
     border-color: var(--alert-light);
   }
 
   .filled {
-    color: var(--query-builder-color-white);
+    color: var(--query-builder-color-background);
     background: var(--alert-primary);
     border-color: var(--alert-primary);
   }

--- a/src/builder/components/button/button.module.css
+++ b/src/builder/components/button/button.module.css
@@ -5,9 +5,10 @@
     justify-content: center;
     padding: 0.5rem 1.2rem;
     color: var(--query-builder-color-primary-contrast-text);
-    font-size: 0.7rem;
+    font-size: 0.6875rem;
+    height: 2rem;
     min-height: 2rem;
-    line-height: 1;
+    line-height: 1rem;
     white-space: nowrap;
     text-transform: uppercase;
     background-color: var(--query-builder-color-primary-default);

--- a/src/builder/components/button/button.test.tsx
+++ b/src/builder/components/button/button.test.tsx
@@ -1,3 +1,5 @@
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
 import React from 'react';
 import '@testing-library/jest-dom';
 import { fireEvent, render, screen } from '@testing-library/react';
@@ -70,6 +72,15 @@ describe('#components/Button', () => {
     expect(button.getAttributeNames()).not.toEqual(
       expect.arrayContaining(['$theme', '$disabled'])
     );
+  });
+
+  it('keeps the default action label on an integer-sized line box', () => {
+    const css = readFileSync(join(__dirname, 'button.module.css'), 'utf8');
+
+    expect(css).toContain('font-size: 0.6875rem');
+    expect(css).toContain('line-height: 1rem');
+    expect(css).toContain('height: 2rem');
+    expect(css).toContain('min-height: 2rem');
   });
 
   it('exposes the CSS Module class contract', () => {

--- a/src/builder/components/clone-button/clone-button.module.css
+++ b/src/builder/components/clone-button/clone-button.module.css
@@ -7,7 +7,7 @@
     min-height: 2rem;
     padding: 0 0.625rem;
     color: var(--query-builder-color-grey-600);
-    background-color: var(--query-builder-color-white);
+    background-color: var(--query-builder-color-background);
     border: 1px solid var(--query-builder-color-grey-300);
     border-radius: var(--query-builder-radius-sm, 4px);
     outline: none;
@@ -31,7 +31,7 @@
   .disabled,
   .disabled:hover {
     color: var(--query-builder-color-grey-400);
-    background-color: var(--query-builder-color-white);
+    background-color: var(--query-builder-color-background);
     border-color: var(--query-builder-color-grey-200);
     cursor: not-allowed;
     opacity: 1;

--- a/src/builder/components/form-controls/popover/popover.module.css
+++ b/src/builder/components/form-controls/popover/popover.module.css
@@ -11,7 +11,7 @@
     overflow-y: auto;
     border: 1px solid var(--query-builder-color-grey-300);
     border-radius: 6px;
-    background: var(--query-builder-color-white);
+    background: var(--query-builder-color-background);
     box-shadow: 0 10px 25px rgba(0, 0, 0, 0.12);
   }
 }

--- a/src/builder/components/form-controls/switch/switch.module.css
+++ b/src/builder/components/form-controls/switch/switch.module.css
@@ -44,7 +44,7 @@
     box-sizing: border-box;
     width: 1.2rem;
     height: 1.2rem;
-    background: var(--query-builder-color-white);
+    background: var(--query-builder-color-background);
     border: 1px solid var(--query-builder-color-grey-500);
     border-radius: 50%;
     box-shadow: 0 1px 3px rgba(0, 0, 0, 0.25);

--- a/src/builder/components/group/components/group-container/group-container.module.css
+++ b/src/builder/components/group/components/group-container/group-container.module.css
@@ -3,7 +3,7 @@
     display: grid;
     grid-template-columns: 1fr;
     margin-top: 0.5rem;
-    background: #f4f4f4;
+    background: var(--query-builder-color-grey-100);
     border: 1px solid var(--query-builder-color-grey-200);
     border-radius: var(--query-builder-radius-sm, 4px);
     box-shadow: var(
@@ -46,14 +46,23 @@
     border-radius: 0;
   }
 
-  .left > div:first-child {
+  .left > div:not(:last-child) {
     border-right: 0;
+  }
+
+  .left > div:first-child {
     border-top-left-radius: 3px;
     border-bottom-left-radius: 3px;
   }
 
   .left > div + div {
+    margin-left: -1px;
     border-left: 0;
+  }
+
+  .left > div[data-selected='true'] {
+    position: relative;
+    z-index: 1;
   }
 
   .left > div:last-child {

--- a/src/builder/components/group/components/option/option.module.css
+++ b/src/builder/components/group/components/option/option.module.css
@@ -2,16 +2,27 @@
   .option {
     min-height: 2rem;
     padding: 0.5rem 0.6rem;
-    color: var(--query-builder-color-primary-contrast-text);
+    color: light-dark(
+      var(--query-builder-color-primary-contrast-text),
+      var(--query-builder-color-grey-900)
+    );
     font-size: 0.7rem;
     font-weight: bold;
     text-transform: uppercase;
-    background: var(--query-builder-color-grey-500);
-    border: 1px solid var(--query-builder-color-grey-800);
+    background: light-dark(
+      var(--query-builder-color-grey-500),
+      var(--query-builder-color-grey-400)
+    );
+    border: 1px solid
+      light-dark(
+        var(--query-builder-color-grey-800),
+        var(--query-builder-color-grey-500)
+      );
     cursor: pointer;
   }
 
   .selected {
+    color: var(--query-builder-color-primary-contrast-text);
     background: var(--query-builder-color-primary-default);
   }
 

--- a/src/builder/components/group/group.test.tsx
+++ b/src/builder/components/group/group.test.tsx
@@ -579,13 +579,25 @@ describe('#components/Group', () => {
     expect(groupCss).toContain(
       'padding: var(--query-builder-group-padding, 0.7rem)'
     );
+    expect(groupCss).toContain('.left > div:not(:last-child)');
+    expect(groupCss).toContain('border-right: 0');
     expect(groupCss).toContain('.left > div:first-child');
     expect(groupCss).toContain('.left > div + div');
+    expect(groupCss).toContain('margin-left: -1px');
+    expect(groupCss).toContain(".left > div[data-selected='true']");
+    expect(groupCss).toContain('z-index: 1');
     expect(groupCss).toContain('.left > div:last-child');
     expect(groupCss).toContain('@media (max-width: 900px)');
     expect(groupCss).toContain(
       'grid-template-columns: repeat(3, minmax(0, max-content))'
     );
+
+    expect(optionCss).toContain('color: light-dark(');
+    expect(optionCss).toContain('var(--query-builder-color-grey-900)');
+    expect(optionCss).toContain('background: light-dark(');
+    expect(optionCss).toContain('var(--query-builder-color-grey-400)');
+    expect(optionCss).toContain('border: 1px solid');
+    expect(optionCss).toContain('var(--query-builder-color-grey-500)');
     expect(optionCss).toContain(
       'color: var(--query-builder-color-primary-contrast-text)'
     );

--- a/src/builder/components/lock-toggle/lock-toggle.module.css
+++ b/src/builder/components/lock-toggle/lock-toggle.module.css
@@ -6,7 +6,7 @@
     min-width: 2.5rem;
     min-height: 2rem;
     padding: 0 0.625rem;
-    background-color: var(--query-builder-color-white);
+    background-color: var(--query-builder-color-background);
     border: 1px solid;
     border-radius: var(--query-builder-radius-sm, 4px);
     outline: none;
@@ -57,7 +57,7 @@
   .disabled,
   .disabled:hover {
     color: var(--query-builder-color-grey-400);
-    background-color: var(--query-builder-color-white);
+    background-color: var(--query-builder-color-background);
     border-color: var(--query-builder-color-grey-200);
     cursor: not-allowed;
     opacity: 1;

--- a/src/builder/components/outlined-button/outlined-button.module.css
+++ b/src/builder/components/outlined-button/outlined-button.module.css
@@ -4,7 +4,7 @@
     color: var(--query-builder-color-grey-700);
     font-size: 0.75rem;
     text-transform: none;
-    background-color: var(--query-builder-color-white);
+    background-color: var(--query-builder-color-background);
     border: 1px solid var(--query-builder-color-grey-300);
   }
 

--- a/src/builder/components/popover-item/popover-item.module.css
+++ b/src/builder/components/popover-item/popover-item.module.css
@@ -4,7 +4,7 @@
     padding: 0.65rem 0.85rem;
     color: var(--query-builder-color-grey-700);
     text-align: left;
-    background: var(--query-builder-color-white);
+    background: var(--query-builder-color-background);
     border: 0;
     border-bottom: 1px solid var(--query-builder-color-grey-100);
     cursor: pointer;

--- a/src/builder/components/popover/popover.module.css
+++ b/src/builder/components/popover/popover.module.css
@@ -10,7 +10,7 @@
     left: 0;
     z-index: var(--query-builder-popover-z-index, 5);
     min-width: 180px;
-    background: var(--query-builder-color-white);
+    background: var(--query-builder-color-background);
     border: 1px solid var(--query-builder-color-grey-500);
     box-shadow: var(
       --query-builder-shadow-popover,

--- a/src/builder/components/popover/popover.test.tsx
+++ b/src/builder/components/popover/popover.test.tsx
@@ -170,7 +170,7 @@ describe('#components/Popover', () => {
     );
 
     expect(markup).toContain('data-test="PopoverTrigger"');
-    expect(markup).not.toContain('--query-builder-color-white');
+    expect(markup).not.toContain('--query-builder-color-background');
     expect(markup).not.toContain('With Modifiers');
   });
 

--- a/src/builder/components/rule-controls/select-multi/components/option/option.module.css
+++ b/src/builder/components/rule-controls/select-multi/components/option/option.module.css
@@ -7,7 +7,7 @@
     width: 100%;
     padding: 0.55rem 0.75rem;
     border: 0;
-    background: var(--query-builder-color-white);
+    background: var(--query-builder-color-background);
     color: var(--query-builder-color-grey-900);
     text-align: left;
     cursor: pointer;
@@ -33,7 +33,7 @@
 
   .disabled:hover,
   .disabled:focus-visible {
-    background: var(--query-builder-color-white);
+    background: var(--query-builder-color-background);
   }
 
   .selected {

--- a/src/builder/components/rule-controls/select-multi/components/tag/tag.module.css
+++ b/src/builder/components/rule-controls/select-multi/components/tag/tag.module.css
@@ -8,7 +8,7 @@
     padding: 0.2rem 0.55rem;
     border: 1px solid var(--query-builder-color-grey-400);
     border-radius: 999px;
-    background: var(--query-builder-color-white);
+    background: var(--query-builder-color-background);
     color: var(--query-builder-color-grey-900);
     font-size: 0.8rem;
   }

--- a/src/builder/components/rule/components/rule-container/rule-container.module.css
+++ b/src/builder/components/rule/components/rule-container/rule-container.module.css
@@ -3,7 +3,7 @@
     display: grid;
     grid-template-columns: 1fr;
     margin-top: 0.5rem;
-    background-color: var(--query-builder-color-white);
+    background-color: var(--query-builder-color-background);
     border: 1px solid var(--query-builder-color-grey-300);
     border-radius: var(--query-builder-radius-sm, 4px);
   }

--- a/src/builder/components/rule/rule.test.tsx
+++ b/src/builder/components/rule/rule.test.tsx
@@ -569,7 +569,7 @@ describe('#components/Rule CSS Module presentation', () => {
     );
 
     expect(containerCss).toContain(
-      'background-color: var(--query-builder-color-white)'
+      'background-color: var(--query-builder-color-background)'
     );
     expect(containerCss).toContain(
       'border: 1px solid var(--query-builder-color-grey-300)'

--- a/src/builder/components/styled-builder/styled-builder.module.css
+++ b/src/builder/components/styled-builder/styled-builder.module.css
@@ -1,11 +1,14 @@
 @layer react-query-builder {
   .builder {
-    padding: var(--query-builder-root-padding, 1rem);
     color: var(--query-builder-color-grey-800);
     font-family: var(--query-builder-font-family, Arial, sans-serif);
     font-size: var(--query-builder-font-size, 16px);
     line-height: var(--query-builder-line-height, normal);
-    background: var(--query-builder-color-white);
+  }
+
+  .container {
+    padding: var(--query-builder-root-padding, 1rem);
+    background: var(--query-builder-color-background);
     border: 1px solid var(--query-builder-color-grey-100);
     border-radius: var(--query-builder-root-radius, 0);
     box-shadow: var(--query-builder-shadow-root, none);

--- a/src/builder/components/styled-builder/styled-builder.test.tsx
+++ b/src/builder/components/styled-builder/styled-builder.test.tsx
@@ -24,7 +24,11 @@ describe('#components/StyledBuilder', () => {
     );
     const root = getByTestId('builder-root');
 
-    expect(root).toHaveClass(styles.builder, 'consumer-builder');
+    expect(root).toHaveClass(
+      styles.builder,
+      styles.container,
+      'consumer-builder'
+    );
     expect(root).toHaveAttribute('data-query-builder', 'root');
     expect(root).toHaveAttribute('aria-label', 'Query builder');
     expect(root).toHaveStyle({ color: 'rgb(1, 2, 3)' });
@@ -32,12 +36,27 @@ describe('#components/StyledBuilder', () => {
     expect(ref.current).toBe(root);
   });
 
+  it('keeps baseline styles and omits only the container class when default styles are disabled', () => {
+    const { getByTestId } = render(
+      <StyledBuilder
+        className="consumer-builder"
+        data-testid="builder-root"
+        useDefaultStyles={false}
+      />
+    );
+
+    expect(getByTestId('builder-root')).toHaveClass(
+      styles.builder,
+      'consumer-builder'
+    );
+    expect(getByTestId('builder-root')).not.toHaveClass(styles.container);
+  });
   it('renders on the server without styled-components attributes', () => {
     const markup = renderToString(
       <StyledBuilder data-query-builder="root">Content</StyledBuilder>
     );
 
-    expect(markup).toContain(`class="${styles.builder}"`);
+    expect(markup).toContain(`class="${styles.builder} ${styles.container}"`);
     expect(markup).toContain('data-query-builder="root"');
     expect(markup).not.toContain('data-styled');
     expect(markup).not.toContain('$theme');
@@ -45,6 +64,7 @@ describe('#components/StyledBuilder', () => {
 
   it('exposes its CSS Module class', () => {
     expect(styles.builder).toBe('builder');
+    expect(styles.container).toBe('container');
   });
 
   it('defines the root token fallbacks and shell presentation', () => {
@@ -53,16 +73,41 @@ describe('#components/StyledBuilder', () => {
       'utf8'
     );
 
-    expect(css).toContain('padding: var(--query-builder-root-padding, 1rem)');
-    expect(css).toContain('color: var(--query-builder-color-grey-800)');
-    expect(css).toContain(
+    const builderRule = css.match(/\.builder\s*\{(?<declarations>[^}]*)\}/)
+      ?.groups?.declarations;
+    const containerRule = css.match(/\.container\s*\{(?<declarations>[^}]*)\}/)
+      ?.groups?.declarations;
+
+    expect(builderRule).toContain('color: var(--query-builder-color-grey-800)');
+    expect(builderRule).toContain(
       'font-family: var(--query-builder-font-family, Arial, sans-serif)'
     );
-    expect(css).toContain('background: var(--query-builder-color-white)');
-    expect(css).toContain(
+    expect(builderRule).toContain(
+      'font-size: var(--query-builder-font-size, 16px)'
+    );
+    expect(builderRule).toContain(
+      'line-height: var(--query-builder-line-height, normal)'
+    );
+    expect(builderRule).not.toContain('padding:');
+    expect(builderRule).not.toContain('background:');
+    expect(builderRule).not.toContain('border:');
+    expect(builderRule).not.toContain('border-radius:');
+    expect(builderRule).not.toContain('box-shadow:');
+
+    expect(containerRule).toContain(
+      'padding: var(--query-builder-root-padding, 1rem)'
+    );
+    expect(containerRule).toContain(
+      'background: var(--query-builder-color-background)'
+    );
+    expect(containerRule).toContain(
       'border: 1px solid var(--query-builder-color-grey-100)'
     );
-    expect(css).toContain('border-radius: var(--query-builder-root-radius, 0)');
-    expect(css).toContain('box-shadow: var(--query-builder-shadow-root, none)');
+    expect(containerRule).toContain(
+      'border-radius: var(--query-builder-root-radius, 0)'
+    );
+    expect(containerRule).toContain(
+      'box-shadow: var(--query-builder-shadow-root, none)'
+    );
   });
 });

--- a/src/builder/components/styled-builder/styled-builder.tsx
+++ b/src/builder/components/styled-builder/styled-builder.tsx
@@ -2,11 +2,22 @@ import clsx from 'clsx';
 import React, { ComponentPropsWithoutRef, forwardRef } from 'react';
 import styles from './styled-builder.module.css';
 
-export const StyledBuilder = forwardRef<
-  HTMLDivElement,
-  ComponentPropsWithoutRef<'div'>
->(({ className, ...props }, ref) => (
-  <div ref={ref} className={clsx(styles.builder, className)} {...props} />
-));
+export interface IStyledBuilderProps extends ComponentPropsWithoutRef<'div'> {
+  useDefaultStyles?: boolean;
+}
+
+export const StyledBuilder = forwardRef<HTMLDivElement, IStyledBuilderProps>(
+  ({ className, useDefaultStyles = true, ...props }, ref) => (
+    <div
+      ref={ref}
+      className={clsx(
+        styles.builder,
+        useDefaultStyles && styles.container,
+        className
+      )}
+      {...props}
+    />
+  )
+);
 
 StyledBuilder.displayName = 'StyledBuilder';

--- a/src/builder/drag-and-drop/components/drop-zone/drop-zone.module.css
+++ b/src/builder/drag-and-drop/components/drop-zone/drop-zone.module.css
@@ -94,7 +94,11 @@
 
   .inner.active {
     border-color: var(--query-builder-color-grey-300);
-    background: rgba(204, 204, 204, 0.08);
+    background: color-mix(
+      in srgb,
+      var(--query-builder-color-grey-300) 8%,
+      transparent
+    );
   }
 
   .inner.active,

--- a/src/builder/drag-and-drop/components/empty-group-drop-zone/empty-group-drop-zone.module.css
+++ b/src/builder/drag-and-drop/components/empty-group-drop-zone/empty-group-drop-zone.module.css
@@ -49,7 +49,11 @@
 
   .placeholderInner.active {
     border-color: var(--query-builder-color-grey-500);
-    background: rgba(204, 204, 204, 0.08);
+    background: color-mix(
+      in srgb,
+      var(--query-builder-color-grey-300) 8%,
+      transparent
+    );
   }
 
   .transitionDisabled {

--- a/src/builder/text-mode/components/text-mode-editor/text-mode-editor.module.css
+++ b/src/builder/text-mode/components/text-mode-editor/text-mode-editor.module.css
@@ -40,12 +40,20 @@
   .frame :global(.builder-text-mode-input-field)::selection {
     color: transparent;
     -webkit-text-fill-color: transparent;
-    background: rgba(37, 99, 235, 0.22);
+    background: color-mix(
+      in srgb,
+      var(--query-builder-color-info-primary) 22%,
+      transparent
+    );
   }
 
   .frame :global(.builder-text-mode-input-field)::-moz-selection {
     color: transparent;
-    background: rgba(37, 99, 235, 0.22);
+    background: color-mix(
+      in srgb,
+      var(--query-builder-color-info-primary) 22%,
+      transparent
+    );
   }
 
   .editorLayer,
@@ -74,13 +82,13 @@
 
   .editorLayer :global(.token.keyword),
   .editorLayer :global(.token.boolean) {
-    color: #1d4ed8;
+    color: var(--query-builder-color-info-primary);
     font-weight: 700;
   }
 
   .editorLayer :global(.token.operator),
   .editorLayer :global(.token.punctuation) {
-    color: #374151;
+    color: var(--query-builder-color-grey-700);
   }
 
   .editorLayer :global(.token.operator) {
@@ -88,15 +96,15 @@
   }
 
   .editorLayer :global(.token.string) {
-    color: #047857;
+    color: var(--query-builder-color-success-primary);
   }
 
   .editorLayer :global(.token.number) {
-    color: #c2410c;
+    color: var(--query-builder-color-warning-primary);
   }
 
   .editorLayer :global(.token.function) {
-    color: #7c3aed;
+    color: var(--query-builder-color-primary-default);
     font-weight: 600;
   }
 
@@ -113,7 +121,11 @@
   }
 
   .diagnosticText {
-    background: rgba(244, 67, 54, 0.12);
+    background: color-mix(
+      in srgb,
+      var(--query-builder-color-error-primary) 12%,
+      transparent
+    );
     border-radius: 2px;
     box-shadow: inset 0 -2px 0 var(--query-builder-color-secondary-dark);
   }

--- a/src/builder/text-mode/components/text-mode-editor/text-mode-editor.test.tsx
+++ b/src/builder/text-mode/components/text-mode-editor/text-mode-editor.test.tsx
@@ -180,6 +180,11 @@ describe('#builder/text-mode/TextModeEditor', () => {
       expect(css).toContain(`.editorLayer :global(.token.${token})`);
     }
 
+    expect(css).toContain('color: var(--query-builder-color-info-primary)');
+    expect(css).toContain('color: var(--query-builder-color-success-primary)');
+    expect(css).toContain('color: var(--query-builder-color-warning-primary)');
+    expect(css).toContain('color: var(--query-builder-color-primary-default)');
+    expect(css).not.toMatch(/#[0-9a-f]{6}/i);
     expect(css).not.toMatch(/^\s*:global\(\.token/m);
     expect(css).toContain('caret-color: var(--query-builder-color-grey-800)');
     expect(css).toContain('::selection');

--- a/src/builder/text-mode/components/text-mode-input/text-mode-input.module.css
+++ b/src/builder/text-mode/components/text-mode-input/text-mode-input.module.css
@@ -2,7 +2,7 @@
   .root {
     min-height: var(--query-builder-editor-min-height, 10rem);
     overflow: hidden;
-    background: var(--query-builder-color-white);
+    background: var(--query-builder-color-background);
     border: 1px solid var(--query-builder-color-grey-300);
     border-radius: var(--query-builder-radius-sm, 4px);
   }

--- a/src/builder/text-mode/types/text-mode-editor-props.ts
+++ b/src/builder/text-mode/types/text-mode-editor-props.ts
@@ -8,6 +8,7 @@ export interface ITextModeEditorProps {
   protectedRangesMessage?: string | null;
   protectedRangeHoverMessage?: string | null;
   errorMessage: string | null;
+  colorScheme?: 'light' | 'dark';
   readOnly?: boolean;
   allowProtectedRangeDeletion?: boolean;
   onChange: (value: string) => void;

--- a/src/builder/theme/styles/colors.ts
+++ b/src/builder/theme/styles/colors.ts
@@ -62,11 +62,11 @@ export const colors: IColors = {
     light: '#8fb2ff',
   },
   success: {
-    primary: '#2f8f4e',
+    primary: '#237a40',
     light: '#8fd3a3',
   },
   warning: {
-    primary: '#dc7a1e',
+    primary: '#b45309',
     light: '#f7b578',
   },
   error: {

--- a/src/builder/theme/styles/dark-colors.ts
+++ b/src/builder/theme/styles/dark-colors.ts
@@ -1,0 +1,44 @@
+﻿import type { IColors } from './colors';
+
+export const darkColors: IColors = {
+  primary: {
+    default: '#8c9eff',
+    light: '#5365a8',
+    dark: '#b3c0ff',
+    contrastText: '#111827',
+  },
+  secondary: {
+    default: '#ff6b6b',
+    light: '#ff8a80',
+    dark: '#ffb4ab',
+    contrastText: '#111827',
+  },
+  grey: {
+    100: '#1f2937',
+    200: '#273449',
+    300: '#374151',
+    400: '#4b5563',
+    500: '#9ca3af',
+    600: '#c0c7d1',
+    700: '#d1d5db',
+    800: '#e5e7eb',
+    900: '#f9fafb',
+  },
+  info: {
+    primary: '#8fb2ff',
+    light: '#456194',
+  },
+  success: {
+    primary: '#8fd3a3',
+    light: '#3f6f4d',
+  },
+  warning: {
+    primary: '#f7b578',
+    light: '#835421',
+  },
+  error: {
+    primary: '#f2a0a0',
+    light: '#7f3d3d',
+  },
+  white: '#111827',
+};

--- a/src/builder/theme/styles/dark-mode.variables.css
+++ b/src/builder/theme/styles/dark-mode.variables.css
@@ -1,0 +1,31 @@
+@layer react-query-builder {
+  :where([data-query-builder-color-scheme='dark']) {
+    color-scheme: dark;
+    --query-builder-color-primary-default: #8c9eff;
+    --query-builder-color-primary-light: #5365a8;
+    --query-builder-color-primary-dark: #b3c0ff;
+    --query-builder-color-primary-contrast-text: #111827;
+    --query-builder-color-secondary-default: #ff6b6b;
+    --query-builder-color-secondary-light: #ff8a80;
+    --query-builder-color-secondary-dark: #ffb4ab;
+    --query-builder-color-secondary-contrast-text: #111827;
+    --query-builder-color-grey-100: #1f2937;
+    --query-builder-color-grey-200: #273449;
+    --query-builder-color-grey-300: #374151;
+    --query-builder-color-grey-400: #4b5563;
+    --query-builder-color-grey-500: #9ca3af;
+    --query-builder-color-grey-600: #c0c7d1;
+    --query-builder-color-grey-700: #d1d5db;
+    --query-builder-color-grey-800: #e5e7eb;
+    --query-builder-color-grey-900: #f9fafb;
+    --query-builder-color-info-primary: #8fb2ff;
+    --query-builder-color-info-light: #456194;
+    --query-builder-color-success-primary: #8fd3a3;
+    --query-builder-color-success-light: #3f6f4d;
+    --query-builder-color-warning-primary: #f7b578;
+    --query-builder-color-warning-light: #835421;
+    --query-builder-color-error-primary: #f2a0a0;
+    --query-builder-color-error-light: #7f3d3d;
+    --query-builder-color-background: #111827;
+  }
+}

--- a/src/builder/theme/styles/input.module.css
+++ b/src/builder/theme/styles/input.module.css
@@ -16,7 +16,7 @@
     height: 2rem;
     border: 1px solid var(--query-builder-color-grey-500);
     border-radius: 3px;
-    background: var(--query-builder-color-white);
+    background: var(--query-builder-color-background);
   }
 
   .control:disabled {

--- a/src/builder/theme/styles/tokens.css
+++ b/src/builder/theme/styles/tokens.css
@@ -19,13 +19,13 @@
     --query-builder-color-grey-900: #212121;
     --query-builder-color-info-primary: #2563eb;
     --query-builder-color-info-light: #8fb2ff;
-    --query-builder-color-success-primary: #2f8f4e;
+    --query-builder-color-success-primary: #237a40;
     --query-builder-color-success-light: #8fd3a3;
-    --query-builder-color-warning-primary: #dc7a1e;
+    --query-builder-color-warning-primary: #b45309;
     --query-builder-color-warning-light: #f7b578;
     --query-builder-color-error-primary: #d14343;
     --query-builder-color-error-light: #f2a0a0;
-    --query-builder-color-white: #ffffff;
+    --query-builder-color-background: #ffffff;
     --query-builder-spacing-xs: 0.25rem;
     --query-builder-spacing-sm: 0.5rem;
     --query-builder-spacing-md: 0.75rem;
@@ -58,5 +58,35 @@
     --query-builder-motion-duration: 180ms;
     --query-builder-motion-easing: ease;
     --query-builder-popover-z-index: 5;
+  }
+
+  :where([data-query-builder-color-scheme='light']) {
+    color-scheme: light;
+    --query-builder-color-primary-default: #3f51b5;
+    --query-builder-color-primary-light: #757de8;
+    --query-builder-color-primary-dark: #002984;
+    --query-builder-color-primary-contrast-text: #ffffff;
+    --query-builder-color-secondary-default: #f44336;
+    --query-builder-color-secondary-light: #ff7961;
+    --query-builder-color-secondary-dark: #ba000d;
+    --query-builder-color-secondary-contrast-text: #ffffff;
+    --query-builder-color-grey-100: #f5f5f5;
+    --query-builder-color-grey-200: #eeeeee;
+    --query-builder-color-grey-300: #e0e0e0;
+    --query-builder-color-grey-400: #bdbdbd;
+    --query-builder-color-grey-500: #9e9e9e;
+    --query-builder-color-grey-600: #757575;
+    --query-builder-color-grey-700: #616161;
+    --query-builder-color-grey-800: #424242;
+    --query-builder-color-grey-900: #212121;
+    --query-builder-color-info-primary: #2563eb;
+    --query-builder-color-info-light: #8fb2ff;
+    --query-builder-color-success-primary: #237a40;
+    --query-builder-color-success-light: #8fd3a3;
+    --query-builder-color-warning-primary: #b45309;
+    --query-builder-color-warning-light: #f7b578;
+    --query-builder-color-error-primary: #d14343;
+    --query-builder-color-error-light: #f2a0a0;
+    --query-builder-color-background: #ffffff;
   }
 }

--- a/src/builder/theme/styles/visual-accessibility-contract.test.ts
+++ b/src/builder/theme/styles/visual-accessibility-contract.test.ts
@@ -1,6 +1,7 @@
 import { readFileSync } from 'node:fs';
 import { join } from 'node:path';
 import { colors } from './colors';
+import { darkColors } from './dark-colors';
 
 const readCss = (relativePath: string): string =>
   readFileSync(join(__dirname, '..', '..', '..', relativePath), 'utf8');
@@ -150,9 +151,76 @@ describe('visual and accessibility contract', () => {
     }
   );
 
+  it('scopes complete light and dark color palettes to Builder roots', () => {
+    const lightTokens = readFileSync(join(__dirname, 'tokens.css'), 'utf8');
+    const darkTokens = readFileSync(
+      join(__dirname, 'dark-mode.variables.css'),
+      'utf8'
+    );
+
+    expect(lightTokens).toContain(
+      ":where([data-query-builder-color-scheme='light'])"
+    );
+    expect(darkTokens).toContain(
+      ":where([data-query-builder-color-scheme='dark'])"
+    );
+    expect(darkTokens).not.toContain(':where(:root)');
+    expect(lightTokens).toContain('--query-builder-color-background: #ffffff');
+    expect(darkTokens).toContain('--query-builder-color-background: #111827');
+  });
+
+  it('keeps dark text, actions, statuses, and syntax colors at AA contrast', () => {
+    for (const foreground of [
+      darkColors.grey[700],
+      darkColors.grey[800],
+      darkColors.grey[900],
+      darkColors.info.primary,
+      darkColors.success.primary,
+      darkColors.warning.primary,
+      darkColors.error.primary,
+    ]) {
+      expect(
+        getContrastRatio(foreground, darkColors.white)
+      ).toBeGreaterThanOrEqual(4.5);
+    }
+
+    expect(
+      getContrastRatio(
+        darkColors.primary.contrastText,
+        darkColors.primary.default
+      )
+    ).toBeGreaterThanOrEqual(4.5);
+    expect(
+      getContrastRatio(
+        darkColors.secondary.contrastText,
+        darkColors.secondary.light
+      )
+    ).toBeGreaterThanOrEqual(4.5);
+    expect(
+      getContrastRatio(darkColors.grey[700], darkColors.grey[300])
+    ).toBeGreaterThanOrEqual(4.5);
+  });
+  it('keeps light syntax colors at WCAG AA contrast', () => {
+    for (const foreground of [
+      colors.info.primary,
+      colors.success.primary,
+      colors.warning.primary,
+      colors.primary.default,
+      colors.grey[700],
+      colors.grey[900],
+    ]) {
+      expect(getContrastRatio(foreground, colors.white)).toBeGreaterThanOrEqual(
+        4.5
+      );
+    }
+  });
+
   it('keeps core text and validation contrast at WCAG AA ratios', () => {
     expect(
       getContrastRatio(colors.primary.default, colors.white)
+    ).toBeGreaterThanOrEqual(4.5);
+    expect(
+      getContrastRatio(colors.grey[700], colors.grey[100])
     ).toBeGreaterThanOrEqual(4.5);
     expect(
       getContrastRatio(colors.grey[700], colors.white)

--- a/src/builder/theme/utils/create-theme-css-variables.util.test.ts
+++ b/src/builder/theme/utils/create-theme-css-variables.util.test.ts
@@ -25,13 +25,13 @@ describe('#utils/createThemeCssVariables', () => {
       '--query-builder-color-grey-900': '#212121',
       '--query-builder-color-info-primary': '#2563eb',
       '--query-builder-color-info-light': '#8fb2ff',
-      '--query-builder-color-success-primary': '#2f8f4e',
+      '--query-builder-color-success-primary': '#237a40',
       '--query-builder-color-success-light': '#8fd3a3',
-      '--query-builder-color-warning-primary': '#dc7a1e',
+      '--query-builder-color-warning-primary': '#b45309',
       '--query-builder-color-warning-light': '#f7b578',
       '--query-builder-color-error-primary': '#d14343',
       '--query-builder-color-error-light': '#f2a0a0',
-      '--query-builder-color-white': '#ffffff',
+      '--query-builder-color-background': '#ffffff',
     });
   });
 

--- a/src/builder/theme/utils/create-theme-css-variables.util.ts
+++ b/src/builder/theme/utils/create-theme-css-variables.util.ts
@@ -33,7 +33,7 @@ export const createThemeCssVariables = ({
     '--query-builder-color-warning-light': colors?.warning?.light,
     '--query-builder-color-error-primary': colors?.error?.primary,
     '--query-builder-color-error-light': colors?.error?.light,
-    '--query-builder-color-white': colors?.white,
+    '--query-builder-color-background': colors?.white,
   };
 
   return Object.fromEntries(

--- a/src/builder/types/builder-style.ts
+++ b/src/builder/types/builder-style.ts
@@ -26,7 +26,7 @@ export interface IBuilderStyle extends CSSProperties {
   '--query-builder-color-warning-light'?: string;
   '--query-builder-color-error-primary'?: string;
   '--query-builder-color-error-light'?: string;
-  '--query-builder-color-white'?: string;
+  '--query-builder-color-background'?: string;
   '--query-builder-spacing-xs'?: string;
   '--query-builder-spacing-sm'?: string;
   '--query-builder-spacing-md'?: string;

--- a/src/builder/types/index.ts
+++ b/src/builder/types/index.ts
@@ -177,7 +177,8 @@ export interface IBuilderProps {
   data: DenormalizedQuery;
   className?: string;
   style?: IBuilderStyle;
-  showOuterContainer?: boolean;
+  useDefaultContainerStyles?: boolean;
+  colorScheme?: 'light' | 'dark';
   components?: IBuilderComponentsProps;
   strings?: IStrings;
   textMode?: boolean | IBuilderTextModeConfig;

--- a/src/subpackages/monaco/components/monaco-text-mode-editor/monaco-text-mode-editor.module.css
+++ b/src/subpackages/monaco/components/monaco-text-mode-editor/monaco-text-mode-editor.module.css
@@ -9,7 +9,7 @@
     overflow: hidden;
     border: 1px solid var(--query-builder-color-grey-300);
     border-radius: var(--query-builder-radius-sm);
-    background: var(--query-builder-color-white);
+    background: var(--query-builder-color-background);
   }
 
   .surface,
@@ -37,19 +37,37 @@
         .view-lines
         span.rqb-monaco-text-mode-protected[class*='mtk']
     ) {
-    color: var(--query-builder-color-grey-600) !important;
-    background: rgba(245, 245, 245, 0.92) !important;
+    color: light-dark(
+      var(--query-builder-color-grey-700),
+      var(--query-builder-color-grey-700)
+    ) !important;
+    background: light-dark(
+      color-mix(
+        in srgb,
+        var(--query-builder-color-grey-100) 60%,
+        var(--query-builder-color-background)
+      ),
+      color-mix(
+        in srgb,
+        var(--query-builder-color-grey-300) 78%,
+        var(--query-builder-color-background)
+      )
+    ) !important;
     border-radius: 3px;
-    box-shadow: inset 0 0 0 1px rgba(189, 189, 189, 0.65);
+    box-shadow: inset 0 0 0 1px
+      light-dark(rgba(189, 189, 189, 0.65), var(--query-builder-color-grey-500));
     filter: grayscale(1);
-    opacity: 0.62;
+    opacity: 1;
     text-shadow: none !important;
   }
 
   .frame :global(.monaco-editor .view-lines .rqb-monaco-text-mode-protected *),
   .frame
     :global(.monaco-editor .view-lines span.rqb-monaco-text-mode-protected *) {
-    color: var(--query-builder-color-grey-600) !important;
+    color: light-dark(
+      var(--query-builder-color-grey-700),
+      var(--query-builder-color-grey-700)
+    ) !important;
     text-shadow: none !important;
   }
 

--- a/src/subpackages/monaco/components/monaco-text-mode-editor/monaco-text-mode-editor.test.tsx
+++ b/src/subpackages/monaco/components/monaco-text-mode-editor/monaco-text-mode-editor.test.tsx
@@ -87,11 +87,13 @@ jest.mock(
         return editorInstance;
       }
     );
+    const defineTheme = jest.fn();
 
     return {
       __esModule: true,
       editor: {
         create,
+        defineTheme,
       },
       Selection: class {
         startLineNumber: number;
@@ -145,6 +147,15 @@ jest.mock(
       },
       __mock: {
         getCreateCallCount: () => create.mock.calls.length,
+        getCreateOptions: () =>
+          create.mock.calls[create.mock.calls.length - 1]?.[1],
+        getDefinedThemes: () =>
+          defineTheme.mock.calls.map(([name, data]) => ({ name, data })),
+        getThemeDefinitionCallOrder: () =>
+          defineTheme.mock.invocationCallOrder[0],
+        getCreateCallOrder: () => create.mock.invocationCallOrder[0],
+        getUpdateOptions: () =>
+          editorInstance.updateOptions.mock.calls.map(([options]) => options),
         getCurrentValue: () => currentValue,
         getLastDecorations: () => lastDecorations,
         getSelections: () => currentSelections,
@@ -180,6 +191,7 @@ jest.mock(
             },
           ];
           create.mockClear();
+          defineTheme.mockClear();
           editorInstance.updateOptions.mockClear();
           editorInstance.deltaDecorations.mockClear();
           editorInstance.setSelections.mockClear();
@@ -196,6 +208,14 @@ const getMonacoMock = () =>
     jest.requireMock('monaco-editor') as {
       __mock: {
         getCreateCallCount: () => number;
+        getCreateOptions: () => { theme?: string } | undefined;
+        getDefinedThemes: () => Array<{
+          name: string;
+          data: { base?: string; colors?: Record<string, string> };
+        }>;
+        getThemeDefinitionCallOrder: () => number | undefined;
+        getCreateCallOrder: () => number | undefined;
+        getUpdateOptions: () => Array<{ readOnly?: boolean; theme?: string }>;
         getCurrentValue: () => string;
         getLastDecorations: () => IMonacoDecoration[];
         getSelections: () => Array<{
@@ -575,9 +595,71 @@ describe('MonacoTextModeEditor presentation', () => {
 
     await waitFor(() => {
       expect(getMonacoMock().getCurrentValue()).toBe(baseProps.value);
+      expect(getMonacoMock().getCreateOptions()).toMatchObject({
+        theme: 'rqb-query-builder-light',
+      });
     });
   });
 
+  it('follows colorScheme reactively without recreating the editor', async () => {
+    const monacoMock = getMonacoMock();
+    const { rerender } = render(
+      <MonacoTextModeEditor {...baseProps} colorScheme="dark" />
+    );
+
+    await waitFor(() => {
+      expect(monacoMock.getCreateOptions()).toMatchObject({
+        theme: 'rqb-query-builder-dark',
+      });
+    });
+    expect(monacoMock.getDefinedThemes()).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          name: 'rqb-query-builder-light',
+          data: expect.objectContaining({ base: 'vs' }),
+        }),
+        expect.objectContaining({
+          name: 'rqb-query-builder-dark',
+          data: expect.objectContaining({ base: 'vs-dark' }),
+        }),
+      ])
+    );
+    expect(monacoMock.getThemeDefinitionCallOrder()).toBeLessThan(
+      monacoMock.getCreateCallOrder() as number
+    );
+
+    const createCallCount = monacoMock.getCreateCallCount();
+
+    rerender(<MonacoTextModeEditor {...baseProps} colorScheme="light" />);
+
+    await waitFor(() => {
+      expect(monacoMock.getUpdateOptions()).toContainEqual(
+        expect.objectContaining({ theme: 'rqb-query-builder-light' })
+      );
+    });
+    expect(monacoMock.getCreateCallCount()).toBe(createCallCount);
+
+    const themeUpdateCount = monacoMock
+      .getUpdateOptions()
+      .filter((options) => options.theme !== undefined).length;
+
+    rerender(
+      <MonacoTextModeEditor
+        {...baseProps}
+        colorScheme="light"
+        readOnly={true}
+      />
+    );
+
+    await waitFor(() => {
+      expect(monacoMock.getUpdateOptions()).toContainEqual({ readOnly: true });
+    });
+    expect(
+      monacoMock
+        .getUpdateOptions()
+        .filter((options) => options.theme !== undefined)
+    ).toHaveLength(themeUpdateCount);
+  });
   it('scopes Monaco-generated decoration selectors and preserves their visuals', () => {
     const css = readFileSync(
       join(__dirname, 'monaco-text-mode-editor.module.css'),
@@ -596,9 +678,17 @@ describe('MonacoTextModeEditor presentation', () => {
     expect(css).not.toMatch(/^ {2}:global\(/m);
     expect(css).toContain('var(--query-builder-editor-min-height)');
     expect(css).toContain('var(--query-builder-color-error-primary)');
-    expect(css).toContain('var(--query-builder-color-grey-600) !important');
+    expect(css).toContain('color: light-dark(');
+    expect(css).toContain('background: light-dark(');
+    expect(css).toContain('color-mix(');
+    expect(css).toContain('var(--query-builder-color-grey-700)');
+    expect(css).toContain('var(--query-builder-color-grey-300) 78%');
+    expect(css).toContain('var(--query-builder-color-grey-500)');
+    expect(css).not.toContain('rgba(245, 245, 245, 0.92)');
+    expect(css).not.toContain('opacity: 0.62');
     expect(css).toContain("[class*='mtk']");
     expect(css).toContain('filter: grayscale(1)');
+    expect(css).toContain('opacity: 1');
     expect(css).toContain('opacity: 1 !important');
   });
 

--- a/src/subpackages/monaco/components/monaco-text-mode-editor/monaco-text-mode-editor.tsx
+++ b/src/subpackages/monaco/components/monaco-text-mode-editor/monaco-text-mode-editor.tsx
@@ -3,6 +3,7 @@ import type * as Monaco from 'monaco-editor';
 import { ITextModeEditorProps } from '../../../../builder/text-mode/types/text-mode-editor-props';
 import { ITextModeProtectedRange } from '../../../../builder/text-mode/types/text-mode-protected-range';
 import { createMonacoRangeFromOffsets } from '../../utils/create-monaco-range-from-offsets';
+import { createMonacoQueryBuilderTheme } from '../../utils/create-monaco-query-builder-theme.util';
 import { createMonacoDiagnosticDecoration } from '../../utils/create-monaco-diagnostic-decoration';
 import { doesChangeIntersectProtectedRanges } from '../../utils/does-change-intersect-protected-ranges';
 import { restoreSelectionsBeforeChange } from '../../utils/restore-selection-before-change';
@@ -11,6 +12,8 @@ import { updateProtectedRangesAfterChange } from '../../utils/update-protected-r
 import styles from './monaco-text-mode-editor.module.css';
 
 const EMPTY_PROTECTED_RANGES: ITextModeProtectedRange[] = [];
+const LIGHT_MONACO_THEME = createMonacoQueryBuilderTheme('light');
+const DARK_MONACO_THEME = createMonacoQueryBuilderTheme('dark');
 
 const areProtectedRangesEqual = (
   left: ITextModeProtectedRange[],
@@ -28,6 +31,7 @@ export const MonacoTextModeEditor: FC<ITextModeEditorProps> = ({
   protectedRanges = EMPTY_PROTECTED_RANGES,
   protectedRangeHoverMessage = null,
   errorMessage,
+  colorScheme,
   readOnly = false,
   allowProtectedRangeDeletion = false,
   onChange,
@@ -38,7 +42,10 @@ export const MonacoTextModeEditor: FC<ITextModeEditorProps> = ({
   const changeSubscriptionRef = useRef<Monaco.IDisposable | null>(null);
   const onChangeRef = useRef(onChange);
   const allowProtectedRangeDeletionRef = useRef(allowProtectedRangeDeletion);
+  const monacoTheme =
+    colorScheme === 'dark' ? DARK_MONACO_THEME.name : LIGHT_MONACO_THEME.name;
   const initialReadOnlyRef = useRef(readOnly);
+  const initialThemeRef = useRef(monacoTheme);
   const initialValueRef = useRef(value);
   const isSyncingValueRef = useRef(false);
   const isRevertingChangeRef = useRef(false);
@@ -78,10 +85,15 @@ export const MonacoTextModeEditor: FC<ITextModeEditorProps> = ({
       }
 
       monacoRef.current = monaco;
+      monaco.editor.defineTheme(
+        LIGHT_MONACO_THEME.name,
+        LIGHT_MONACO_THEME.data
+      );
+      monaco.editor.defineTheme(DARK_MONACO_THEME.name, DARK_MONACO_THEME.data);
       const editor = monaco.editor.create(containerRef.current, {
         value: initialValueRef.current,
         language: 'sql',
-        theme: 'vs',
+        theme: initialThemeRef.current,
         readOnly: initialReadOnlyRef.current,
         automaticLayout: true,
         wordWrap: 'on',
@@ -215,12 +227,20 @@ export const MonacoTextModeEditor: FC<ITextModeEditorProps> = ({
   }, [protectedRanges]);
 
   useEffect(() => {
-    if (!editorRef.current) {
+    if (!editorReady || !editorRef.current) {
       return;
     }
 
     editorRef.current.updateOptions({ readOnly });
-  }, [readOnly]);
+  }, [editorReady, readOnly]);
+
+  useEffect(() => {
+    if (!editorReady || !editorRef.current) {
+      return;
+    }
+
+    editorRef.current.updateOptions({ theme: monacoTheme });
+  }, [editorReady, monacoTheme]);
 
   useEffect(() => {
     if (!editorRef.current) {

--- a/src/subpackages/monaco/utils/create-monaco-query-builder-theme.util.test.ts
+++ b/src/subpackages/monaco/utils/create-monaco-query-builder-theme.util.test.ts
@@ -1,0 +1,98 @@
+import { colors } from '../../../builder/theme/styles/colors';
+import { darkColors } from '../../../builder/theme/styles/dark-colors';
+import { createMonacoQueryBuilderTheme } from './create-monaco-query-builder-theme.util';
+
+describe('#utils/createMonacoQueryBuilderTheme', () => {
+  it.each([
+    ['light', colors, 'vs'],
+    ['dark', darkColors, 'vs-dark'],
+  ] as const)(
+    'maps the %s Monaco SQL theme to the built-in palette roles',
+    (colorScheme, palette, base) => {
+      const theme = createMonacoQueryBuilderTheme(colorScheme);
+      const rules = Object.fromEntries(
+        theme.data.rules.map((rule) => [rule.token, rule])
+      );
+
+      expect(theme.name).toBe(`rqb-query-builder-${colorScheme}`);
+      expect(theme.data.base).toBe(base);
+      expect(theme.data.inherit).toBe(true);
+      expect(theme.data.colors).toMatchObject({
+        'editor.background': palette.white,
+        'editor.foreground': palette.grey[800],
+        'editorBracketHighlight.foreground1': palette.grey[700],
+        'editorBracketHighlight.foreground2': palette.grey[700],
+        'editorBracketHighlight.foreground3': palette.grey[700],
+        'editorBracketHighlight.foreground4': palette.grey[700],
+        'editorBracketHighlight.foreground5': palette.grey[700],
+        'editorBracketHighlight.foreground6': palette.grey[700],
+        'editorBracketHighlight.unexpectedBracketForeground':
+          palette.error.primary,
+      });
+      expect(rules['']).toMatchObject({
+        foreground: palette.grey[800].slice(1),
+      });
+      expect(rules.keyword).toMatchObject({
+        foreground: palette.info.primary.slice(1),
+        fontStyle: 'bold',
+      });
+      expect(rules.operator).toMatchObject({
+        foreground: palette.grey[700].slice(1),
+        fontStyle: 'bold',
+      });
+      expect(rules.delimiter).toMatchObject({
+        foreground: palette.grey[700].slice(1),
+      });
+      expect(rules['delimiter.parenthesis']).toEqual({
+        ...rules.delimiter,
+        token: 'delimiter.parenthesis',
+      });
+      expect(rules.string).toMatchObject({
+        foreground: palette.success.primary.slice(1),
+      });
+      expect(rules.number).toMatchObject({
+        foreground: palette.warning.primary.slice(1),
+      });
+      expect(rules.predefined).toMatchObject({
+        foreground: palette.primary.default.slice(1),
+        fontStyle: 'bold',
+      });
+      expect(rules.identifier).toMatchObject({
+        foreground: palette.grey[900].slice(1),
+        fontStyle: 'bold',
+      });
+      expect(rules['keyword.sql']).toEqual({
+        ...rules.keyword,
+        token: 'keyword.sql',
+      });
+      expect(rules['operator.sql']).toEqual({
+        ...rules.operator,
+        token: 'operator.sql',
+      });
+      expect(rules['delimiter.sql']).toEqual({
+        ...rules.delimiter,
+        token: 'delimiter.sql',
+      });
+      expect(rules['delimiter.parenthesis.sql']).toEqual({
+        ...rules.delimiter,
+        token: 'delimiter.parenthesis.sql',
+      });
+      expect(rules['string.sql']).toEqual({
+        ...rules.string,
+        token: 'string.sql',
+      });
+      expect(rules['number.sql']).toEqual({
+        ...rules.number,
+        token: 'number.sql',
+      });
+      expect(rules['predefined.sql']).toEqual({
+        ...rules.predefined,
+        token: 'predefined.sql',
+      });
+      expect(rules['identifier.sql']).toEqual({
+        ...rules.identifier,
+        token: 'identifier.sql',
+      });
+    }
+  );
+});

--- a/src/subpackages/monaco/utils/create-monaco-query-builder-theme.util.ts
+++ b/src/subpackages/monaco/utils/create-monaco-query-builder-theme.util.ts
@@ -1,0 +1,87 @@
+import type { editor } from 'monaco-editor';
+import { colors } from '../../../builder/theme/styles/colors';
+import { darkColors } from '../../../builder/theme/styles/dark-colors';
+
+export const createMonacoQueryBuilderTheme = (
+  colorScheme: 'light' | 'dark'
+): { data: editor.IStandaloneThemeData; name: string } => {
+  const palette = colorScheme === 'dark' ? darkColors : colors;
+  const data: editor.IStandaloneThemeData = {
+    base: colorScheme === 'dark' ? 'vs-dark' : 'vs',
+    inherit: true,
+    rules: [
+      { token: '', foreground: palette.grey[800].slice(1) },
+      {
+        token: 'keyword',
+        foreground: palette.info.primary.slice(1),
+        fontStyle: 'bold',
+      },
+      {
+        token: 'operator',
+        foreground: palette.grey[700].slice(1),
+        fontStyle: 'bold',
+      },
+      { token: 'delimiter', foreground: palette.grey[700].slice(1) },
+      {
+        token: 'delimiter.parenthesis',
+        foreground: palette.grey[700].slice(1),
+      },
+      { token: 'string', foreground: palette.success.primary.slice(1) },
+      { token: 'number', foreground: palette.warning.primary.slice(1) },
+      {
+        token: 'predefined',
+        foreground: palette.primary.default.slice(1),
+        fontStyle: 'bold',
+      },
+      {
+        token: 'identifier',
+        foreground: palette.grey[900].slice(1),
+        fontStyle: 'bold',
+      },
+      {
+        token: 'keyword.sql',
+        foreground: palette.info.primary.slice(1),
+        fontStyle: 'bold',
+      },
+      {
+        token: 'operator.sql',
+        foreground: palette.grey[700].slice(1),
+        fontStyle: 'bold',
+      },
+      { token: 'delimiter.sql', foreground: palette.grey[700].slice(1) },
+      {
+        token: 'delimiter.parenthesis.sql',
+        foreground: palette.grey[700].slice(1),
+      },
+      { token: 'string.sql', foreground: palette.success.primary.slice(1) },
+      { token: 'number.sql', foreground: palette.warning.primary.slice(1) },
+      {
+        token: 'predefined.sql',
+        foreground: palette.primary.default.slice(1),
+        fontStyle: 'bold',
+      },
+      {
+        token: 'identifier.sql',
+        foreground: palette.grey[900].slice(1),
+        fontStyle: 'bold',
+      },
+    ],
+    colors: {
+      'editor.background': palette.white,
+      'editor.foreground': palette.grey[800],
+      'editorBracketHighlight.foreground1': palette.grey[700],
+      'editorBracketHighlight.foreground2': palette.grey[700],
+      'editorBracketHighlight.foreground3': palette.grey[700],
+      'editorBracketHighlight.foreground4': palette.grey[700],
+      'editorBracketHighlight.foreground5': palette.grey[700],
+      'editorBracketHighlight.foreground6': palette.grey[700],
+      'editorBracketHighlight.unexpectedBracketForeground':
+        palette.error.primary,
+    },
+  };
+
+  return {
+    data,
+    name: `rqb-query-builder-${colorScheme}`,
+  };
+};

--- a/website/config/package-bindings/package-bindings.test.ts
+++ b/website/config/package-bindings/package-bindings.test.ts
@@ -55,7 +55,9 @@ describe('versioned package bindings', () => {
         ...packageExports.map(({ subpath }) =>
           subpath === '' ? '.' : `.${subpath}`
         ),
-        ...(binding.target === 'v2' ? ['./styles.css'] : []),
+        ...(binding.target === 'v2'
+          ? ['./styles.css', './dark-mode.variables.css']
+          : []),
       ];
 
       expect(Object.keys(manifest.exports).sort()).toEqual(
@@ -72,6 +74,9 @@ describe('versioned package bindings', () => {
 
     expect(packageAliases.map(({ find }) => find)).toEqual([
       ...(binding.stylesheetPath ? [`${canonicalPackageName}/styles.css`] : []),
+      ...(binding.darkModeStylesheetPath
+        ? [`${canonicalPackageName}/dark-mode.variables.css`]
+        : []),
       ...packageExports.map(
         ({ subpath }) => `${canonicalPackageName}${subpath}`
       ),
@@ -98,7 +103,8 @@ describe('versioned package bindings', () => {
         packageReplacements.every(
           (path) =>
             path.startsWith(binding.implementationRoot) ||
-            path === binding.stylesheetPath
+            path === binding.stylesheetPath ||
+            path === binding.darkModeStylesheetPath
         )
       ).toBe(true);
       expect(
@@ -109,12 +115,17 @@ describe('versioned package bindings', () => {
     }
   );
 
-  it('resolves the public stylesheet only for v2', () => {
+  it('resolves the public stylesheets only for v2', () => {
     expect(v1PackageBinding.stylesheetPath).toBeUndefined();
+    expect(v1PackageBinding.darkModeStylesheetPath).toBeUndefined();
     expect(v2PackageBinding.stylesheetPath).toBe(
       resolve(v2PackageBinding.implementationRoot, 'styles.css')
     );
+    expect(v2PackageBinding.darkModeStylesheetPath).toBe(
+      resolve(v2PackageBinding.implementationRoot, 'dark-mode.variables.css')
+    );
     expect(existsSync(v2PackageBinding.stylesheetPath!)).toBe(true);
+    expect(existsSync(v2PackageBinding.darkModeStylesheetPath!)).toBe(true);
   });
 
   it('keeps package runtimes mutually exclusive', () => {

--- a/website/config/package-bindings/types/package-binding.ts
+++ b/website/config/package-bindings/types/package-binding.ts
@@ -11,6 +11,7 @@ export interface IPackageBinding {
   reactDomRoot: string;
   reactRoot: string;
   ssrNoExternal: (string | RegExp)[];
+  darkModeStylesheetPath?: string;
   stylesheetPath?: string;
   target: PackageBindingTarget;
   typeScriptPaths: Record<string, string[]>;

--- a/website/config/package-bindings/utils/create-package-binding.util.ts
+++ b/website/config/package-bindings/utils/create-package-binding.util.ts
@@ -27,6 +27,9 @@ export const createPackageBinding = (
   const stylesheetPath = isV1
     ? undefined
     : resolve(implementationRoot, 'styles.css');
+  const darkModeStylesheetPath = isV1
+    ? undefined
+    : resolve(implementationRoot, 'dark-mode.variables.css');
 
   return {
     target,
@@ -37,6 +40,7 @@ export const createPackageBinding = (
     reactDomRoot,
     mantineCoreRoot,
     mantineHooksRoot,
+    darkModeStylesheetPath,
     aliases: [
       { find: 'react-dom', replacement: reactDomRoot },
       { find: 'react', replacement: reactRoot },
@@ -47,6 +51,14 @@ export const createPackageBinding = (
             {
               find: `${canonicalPackageName}/styles.css`,
               replacement: stylesheetPath,
+            },
+          ]
+        : []),
+      ...(darkModeStylesheetPath
+        ? [
+            {
+              find: `${canonicalPackageName}/dark-mode.variables.css`,
+              replacement: darkModeStylesheetPath,
             },
           ]
         : []),

--- a/website/scripts/verify-versioned-stage.mjs
+++ b/website/scripts/verify-versioned-stage.mjs
@@ -55,19 +55,25 @@ const stagedFiles = fs
   .readdirSync(stageRoot, { recursive: true })
   .map((file) => file.replaceAll('\\', '/'));
 const stylesheetFiles = stagedFiles.filter((file) => file.endsWith('.css'));
-const stylesheetMarkerCount = stylesheetFiles.reduce((count, file) => {
+const packageStylesheetFiles = stylesheetFiles.filter((file) =>
+  fs.readFileSync(path.join(stageRoot, file), 'utf8').includes(stylesheetMarker)
+);
+const stylesheetMarkerCount = packageStylesheetFiles.reduce((count, file) => {
   const stylesheet = fs.readFileSync(path.join(stageRoot, file), 'utf8');
 
   return count + stylesheet.split(stylesheetMarker).length - 1;
 }, 0);
-const expectedMarkerCount = target === 'v2' ? 1 : 0;
+const expectedStylesheetCount = target === 'v2' ? 1 : 0;
+const expectedMarkerCount = target === 'v2' ? 3 : 0;
 
-if (stylesheetMarkerCount !== expectedMarkerCount) {
+if (
+  packageStylesheetFiles.length !== expectedStylesheetCount ||
+  stylesheetMarkerCount !== expectedMarkerCount
+) {
   throw new Error(
-    `${target} staging contains ${stylesheetMarkerCount} React Query Builder stylesheet copies; expected ${expectedMarkerCount}.`
+    `${target} staging contains ${packageStylesheetFiles.length} React Query Builder stylesheet assets with ${stylesheetMarkerCount} scheme declarations; expected ${expectedStylesheetCount} asset with ${expectedMarkerCount} declarations.`
   );
 }
-
 const htmlFiles = stagedFiles.filter((file) => file.endsWith('.html'));
 const containsPrismMarkup = htmlFiles.some((htmlFile) => {
   const html = fs.readFileSync(path.join(stageRoot, htmlFile), 'utf8');

--- a/website/src/v2/entry-client.tsx
+++ b/website/src/v2/entry-client.tsx
@@ -1,4 +1,5 @@
 import '@vojtechportes/react-query-builder/styles.css';
+import '@vojtechportes/react-query-builder/dark-mode.variables.css';
 import * as React from 'react';
 import { hydrateApp } from '../shared/client/hydrate-app.util';
 import { V2App } from './app/v2-app';

--- a/website/src/v2/entry-server.tsx
+++ b/website/src/v2/entry-server.tsx
@@ -1,4 +1,5 @@
 import '@vojtechportes/react-query-builder/styles.css';
+import '@vojtechportes/react-query-builder/dark-mode.variables.css';
 import * as React from 'react';
 import { renderApp } from '../shared/ssr/render-app.util';
 import { V2AppRoutes } from './app/v2-app-routes';

--- a/website/src/v2/pages/api-page/api-content.test.tsx
+++ b/website/src/v2/pages/api-page/api-content.test.tsx
@@ -65,8 +65,26 @@ describe('v2 API content', () => {
       </StaticRouter>
     );
 
-    expect(content).toContain('showOuterContainer');
+    expect(content).toContain('useDefaultContainerStyles');
     expect(content).toContain('Defaults to');
+    expect(content).toContain('colorScheme');
+  });
+  it('documents dark mode exports, precedence, and the background token', () => {
+    const themingContent = renderToStaticMarkup(
+      <StaticRouter location="/api/theming">
+        {findApiPage('/api/theming').content}
+      </StaticRouter>
+    );
+    const variableContent = renderToStaticMarkup(
+      <StaticRouter location="/api/css-variables">
+        {findApiPage('/api/css-variables').content}
+      </StaticRouter>
+    );
+
+    expect(themingContent).toContain('dark-mode.variables.css');
+    expect(themingContent).toContain('colorScheme');
+    expect(themingContent).toContain('explicit light/dark scheme variables');
+    expect(variableContent).toContain('--query-builder-color-background');
   });
   it('normalizes trailing slashes and preserves the overview fallback', () => {
     expect(findApiPage('/api/adapters/mui///').path).toBe('/api/adapters/mui');

--- a/website/src/v2/pages/api-page/components/builder-behavior-props-api-items.tsx
+++ b/website/src/v2/pages/api-page/components/builder-behavior-props-api-items.tsx
@@ -5,14 +5,25 @@ export const BuilderBehaviorPropsApiItems: React.FC = () => (
   <>
     <li>
       <ItemTitle>
-        <InlineCode>showOuterContainer</InlineCode>:
+        <InlineCode>useDefaultContainerStyles</InlineCode>:
       </ItemTitle>{' '}
       Defaults to <InlineCode>true</InlineCode>. Set it to{' '}
-      <InlineCode>false</InlineCode> to omit the outer styled container. The
-      Builder then renders its controls and query content directly, so{' '}
-      <InlineCode>className</InlineCode> and <InlineCode>style</InlineCode> have
-      no container to target.
+      <InlineCode>false</InlineCode> to omit the built-in root surface styles
+      while retaining the baseline typography and color styles. The root{' '}
+      <InlineCode>div</InlineCode>, <InlineCode>className</InlineCode>,{' '}
+      <InlineCode>style</InlineCode>, and data attributes remain available.{' '}
     </li>
+    <li>
+      <ItemTitle>
+        <InlineCode>colorScheme</InlineCode>:
+      </ItemTitle>{' '}
+      Optional <InlineCode>'light' | 'dark'</InlineCode> built-in component
+      scheme. Dark mode requires importing{' '}
+      <InlineCode>
+        @vojtechportes/react-query-builder/dark-mode.variables.css
+      </InlineCode>
+      . Leave this undefined to preserve inherited application variables.
+    </li>{' '}
     <li>
       <ItemTitle>
         <InlineCode>allowGroupNegation</InlineCode>:

--- a/website/src/v2/pages/api-page/components/component-prop-contracts-api-section.tsx
+++ b/website/src/v2/pages/api-page/components/component-prop-contracts-api-section.tsx
@@ -50,7 +50,8 @@ export const ComponentPropContractsApiSection: React.FC = () => (
           <InlineCode>TextModeEditor</InlineCode>:
         </ItemTitle>{' '}
         Receives the current SQL text, diagnostics, optional protected ranges,
-        an optional hover message for protected ranges, and{' '}
+        an optional hover message, the Builder's optional{' '}
+        <InlineCode>colorScheme</InlineCode>, and{' '}
         <InlineCode>onChange(value)</InlineCode>.
       </li>
       <li>

--- a/website/src/v2/pages/api-page/components/css-variables-api-content.tsx
+++ b/website/src/v2/pages/api-page/components/css-variables-api-content.tsx
@@ -17,6 +17,20 @@ export const CssVariablesApiContent: React.FC = () => (
       application-owned wrapper, or one builder through its typed{' '}
       <InlineCode>style</InlineCode> prop.
     </Typography>
+    <SectionTitle>Color schemes</SectionTitle>
+    <Typography color="muted">
+      The base stylesheet defines root defaults and an explicit light palette.
+      The optional{' '}
+      <InlineCode>
+        @vojtechportes/react-query-builder/dark-mode.variables.css
+      </InlineCode>{' '}
+      export defines the scoped dark palette. Select either palette with the
+      typed <InlineCode>Builder.colorScheme</InlineCode> prop.
+    </Typography>
+    <Typography color="muted">
+      <InlineCode>--query-builder-color-background</InlineCode> replaces the
+      former <InlineCode>--query-builder-color-white</InlineCode> surface token.
+    </Typography>{' '}
     <SectionTitle>Variables and defaults</SectionTitle>
     <CodeBlock
       code={cssVariablesReference}

--- a/website/src/v2/pages/api-page/components/monaco-subpackage-api-section.tsx
+++ b/website/src/v2/pages/api-page/components/monaco-subpackage-api-section.tsx
@@ -39,6 +39,17 @@ export const MonacoSubpackageApiSection: React.FC = () => (
         private.
       </li>
       <li>
+        <ItemTitle>Color scheme:</ItemTitle> An explicit Builder{' '}
+        <InlineCode>colorScheme</InlineCode> reactively selects the packaged
+        light or dark Monaco theme. Both themes use the same query-builder
+        palette roles as the built-in SQL editor for keywords, operators,
+        delimiters, strings, numbers, predefined values, and identifiers. An
+        undefined scheme uses the packaged light theme. Monaco's standalone
+        theme service is global, so the latest mounted packaged editor, or the
+        editor whose scheme changes most recently, wins across all mounted
+        Monaco editors.
+      </li>
+      <li>
         <ItemTitle>Peer dependency:</ItemTitle>{' '}
         <InlineCode>monaco-editor</InlineCode> is optional and only required
         when you use that subpackage.

--- a/website/src/v2/pages/api-page/components/theming-api-content.tsx
+++ b/website/src/v2/pages/api-page/components/theming-api-content.tsx
@@ -25,6 +25,17 @@ export const ThemingApiContent: React.FC = () => (
       </li>
       <li>
         <ItemTitle>
+          <InlineCode>
+            @vojtechportes/react-query-builder/dark-mode.variables.css
+          </InlineCode>
+          :
+        </ItemTitle>{' '}
+        Optional dark palette for built-in components. Import it after{' '}
+        <InlineCode>styles.css</InlineCode> before using{' '}
+        <InlineCode>colorScheme=&quot;dark&quot;</InlineCode>.
+      </li>{' '}
+      <li>
+        <ItemTitle>
           <InlineCode>--query-builder-*</InlineCode>:
         </ItemTitle>{' '}
         Public inherited variables for colors, spacing, padding, gaps, radii,
@@ -64,6 +75,13 @@ export const ThemingApiContent: React.FC = () => (
     <List>
       <li>
         <ItemTitle>
+          <InlineCode>colorScheme</InlineCode>:
+        </ItemTitle>{' '}
+        Optional <InlineCode>'light' | 'dark'</InlineCode> palette boundary for
+        one Builder. Leave it undefined to preserve inherited variables.
+      </li>{' '}
+      <li>
+        <ItemTitle>
           <InlineCode>colors</InlineCode>:
         </ItemTitle>{' '}
         Optional deep partial color overrides. Only provided leaves become CSS
@@ -81,10 +99,21 @@ export const ThemingApiContent: React.FC = () => (
         <InlineCode>colors</InlineCode> defaults instead of the outer provider.
       </li>
       <li>
-        <ItemTitle>Precedence:</ItemTitle> Stylesheet defaults, inherited global
-        or wrapper CSS, explicit provider colors, then explicit{' '}
-        <InlineCode>Builder.style</InlineCode> values.
+        <ItemTitle>Precedence:</ItemTitle> Base defaults, inherited variables,
+        explicit light/dark scheme variables, consumer root classes, legacy
+        provider colors, then <InlineCode>Builder.style</InlineCode>{' '}
+        values.{' '}
       </li>
+      <li>
+        <ItemTitle>Monaco note:</ItemTitle> The packaged Monaco light and dark
+        themes map SQL tokens to the same query-builder palette roles as the
+        built-in editor. An undefined <InlineCode>colorScheme</InlineCode> uses
+        the packaged light theme. Monaco's standalone theme service is global,
+        so the latest mounted packaged editor, or the editor whose scheme
+        changes most recently, wins across all mounted editors. Synchronizing
+        consumer CSS variable overrides or custom per-editor themes remains
+        application-managed.
+      </li>{' '}
       <li>
         <ItemTitle>Adapter note:</ItemTitle>{' '}
         <InlineCode>ThemeProvider</InlineCode> affects the built-in default

--- a/website/src/v2/pages/api-page/constants/api-baseline.ts
+++ b/website/src/v2/pages/api-page/constants/api-baseline.ts
@@ -9,7 +9,7 @@ export const apiBaseline = [
     path: '/api/builder',
     title: 'Builder',
     contentHash:
-      'c634fddcfd9aee60ce90dc4185de78d518019126cd697fccde297f470b8bb595',
+      'dbc248a5d10958da9d7de66967820c8d1410f132cf920f682aa6e5dcf9a1d01e',
   },
   {
     path: '/api/builder-ref',
@@ -33,7 +33,7 @@ export const apiBaseline = [
     path: '/api/components',
     title: 'Components',
     contentHash:
-      'f111af4d0d78fe777ecadcb45946c166fbae5ad18c146d563e70fb8e3869e7ea',
+      '59909b0cdd803e403ca11840ef89154aab918bfc60b411b18d0993e2070919da',
   },
   {
     path: '/api/adapters',
@@ -81,13 +81,13 @@ export const apiBaseline = [
     path: '/api/css-variables',
     title: 'CSS Variables',
     contentHash:
-      '5d0072824f1c5f8c861000b7d49565e6e835faeb27bfa17da34a498feaef2c1b',
+      '1658a6f94b46071bdbbe8421573c537b828df8402153c1181e597493e0261ed4',
   },
   {
     path: '/api/theming',
     title: 'Theming',
     contentHash:
-      '9556b871b7af7c011c67774d92ab2c66d988ba00706604a4ac153f14f9064d09',
+      '5a33af4417729fb25fd582f7edfaf35696414581b57c2eaeb2ab97ae0b2b3a1d',
   },
   {
     path: '/api/format-query',

--- a/website/src/v2/pages/api-page/constants/api-pages.tsx
+++ b/website/src/v2/pages/api-page/constants/api-pages.tsx
@@ -188,9 +188,9 @@ export const apiPages: IApiPage[] = [
     sectionTitle: 'Customization',
     summary: '',
     description:
-      'Complete API reference for every public query builder CSS variable and its default value.',
+      'Complete API reference for light and dark query builder CSS variables, color schemes, and default values.',
     searchText:
-      'CSS variables custom properties tokens defaults IBuilderStyle colors spacing padding gaps radii shadows controls typography editor drop zone motion popover',
+      'CSS variables dark mode colorScheme background custom properties tokens defaults IBuilderStyle colors spacing padding gaps radii shadows controls typography editor drop zone motion popover',
     content: <CssVariablesApiContent />,
   },
   {
@@ -200,9 +200,9 @@ export const apiPages: IApiPage[] = [
     sectionTitle: 'Customization',
     summary: '',
     description:
-      'Theming API reference for ThemeProvider, IThemeProviderProps, IColors, and exported color tokens.',
+      'Theming API reference for colorScheme, dark-mode variables, precedence, ThemeProvider, and exported color tokens.',
     searchText:
-      'ThemeProvider IThemeProviderProps IThemeProps IColors colors primary secondary grey white theme customization',
+      'colorScheme dark mode dark-mode variables background ThemeProvider IThemeProviderProps IThemeProps IColors colors theme customization',
     content: <ThemingApiContent />,
   },
   {

--- a/website/src/v2/pages/api-page/constants/builder-signature.ts
+++ b/website/src/v2/pages/api-page/constants/builder-signature.ts
@@ -1,7 +1,10 @@
 export const builderSignature = `export interface IBuilderProps {
   fields: IBuilderFieldProps[];
   data: DenormalizedQuery;
-  showOuterContainer?: boolean;
+  className?: string;
+  style?: IBuilderStyle;
+  useDefaultContainerStyles?: boolean;
+  colorScheme?: 'light' | 'dark';
   components?: IBuilderComponentsProps;
   strings?: IStrings;
   textMode?: boolean | IBuilderTextModeConfig;

--- a/website/src/v2/pages/api-page/constants/css-variables-reference.ts
+++ b/website/src/v2/pages/api-page/constants/css-variables-reference.ts
@@ -19,13 +19,13 @@ export const cssVariablesReference = `:root {
   --query-builder-color-grey-900: #212121;
   --query-builder-color-info-primary: #2563eb;
   --query-builder-color-info-light: #8fb2ff;
-  --query-builder-color-success-primary: #2f8f4e;
+  --query-builder-color-success-primary: #237a40;
   --query-builder-color-success-light: #8fd3a3;
-  --query-builder-color-warning-primary: #dc7a1e;
+  --query-builder-color-warning-primary: #b45309;
   --query-builder-color-warning-light: #f7b578;
   --query-builder-color-error-primary: #d14343;
   --query-builder-color-error-light: #f2a0a0;
-  --query-builder-color-white: #ffffff;
+  --query-builder-color-background: #ffffff;
 
   /* Spacing and layout */
   --query-builder-spacing-xs: 0.25rem;

--- a/website/src/v2/pages/api-page/constants/text-mode-editor-signature.ts
+++ b/website/src/v2/pages/api-page/constants/text-mode-editor-signature.ts
@@ -5,6 +5,7 @@ export const textModeEditorSignature = `export interface ITextModeEditorProps {
   protectedRangesMessage?: string | null;
   protectedRangeHoverMessage?: string | null;
   errorMessage: string | null;
+  colorScheme?: 'light' | 'dark';
   readOnly?: boolean;
   onChange: (value: string) => void;
 }

--- a/website/src/v2/pages/demo-page/components/demo-playground-behavior-controls.tsx
+++ b/website/src/v2/pages/demo-page/components/demo-playground-behavior-controls.tsx
@@ -56,9 +56,9 @@ export const DemoPlaygroundBehaviorControls: React.FC<
       onChange={(value) => onSettingChange('history', value)}
     />
     <ControlToggle
-      checked={settings.showOuterContainer}
-      label="Show outer container"
-      onChange={(value) => onSettingChange('showOuterContainer', value)}
+      checked={settings.useDefaultContainerStyles}
+      label="Use default container styles"
+      onChange={(value) => onSettingChange('useDefaultContainerStyles', value)}
     />
     <ControlToggle
       checked={settings.showValidation}

--- a/website/src/v2/pages/demo-page/components/demo-playground-customization.tsx
+++ b/website/src/v2/pages/demo-page/components/demo-playground-customization.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
 import styled from 'styled-components';
 import type { CustomizationMode } from '../types/customization-mode';
+import { ControlToggle } from './controls/control-toggle';
 
 const Panel = styled.section`
   display: grid;
@@ -55,26 +56,38 @@ const customizationOptions: Array<{
 ];
 
 export interface IDemoPlaygroundCustomizationProps {
+  darkMode: boolean;
   mode: CustomizationMode;
   onChange: (mode: CustomizationMode) => void;
+  onDarkModeChange: (darkMode: boolean) => void;
 }
 
 export const DemoPlaygroundCustomization: React.FC<
   IDemoPlaygroundCustomizationProps
-> = ({ mode, onChange }) => (
+> = ({ darkMode, mode, onChange, onDarkModeChange }) => (
   <Panel>
     <PanelTitle>Customization</PanelTitle>
     <ChoiceGroup>
       {customizationOptions.map((option) => (
-        <Choice key={option.value}>
-          <Radio
-            type="radio"
-            name="customization-mode"
-            checked={mode === option.value}
-            onChange={() => onChange(option.value)}
-          />
-          <span>{option.label}</span>
-        </Choice>
+        <React.Fragment key={option.value}>
+          <Choice>
+            <Radio
+              type="radio"
+              name="customization-mode"
+              checked={mode === option.value}
+              onChange={() => onChange(option.value)}
+            />
+            <span>{option.label}</span>
+          </Choice>
+          {option.value === 'default' && (
+            <ControlToggle
+              checked={darkMode}
+              disabled={mode !== 'default'}
+              label="Dark mode"
+              onChange={onDarkModeChange}
+            />
+          )}
+        </React.Fragment>
       ))}
     </ChoiceGroup>
   </Panel>

--- a/website/src/v2/pages/demo-page/components/demo-playground.test.tsx
+++ b/website/src/v2/pages/demo-page/components/demo-playground.test.tsx
@@ -32,7 +32,8 @@ vi.mock('@vojtechportes/react-query-builder', async (importOriginal) => {
       textMode,
       defaultMode,
       singleRootGroup,
-      showOuterContainer,
+      useDefaultContainerStyles,
+      colorScheme,
       showValidation,
       components,
       style,
@@ -50,7 +51,8 @@ vi.mock('@vojtechportes/react-query-builder', async (importOriginal) => {
       textMode?: boolean;
       defaultMode?: string;
       singleRootGroup?: boolean;
-      showOuterContainer?: boolean;
+      useDefaultContainerStyles?: boolean;
+      colorScheme?: 'light' | 'dark';
       showValidation?: boolean;
       components?: unknown;
       style?: React.CSSProperties;
@@ -73,7 +75,8 @@ vi.mock('@vojtechportes/react-query-builder', async (importOriginal) => {
             textMode,
             defaultMode,
             singleRootGroup,
-            showOuterContainer,
+            useDefaultContainerStyles,
+            colorScheme,
             showValidation,
             hasComponents: Boolean(components),
           })}
@@ -204,11 +207,11 @@ describe('DemoPlayground locale selection', () => {
     expect(screen.getByText('Builder source')).toBeInTheDocument();
 
     expect(
-      screen.getByRole('checkbox', { name: 'Show outer container' })
+      screen.getByRole('checkbox', { name: 'Use default container styles' })
     ).toBeChecked();
     expect(
       JSON.parse(screen.getByTestId('builder-props').textContent ?? '')
-    ).toMatchObject({ showOuterContainer: true });
+    ).toMatchObject({ useDefaultContainerStyles: true });
 
     for (const checkboxName of [
       'Read-only mode',
@@ -218,7 +221,7 @@ describe('DemoPlayground locale selection', () => {
       'Allow group negation',
       'Allow field comparisons',
       'Undo / redo history',
-      'Show outer container',
+      'Use default container styles',
       'Show validation errors',
     ]) {
       await user.click(screen.getByRole('checkbox', { name: checkboxName }));
@@ -241,7 +244,7 @@ describe('DemoPlayground locale selection', () => {
       newNodePlacement: 'prepend',
       history: true,
       singleRootGroup: true,
-      showOuterContainer: false,
+      useDefaultContainerStyles: false,
       showValidation: false,
     });
     expect(
@@ -251,9 +254,62 @@ describe('DemoPlayground locale selection', () => {
     expect(
       screen.getByText('Builder source').parentElement?.parentElement
         ?.textContent
-    ).toContain('showOuterContainer={false}');
+    ).toContain('useDefaultContainerStyles={false}');
   });
 
+  it('switches dark mode only for default components and restores it', async () => {
+    const user = userEvent.setup();
+    render(<DemoPlayground />);
+
+    const darkMode = screen.getByRole('checkbox', { name: 'Dark mode' });
+    const defaultComponents = screen.getByRole('radio', {
+      name: 'Default components',
+    });
+
+    expect(defaultComponents.closest('label')?.nextElementSibling).toBe(
+      darkMode.closest('label')
+    );
+    expect(darkMode).toBeEnabled();
+    expect(darkMode).not.toBeChecked();
+    expect(
+      JSON.parse(screen.getByTestId('builder-props').textContent ?? '')
+    ).toMatchObject({ colorScheme: 'light' });
+
+    await user.click(darkMode);
+
+    expect(
+      JSON.parse(screen.getByTestId('builder-props').textContent ?? '')
+    ).toMatchObject({ colorScheme: 'dark' });
+
+    await user.click(
+      screen.getByRole('button', { name: 'Show Builder source' })
+    );
+
+    const darkSource =
+      screen.getByText('Builder source').parentElement?.parentElement
+        ?.textContent;
+
+    expect(darkSource).toContain(
+      "import '@vojtechportes/react-query-builder/dark-mode.variables.css';"
+    );
+    expect(darkSource).toContain('colorScheme="dark"');
+
+    await user.click(screen.getByRole('radio', { name: 'MUI adapter' }));
+
+    expect(darkMode).toBeDisabled();
+    expect(darkMode).toBeChecked();
+    expect(
+      JSON.parse(screen.getByTestId('builder-props').textContent ?? '')
+    ).not.toHaveProperty('colorScheme');
+
+    await user.click(screen.getByRole('radio', { name: 'Default components' }));
+
+    expect(darkMode).toBeEnabled();
+    expect(darkMode).toBeChecked();
+    expect(
+      JSON.parse(screen.getByTestId('builder-props').textContent ?? '')
+    ).toMatchObject({ colorScheme: 'dark' });
+  });
   it('preserves text, Monaco, and single-root dependencies', async () => {
     const user = userEvent.setup();
     render(<DemoPlayground />);
@@ -285,7 +341,29 @@ describe('DemoPlayground locale selection', () => {
       textMode: true,
       defaultMode: 'text',
       hasComponents: true,
+      colorScheme: 'light',
     });
+
+    await user.click(screen.getByRole('checkbox', { name: 'Dark mode' }));
+
+    expect(
+      JSON.parse(screen.getByTestId('builder-props').textContent ?? '')
+    ).toMatchObject({
+      hasComponents: true,
+      colorScheme: 'dark',
+    });
+
+    await user.click(
+      screen.getByRole('button', { name: 'Show Builder source' })
+    );
+
+    const monacoDarkSource =
+      screen.getByText('Builder source').parentElement?.parentElement
+        ?.textContent;
+
+    expect(monacoDarkSource).toContain('createMonacoComponents({})');
+    expect(monacoDarkSource).toContain('dark-mode.variables.css');
+    expect(monacoDarkSource).toContain('colorScheme="dark"');
 
     await user.click(
       screen.getByRole('checkbox', { name: 'Single root group' })

--- a/website/src/v2/pages/demo-page/components/demo-playground.tsx
+++ b/website/src/v2/pages/demo-page/components/demo-playground.tsx
@@ -98,7 +98,13 @@ export const DemoPlayground: React.FC<IDemoPlaygroundProps> = ({
     defaultMode: settings.defaultMode,
     groupTypes: 'both' as const,
     singleRootGroup: settings.singleRootGroup,
-    showOuterContainer: settings.showOuterContainer,
+    useDefaultContainerStyles: settings.useDefaultContainerStyles,
+    colorScheme:
+      customizationMode === 'default'
+        ? settings.darkMode
+          ? ('dark' as const)
+          : ('light' as const)
+        : undefined,
     showValidation: settings.showValidation,
     style: themeOverrides,
     ...(builderComponents ? { components: builderComponents } : {}),
@@ -156,8 +162,10 @@ export const DemoPlayground: React.FC<IDemoPlaygroundProps> = ({
           onSettingChange={updateSetting}
         />
         <DemoPlaygroundCustomization
+          darkMode={settings.darkMode}
           mode={customizationMode}
           onChange={setCustomizationMode}
+          onDarkModeChange={(darkMode) => updateSetting('darkMode', darkMode)}
         />
         <DemoPlaygroundTheme
           customizationMode={customizationMode}

--- a/website/src/v2/pages/demo-page/constants/default-demo-playground-settings.ts
+++ b/website/src/v2/pages/demo-page/constants/default-demo-playground-settings.ts
@@ -1,6 +1,7 @@
 import type { IDemoPlaygroundSettings } from '../types/demo-playground-settings';
 
 export const defaultDemoPlaygroundSettings: IDemoPlaygroundSettings = {
+  darkMode: false,
   allowFieldComparisons: true,
   allowGroupNegation: true,
   cloneable: false,
@@ -12,7 +13,7 @@ export const defaultDemoPlaygroundSettings: IDemoPlaygroundSettings = {
   newNodePlacement: 'append',
   readOnly: false,
   readOnlyProtectsDelete: true,
-  showOuterContainer: true,
+  useDefaultContainerStyles: true,
   showValidation: true,
   singleRootGroup: true,
   textMode: false,

--- a/website/src/v2/pages/demo-page/constants/default-theme.ts
+++ b/website/src/v2/pages/demo-page/constants/default-theme.ts
@@ -27,7 +27,7 @@ export const defaultTheme: IBuilderStyle = {
   '--query-builder-color-warning-light': colors.warning.light,
   '--query-builder-color-error-primary': colors.error.primary,
   '--query-builder-color-error-light': colors.error.light,
-  '--query-builder-color-white': colors.white,
+  '--query-builder-color-background': colors.white,
   '--query-builder-root-padding': '1rem',
   '--query-builder-group-padding': '0.7rem',
   '--query-builder-rule-padding': '0.7rem',

--- a/website/src/v2/pages/demo-page/constants/theme-variable-groups.ts
+++ b/website/src/v2/pages/demo-page/constants/theme-variable-groups.ts
@@ -129,7 +129,11 @@ export const themeVariableGroups: IThemeVariableGroup[] = [
         name: '--query-builder-color-error-light',
         type: 'color',
       },
-      { label: 'White', name: '--query-builder-color-white', type: 'color' },
+      {
+        label: 'Background',
+        name: '--query-builder-color-background',
+        type: 'color',
+      },
     ],
   },
   {

--- a/website/src/v2/pages/demo-page/types/builder-source-options.ts
+++ b/website/src/v2/pages/demo-page/types/builder-source-options.ts
@@ -3,6 +3,7 @@ import type { LocaleId } from './locale-id';
 import type { CustomizationMode } from './customization-mode';
 
 export interface IBuilderSourceOptions {
+  darkMode: boolean;
   readOnly: boolean;
   readOnlyProtectsDelete: boolean;
   lockable: boolean;
@@ -17,7 +18,7 @@ export interface IBuilderSourceOptions {
   defaultMode: 'builder' | 'text';
   useMonacoTextEditor: boolean;
   singleRootGroup: boolean;
-  showOuterContainer: boolean;
+  useDefaultContainerStyles: boolean;
   showValidation: boolean;
   customizationMode: CustomizationMode;
   themeStyle: IBuilderStyle;

--- a/website/src/v2/pages/demo-page/types/demo-playground-settings.ts
+++ b/website/src/v2/pages/demo-page/types/demo-playground-settings.ts
@@ -1,4 +1,5 @@
 export interface IDemoPlaygroundSettings {
+  darkMode: boolean;
   allowFieldComparisons: boolean;
   allowGroupNegation: boolean;
   cloneable: boolean;
@@ -10,7 +11,7 @@ export interface IDemoPlaygroundSettings {
   newNodePlacement: 'append' | 'prepend';
   readOnly: boolean;
   readOnlyProtectsDelete: boolean;
-  showOuterContainer: boolean;
+  useDefaultContainerStyles: boolean;
   showValidation: boolean;
   singleRootGroup: boolean;
   textMode: boolean;

--- a/website/src/v2/pages/demo-page/utils/format-builder-source.util.test.ts
+++ b/website/src/v2/pages/demo-page/utils/format-builder-source.util.test.ts
@@ -20,6 +20,7 @@ const adapterCases = [
 ] as const;
 
 const defaultOptions: IBuilderSourceOptions = {
+  darkMode: false,
   readOnly: false,
   readOnlyProtectsDelete: true,
   lockable: false,
@@ -34,7 +35,7 @@ const defaultOptions: IBuilderSourceOptions = {
   defaultMode: 'builder',
   useMonacoTextEditor: false,
   singleRootGroup: true,
-  showOuterContainer: true,
+  useDefaultContainerStyles: true,
   showValidation: true,
   customizationMode: 'default',
   themeStyle: defaultTheme,
@@ -62,10 +63,44 @@ describe('v2 formatBuilderSource', () => {
     expect(source.split(packageStylesheetImport)).toHaveLength(2);
     expect(source).toContain('singleRootGroup');
     expect(source).toContain('showValidation');
-    expect(source).not.toContain('showOuterContainer');
+    expect(source).toContain('colorScheme="light"');
+    expect(source).not.toContain('useDefaultContainerStyles');
     expect(source).not.toContain('ThemeProvider');
   });
 
+  it('adds the scoped dark stylesheet and typed color scheme for dark mode', () => {
+    const source = formatBuilderSource({
+      ...defaultOptions,
+      darkMode: true,
+    });
+
+    expect(source).toContain(
+      "import '@vojtechportes/react-query-builder/dark-mode.variables.css';"
+    );
+    expect(source).toContain('colorScheme="dark"');
+
+    const monacoSource = formatBuilderSource({
+      ...defaultOptions,
+      darkMode: true,
+      textMode: true,
+      useMonacoTextEditor: true,
+    });
+
+    expect(monacoSource).toContain(
+      'const components = createMonacoComponents({});'
+    );
+    expect(monacoSource).toContain('colorScheme="dark"');
+    expect(monacoSource).toContain('dark-mode.variables.css');
+
+    const adapterSource = formatBuilderSource({
+      ...defaultOptions,
+      customizationMode: 'mui',
+      darkMode: true,
+    });
+
+    expect(adapterSource).not.toContain('dark-mode.variables.css');
+    expect(adapterSource).not.toContain('colorScheme');
+  });
   it.each(adapterCases)(
     'renders the %s adapter import',
     (customizationMode: CustomizationMode, packagePath) => {
@@ -86,7 +121,7 @@ describe('v2 formatBuilderSource', () => {
       lockable: true,
       cloneable: true,
       draggable: true,
-      showOuterContainer: false,
+      useDefaultContainerStyles: false,
       history: true,
       textMode: true,
       defaultMode: 'text',
@@ -112,7 +147,7 @@ describe('v2 formatBuilderSource', () => {
     expect(source).toContain('lockable');
     expect(source).toContain('cloneable');
     expect(source).toContain('draggable');
-    expect(source).toContain('showOuterContainer={false}');
+    expect(source).toContain('useDefaultContainerStyles={false}');
     expect(source).toContain('history');
     expect(source).toContain('textMode');
     expect(source).toContain('defaultMode="text"');

--- a/website/src/v2/pages/demo-page/utils/format-builder-source.util.ts
+++ b/website/src/v2/pages/demo-page/utils/format-builder-source.util.ts
@@ -5,6 +5,7 @@ import { formatThemeOverrides } from './format-theme-overrides.util';
 import { indentBlock } from './indent-block.util';
 
 export const formatBuilderSource = ({
+  darkMode,
   readOnly,
   readOnlyProtectsDelete,
   lockable,
@@ -19,7 +20,7 @@ export const formatBuilderSource = ({
   defaultMode,
   useMonacoTextEditor,
   singleRootGroup,
-  showOuterContainer,
+  useDefaultContainerStyles,
   showValidation,
   customizationMode,
   themeStyle,
@@ -31,6 +32,7 @@ export const formatBuilderSource = ({
   const usesFluentUiAdapter = customizationMode === 'fluentui';
   const usesRadixAdapter = customizationMode === 'radix';
   const usesBootstrapAdapter = customizationMode === 'bootstrap';
+  const usesDarkMode = customizationMode === 'default' && darkMode;
   const themeOverrides =
     customizationMode === 'default'
       ? createThemeOverrides(themeStyle, defaultThemeStyle)
@@ -79,6 +81,9 @@ import { Theme } from '@radix-ui/themes';
 import { components as radixComponents } from '@vojtechportes/react-query-builder/radix/v1';`
       : null,
     `import '@vojtechportes/react-query-builder/styles.css';`,
+    usesDarkMode
+      ? `import '@vojtechportes/react-query-builder/dark-mode.variables.css';`
+      : null,
     `import { demoFields, initialQueryTree } from '../constants/demo-data';`,
   ]
     .filter(Boolean)
@@ -102,7 +107,10 @@ import { components as radixComponents } from '@vojtechportes/react-query-builde
     textMode && defaultMode === 'text' ? 'defaultMode="text"' : null,
     'groupTypes="both"',
     singleRootGroup ? 'singleRootGroup' : 'singleRootGroup={false}',
-    showOuterContainer ? null : 'showOuterContainer={false}',
+    useDefaultContainerStyles ? null : 'useDefaultContainerStyles={false}',
+    customizationMode === 'default'
+      ? `colorScheme="${darkMode ? 'dark' : 'light'}"`
+      : null,
     showValidation ? 'showValidation' : null,
     usesMuiAdapter ? 'components={muiComponents}' : null,
     usesAntdAdapter ? 'components={antdComponents}' : null,

--- a/website/src/v2/pages/documentation-page/constants/documentation-baseline.ts
+++ b/website/src/v2/pages/documentation-page/constants/documentation-baseline.ts
@@ -27,7 +27,7 @@ export const documentationBaseline = [
     path: '/documentation/builder-behavior',
     title: 'Builder Behavior',
     contentHash:
-      '466202830a5998f3f973ad97c1ae9b357c6bffa6dc45189c2bb261bcfb0c3817',
+      '333e0280674d9cb807fe7f9ec570ab9b67ced34e27e41d087972507da12fa8cb',
   },
   {
     path: '/documentation/builder-ref',
@@ -81,7 +81,7 @@ export const documentationBaseline = [
     path: '/documentation/text-mode',
     title: 'Text Mode',
     contentHash:
-      'a3e41b12ad7170847c9b0a54e4649c6b6429e93202b9b91f0071aca8730d5299',
+      'ce08d806ac003bf74042534050340918305b81f5fe4168315ec697d9e32d8087',
   },
   {
     path: '/documentation/components',
@@ -135,7 +135,7 @@ export const documentationBaseline = [
     path: '/documentation/theming',
     title: 'Theming',
     contentHash:
-      '293646637625cd031febfa54367ab9edc540be57743e2dcd768d3a5f7ced1459',
+      'c9f5e9b82445e3ddfe7a04506a0c84c571021de240b7cfa4995c0446ebeb211b',
   },
   {
     path: '/documentation/localization',

--- a/website/src/v2/pages/documentation-page/documentation-content.test.tsx
+++ b/website/src/v2/pages/documentation-page/documentation-content.test.tsx
@@ -47,15 +47,32 @@ describe('v2 Documentation content', () => {
 
     expect(content).toContain('href="/api/css-variables"');
   });
-  it('documents how to omit the Builder outer container', () => {
+  it('documents how to disable the default Builder container styles', () => {
     const content = renderToStaticMarkup(
       <StaticRouter location="/documentation/builder-behavior">
         {findDocumentationPage('/documentation/builder-behavior').content}
       </StaticRouter>
     );
 
-    expect(content).toMatch(/<code[^>]*>showOuterContainer=\{false\}<\/code>/);
-    expect(content).toContain('application wrapper');
+    expect(content).toMatch(
+      /<code[^>]*>useDefaultContainerStyles=\{false\}<\/code>/
+    );
+    expect(content).toContain('root');
+    expect(content).toContain('className');
+  });
+  it('documents typed reactive dark mode and its stylesheet', () => {
+    const content = renderToStaticMarkup(
+      <StaticRouter location="/documentation/theming">
+        {findDocumentationPage('/documentation/theming').content}
+      </StaticRouter>
+    );
+
+    expect(content).toContain(
+      '@vojtechportes/react-query-builder/dark-mode.variables.css'
+    );
+    expect(content).toContain('colorScheme');
+    expect(content).toContain('Built-in SQL highlighting');
+    expect(content).toContain('Monaco');
   });
   it('normalizes trailing slashes and preserves the overview fallback', () => {
     expect(

--- a/website/src/v2/pages/documentation-page/pages/builder-behavior-documentation-page/components/builder-behavior-documentation-content.tsx
+++ b/website/src/v2/pages/documentation-page/pages/builder-behavior-documentation-page/components/builder-behavior-documentation-content.tsx
@@ -22,21 +22,24 @@ export const BuilderBehaviorDocumentationContent: React.FC = () => (
       language="tsx"
       label="Builder behavior"
     />
-    <SectionTitle>showOuterContainer</SectionTitle>
+    <SectionTitle>useDefaultContainerStyles</SectionTitle>
     <List>
       <li>
         Defaults to <InlineCode>true</InlineCode> and renders the outer surface
         with the Builder root padding, background, border, radius, and shadow.
       </li>
       <li>
-        Set <InlineCode>{'showOuterContainer={false}'}</InlineCode> when an
-        application wrapper already provides that surface.
+        Set <InlineCode>{'useDefaultContainerStyles={false}'}</InlineCode> when
+        an application wrapper already provides that surface. The Builder's
+        baseline color, font, size, and line height remain active so built-in
+        controls keep their normal dimensions.
       </li>
       <li>
-        Without the container, <InlineCode>className</InlineCode> and{' '}
-        <InlineCode>style</InlineCode> have no Builder element to target. Apply
-        those values to your application wrapper instead.
-      </li>
+        The root <InlineCode>div</InlineCode> remains in the DOM when default
+        styles are disabled, so <InlineCode>className</InlineCode>,{' '}
+        <InlineCode>style</InlineCode>, CSS variables, and{' '}
+        <InlineCode>colorScheme</InlineCode> still have a stable target.
+      </li>{' '}
     </List>
     <SectionTitle>cloneable</SectionTitle>
     <List>

--- a/website/src/v2/pages/documentation-page/pages/builder-behavior-documentation-page/constants/builder-behavior-snippet.ts
+++ b/website/src/v2/pages/documentation-page/pages/builder-behavior-documentation-page/constants/builder-behavior-snippet.ts
@@ -2,7 +2,7 @@ export const builderBehaviorSnippet = `import '@vojtechportes/react-query-builde
 <Builder
   fields={fields}
   data={data}
-  showOuterContainer={false}
+  useDefaultContainerStyles={false}
   lockable
   readOnlyProtectsDelete
   cloneable
@@ -14,9 +14,10 @@ export const builderBehaviorSnippet = `import '@vojtechportes/react-query-builde
   onChange={setData}
 />;
 
-// showOuterContainer={false}:
-// Omits the outer styled container so a surrounding application layout can
-// provide the builder surface. The default is true.
+// useDefaultContainerStyles={false}:
+// Keeps the Builder root div and baseline typography, but omits its padding,
+// background, border, radius, and shadow so an application wrapper can provide
+// the container presentation.
 //
 // lockable:
 // Renders built-in lock controls for rules and groups and writes the resulting

--- a/website/src/v2/pages/documentation-page/pages/text-mode-documentation-page/components/text-mode-documentation-content.tsx
+++ b/website/src/v2/pages/documentation-page/pages/text-mode-documentation-page/components/text-mode-documentation-content.tsx
@@ -144,7 +144,13 @@ export const TextModeDocumentationContent: React.FC = () => (
       <li>
         <ItemTitle>Monaco protected behavior:</ItemTitle> Protected SQL
         fragments are dimmed, protected from edits, and expose their lock
-        explanation on hover.
+        explanation on hover. The packaged Monaco light and dark themes use the
+        same query-builder palette roles as the built-in editor for SQL tokens.
+        An explicit Builder <InlineCode>colorScheme</InlineCode> switches
+        between them without remounting the editor. Because Monaco's standalone
+        theme service is global, the latest mounted packaged editor, or the
+        editor whose scheme changes most recently, wins across all mounted
+        Monaco editors.
       </li>
       <li>
         <ItemTitle>Localized read-only protection:</ItemTitle> Rule field,

--- a/website/src/v2/pages/documentation-page/pages/theming-documentation-page/components/theming-documentation-content.tsx
+++ b/website/src/v2/pages/documentation-page/pages/theming-documentation-page/components/theming-documentation-content.tsx
@@ -10,6 +10,7 @@ import {
   TextLink,
 } from '../../../../../../components/docs-primitives';
 import { builderStyleThemeSnippet } from '../constants/builder-style-theme-snippet';
+import { darkModeSnippet } from '../constants/dark-mode-snippet';
 import { globalThemeSnippet } from '../constants/global-theme-snippet';
 import { themeSnippet } from '../constants/theme-snippet';
 import { wrapperThemeSnippet } from '../constants/wrapper-theme-snippet';
@@ -24,7 +25,50 @@ export const ThemingDocumentationContent: React.FC = () => (
       supplies the default token values; components do not inject runtime
       styles.
     </Typography>
-    <SectionTitle>Global overrides</SectionTitle>
+    <SectionTitle>Dark mode</SectionTitle>
+    <Typography color="muted">
+      Import the optional{' '}
+      <InlineCode>
+        @vojtechportes/react-query-builder/dark-mode.variables.css
+      </InlineCode>{' '}
+      after <InlineCode>styles.css</InlineCode>, then set the{' '}
+      <InlineCode>colorScheme</InlineCode> prop. Changing the prop updates
+      colors without remounting the Builder.
+    </Typography>
+    <CodeBlock
+      code={darkModeSnippet}
+      language="tsx"
+      label="Reactive dark mode"
+    />
+    <List>
+      <li>
+        Use <InlineCode>colorScheme=&quot;light&quot;</InlineCode> or{' '}
+        <InlineCode>colorScheme=&quot;dark&quot;</InlineCode> to create an
+        explicit palette boundary for one Builder.
+      </li>
+      <li>
+        Leave <InlineCode>colorScheme</InlineCode> undefined to preserve colors
+        inherited from your application or a surrounding wrapper.
+      </li>
+      <li>
+        Explicit light and dark Builders can be siblings or nested. The nearest
+        Builder scheme applies to its built-in components.
+      </li>
+      <li>
+        Built-in SQL highlighting uses the same info, success, warning, primary,
+        grey, and error variables as the rest of the Builder.
+      </li>
+    </List>
+    <AlertBox title="Monaco editor" variant="info">
+      The packaged Monaco light and dark themes use the same query-builder
+      palette roles as the built-in SQL editor and update without remounting
+      when <InlineCode>colorScheme</InlineCode> changes. Monaco's standalone
+      theme service is global, so the latest mounted packaged editor, or the
+      editor whose scheme changes most recently, wins across all mounted
+      editors. Synchronizing consumer CSS variable overrides or custom
+      per-editor themes requires application-level configuration.
+    </AlertBox>
+    <SectionTitle>Global overrides</SectionTitle>{' '}
     <Typography color="muted">
       Set variables on <InlineCode>:root</InlineCode> when every builder and
       standalone built-in control should share the same values.
@@ -58,7 +102,7 @@ export const ThemingDocumentationContent: React.FC = () => (
         <ItemTitle>Colors:</ItemTitle>{' '}
         <InlineCode>--query-builder-color-primary-*</InlineCode>,{' '}
         <InlineCode>--query-builder-color-secondary-*</InlineCode>, grey scale,
-        status colors, and white.
+        status colors, and the background surface.
       </li>
       <li>
         <ItemTitle>Spacing and layout:</ItemTitle>{' '}
@@ -92,25 +136,31 @@ export const ThemingDocumentationContent: React.FC = () => (
     </Typography>
     <List>
       <li>
-        <ItemTitle>Stylesheet defaults:</ItemTitle> Generated color defaults and
-        the public layout, sizing, typography, motion, and layering defaults in{' '}
+        <ItemTitle>Stylesheet defaults:</ItemTitle> Light defaults from{' '}
         <InlineCode>styles.css</InlineCode>.
       </li>
       <li>
-        <ItemTitle>Inherited CSS:</ItemTitle> Variables declared by your app on{' '}
-        <InlineCode>:root</InlineCode> or a wrapper around the builder.
+        <ItemTitle>Inherited CSS:</ItemTitle> Application variables when{' '}
+        <InlineCode>colorScheme</InlineCode> is undefined.
       </li>
       <li>
-        <ItemTitle>ThemeProvider:</ItemTitle> Only color values explicitly
-        supplied to the nearest legacy provider become compatibility variables.
+        <ItemTitle>Explicit scheme:</ItemTitle> The complete light or dark
+        palette selected through <InlineCode>colorScheme</InlineCode>.
       </li>
       <li>
-        <ItemTitle>Builder style:</ItemTitle> Variables passed through the{' '}
-        <InlineCode>Builder.style</InlineCode> prop are the final override on
-        the builder root.
+        <ItemTitle>Builder class:</ItemTitle> Consumer CSS targeting the root
+        through <InlineCode>className</InlineCode>.
+      </li>
+      <li>
+        <ItemTitle>ThemeProvider:</ItemTitle> Explicit legacy provider colors
+        mapped to root variables.
+      </li>
+      <li>
+        <ItemTitle>Builder style:</ItemTitle> Variables passed through{' '}
+        <InlineCode>Builder.style</InlineCode> as the final override.
       </li>
     </List>
-    <SectionTitle>Stable styling hooks</SectionTitle>
+    <SectionTitle>Stable styling hooks</SectionTitle>{' '}
     <List>
       <li>
         Pass an application-owned <InlineCode>className</InlineCode> to{' '}
@@ -118,6 +168,13 @@ export const ThemingDocumentationContent: React.FC = () => (
         <InlineCode>[data-query-builder=&quot;root&quot;]</InlineCode>{' '}
         attribute.
       </li>
+      <li>
+        The root remains available when{' '}
+        <InlineCode>
+          useDefaultContainerStyles={'{'}false{'}'}
+        </InlineCode>
+        removes its built-in surface class.
+      </li>{' '}
       <li>
         Prefer public CSS variables for built-in presentation and the component
         override API when you need different markup.

--- a/website/src/v2/pages/documentation-page/pages/theming-documentation-page/constants/dark-mode-snippet.ts
+++ b/website/src/v2/pages/documentation-page/pages/theming-documentation-page/constants/dark-mode-snippet.ts
@@ -1,0 +1,11 @@
+﻿export const darkModeSnippet = `import '@vojtechportes/react-query-builder/styles.css';
+import '@vojtechportes/react-query-builder/dark-mode.variables.css';
+
+const [darkMode, setDarkMode] = useState(false);
+
+<Builder
+  fields={fields}
+  data={data}
+  colorScheme={darkMode ? 'dark' : 'light'}
+  onChange={setData}
+/>;`;

--- a/website/src/v2/pages/documentation-page/pages/theming-documentation-page/theming-documentation-page.tsx
+++ b/website/src/v2/pages/documentation-page/pages/theming-documentation-page/theming-documentation-page.tsx
@@ -9,8 +9,8 @@ export const themingDocumentationPage: IDocumentationPage = {
   sectionTitle: 'Customization',
   summary: '',
   description:
-    'Documentation for customizing builder colors with ThemeProvider and shared theme tokens.',
+    'Documentation for typed light and dark color schemes, CSS variables, custom themes, and ThemeProvider compatibility.',
   searchText:
-    'Theming theme provider colors primary secondary grey tokens design system',
+    'Theming light dark mode colorScheme dark-mode variables background ThemeProvider colors tokens design system',
   content: <ThemingDocumentationContent />,
 };

--- a/website/src/v2/pages/home-page/components/home-mui-adapter-demo.tsx
+++ b/website/src/v2/pages/home-page/components/home-mui-adapter-demo.tsx
@@ -42,6 +42,7 @@ export const HomeMuiAdapterDemo: React.FC = () => {
         fields={fields}
         onChange={setData}
         singleRootGroup
+        useDefaultContainerStyles={false}
       />
     </ScopedCssBaseline>
   );

--- a/website/src/v2/pages/home-page/components/home-showcase.tsx
+++ b/website/src/v2/pages/home-page/components/home-showcase.tsx
@@ -25,7 +25,7 @@ const Root = styled.article<{
   gap: 2rem;
   align-items: start;
   padding: 2rem;
-  overflow: hidden;
+  // overflow: hidden;
   border: 1px solid ${({ $tone }) => ($tone === 'dark' ? '#0f172a' : '#dbe4f0')};
   border-radius: 16px;
   background: ${({ $tone }) => ($tone === 'dark' ? '#0f172a' : '#fff')};

--- a/website/src/v2/pages/home-page/components/home-text-mode-demo.tsx
+++ b/website/src/v2/pages/home-page/components/home-text-mode-demo.tsx
@@ -74,7 +74,9 @@ export const HomeTextModeDemo: React.FC = () => {
       fields={fields}
       onChange={setData}
       singleRootGroup
+      useDefaultContainerStyles={false}
       textMode
+      colorScheme="dark"
     />
   );
 };

--- a/website/src/v2/seo/constants/v2-seo-pages.json
+++ b/website/src/v2/seo/constants/v2-seo-pages.json
@@ -93,8 +93,8 @@
     {
       "path": "/api/css-variables",
       "title": "React Query Builder CSS Variables API",
-      "description": "Complete API reference for every public React Query Builder CSS variable, including color, layout, typography, motion, and overlay defaults.",
-      "keywords": "CSS, variables, custom, properties, tokens, defaults, IBuilderStyle, colors, spacing, padding, gaps, radii, shadows, controls, typography, editor, drop, zone, motion, popover, React Query Builder, React query builder component, React filter builder, React rule builder, TypeScript query builder",
+      "description": "Complete API reference for light and dark React Query Builder CSS variables, color schemes, layout, typography, and other defaults.",
+      "keywords": "CSS, variables, dark, mode, colorScheme, background, custom, properties, tokens, defaults, IBuilderStyle, colors, spacing, layout, typography, React Query Builder, React query builder component, React filter builder, React rule builder, TypeScript query builder",
       "section": "API"
     },
     {
@@ -128,8 +128,8 @@
     {
       "path": "/api/theming",
       "title": "React Query Builder Theming API",
-      "description": "Theming API reference for ThemeProvider, IThemeProviderProps, IColors, and exported color tokens.",
-      "keywords": "ThemeProvider, IThemeProviderProps, IThemeProps, IColors, colors, primary, secondary, grey, white, theme, customization, React Query Builder, React query builder component, React filter builder, React rule builder, TypeScript query builder",
+      "description": "Theming API reference for typed light and dark schemes, variable precedence, ThemeProvider compatibility, and exported color tokens.",
+      "keywords": "colorScheme, dark, mode, dark-mode, variables, background, ThemeProvider, IThemeProviderProps, IColors, colors, theme, customization, React Query Builder, React query builder component, React filter builder, React rule builder, TypeScript query builder",
       "section": "API"
     },
     {
@@ -289,8 +289,8 @@
     {
       "path": "/documentation/theming",
       "title": "React Query Builder Theming Guide",
-      "description": "Documentation for customizing builder colors with ThemeProvider and shared theme tokens.",
-      "keywords": "Theming, theme, provider, colors, primary, secondary, grey, tokens, design, system, React Query Builder, React query builder component, React filter builder, React rule builder, TypeScript query builder",
+      "description": "Documentation for typed light and dark Builder color schemes, reactive switching, CSS variables, custom themes, and ThemeProvider compatibility.",
+      "keywords": "Theming, dark, mode, colorScheme, dark-mode, variables, background, theme, provider, colors, tokens, design, system, React Query Builder, React query builder component, React filter builder, React rule builder, TypeScript query builder",
       "section": "Documentation"
     },
     {


### PR DESCRIPTION
- Added typed light and dark color schemes with an exported dark-mode stylesheet
- Renamed showOuterContainer to useDefaultContainerStyles and preserved root baseline styles
- Aligned built-in and Monaco SQL highlighting with accessible query-builder palette colors
- Updated the v2 Documentation, API, Demo, package exports, and verification coverage